### PR TITLE
Show selected sorting options (comments and posts), Save sorting options

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
@@ -24,6 +24,7 @@ import me.ccrama.redditslide.ColorPreferences;
 import me.ccrama.redditslide.Fragments.MultiredditView;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubredditStorage;
 import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Pallete;
@@ -152,12 +153,28 @@ public class MultiredditOverview extends BaseActivity {
                         reloadSubs();
                         break;
                 }
+                SettingValues.defaultSorting = Reddit.defaultSorting;
+                SettingValues.timePeriod = Reddit.timePeriod;
             }
         };
+        int i = Reddit.defaultSorting == Sorting.HOT ? 0
+                : Reddit.defaultSorting == Sorting.NEW ? 1
+                : Reddit.defaultSorting == Sorting.RISING ? 2
+                : Reddit.defaultSorting == Sorting.TOP ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 3
+                : Reddit.timePeriod == TimePeriod.DAY ? 4
+                : Reddit.timePeriod == TimePeriod.WEEK ? 5
+                : Reddit.timePeriod == TimePeriod.MONTH ? 6
+                : Reddit.timePeriod == TimePeriod.YEAR ? 7
+                : 8)
+                : Reddit.defaultSorting == Sorting.CONTROVERSIAL ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 9
+                : 10)
+                : 0;
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(MultiredditOverview.this);
         builder.setTitle("Choose a Sorting Type");
-        builder.setItems(
-                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, l2);
+        builder.setSingleChoiceItems(
+                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, i, l2);
         builder.show();
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverview.java
@@ -60,6 +60,7 @@ import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubredditInputFilter;
 import me.ccrama.redditslide.SubredditStorage;
 import me.ccrama.redditslide.SubredditStorageNoContext;
@@ -1269,12 +1270,30 @@ public class SubredditOverview extends OverviewBase {
                         reloadSubs();
                         break;
                 }
+                SettingValues.prefs.edit().putString("defaultSorting", Reddit.defaultSorting.name()).apply();
+                SettingValues.prefs.edit().putString("timePeriod", Reddit.timePeriod.name()).apply();
+                SettingValues.defaultSorting = Reddit.defaultSorting;
+                SettingValues.timePeriod = Reddit.timePeriod;
             }
         };
+        int i = Reddit.defaultSorting == Sorting.HOT ? 0
+                : Reddit.defaultSorting == Sorting.NEW ? 1
+                : Reddit.defaultSorting == Sorting.RISING ? 2
+                : Reddit.defaultSorting == Sorting.TOP ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 3
+                        : Reddit.timePeriod == TimePeriod.DAY ? 4
+                        : Reddit.timePeriod == TimePeriod.WEEK ? 5
+                        : Reddit.timePeriod == TimePeriod.MONTH ? 6
+                        : Reddit.timePeriod == TimePeriod.YEAR ? 7
+                        : 8)
+                : Reddit.defaultSorting == Sorting.CONTROVERSIAL ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 9
+                        : 10)
+                : 0;
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(SubredditOverview.this);
         builder.setTitle("Choose a Sorting Type");
-        builder.setItems(
-                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, l2);
+        builder.setSingleChoiceItems(
+                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, i, l2);
         builder.show();
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
@@ -59,6 +59,7 @@ import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubredditInputFilter;
 import me.ccrama.redditslide.SubredditStorage;
 import me.ccrama.redditslide.SubredditStorageNoContext;
@@ -1262,12 +1263,30 @@ public class SubredditOverviewSingle extends OverviewBase  {
                         reloadSubs();
                         break;
                 }
+                SettingValues.prefs.edit().putString("defaultSorting", Reddit.defaultSorting.name()).apply();
+                SettingValues.prefs.edit().putString("timePeriod", Reddit.timePeriod.name()).apply();
+                SettingValues.defaultSorting = Reddit.defaultSorting;
+                SettingValues.timePeriod = Reddit.timePeriod;
             }
         };
-       AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(SubredditOverviewSingle.this);
+        int i = Reddit.defaultSorting == Sorting.HOT ? 0
+                : Reddit.defaultSorting == Sorting.NEW ? 1
+                : Reddit.defaultSorting == Sorting.RISING ? 2
+                : Reddit.defaultSorting == Sorting.TOP ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 3
+                        : Reddit.timePeriod == TimePeriod.DAY ? 4
+                        : Reddit.timePeriod == TimePeriod.WEEK ? 5
+                        : Reddit.timePeriod == TimePeriod.MONTH ? 6
+                        : Reddit.timePeriod == TimePeriod.YEAR ? 7
+                        : 8)
+                : Reddit.defaultSorting == Sorting.CONTROVERSIAL ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 9
+                        : 10)
+                : 0;
+        AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(SubredditOverviewSingle.this);
         builder.setTitle("Choose a Sorting Type");
-        builder.setItems(
-                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, l2);
+        builder.setSingleChoiceItems(
+                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, i, l2);
         builder.show();
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -46,6 +46,7 @@ import me.ccrama.redditslide.ColorPreferences;
 import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubredditStorage;
 import me.ccrama.redditslide.SubredditStorageNoContext;
 import me.ccrama.redditslide.Views.MakeTextviewClickable;
@@ -558,12 +559,30 @@ public class SubredditView extends BaseActivity {
                         reloadSubs();
                         break;
                 }
+                SettingValues.prefs.edit().putString("defaultSorting", Reddit.defaultSorting.name()).apply();
+                SettingValues.prefs.edit().putString("timePeriod", Reddit.timePeriod.name()).apply();
+                SettingValues.defaultSorting = Reddit.defaultSorting;
+                SettingValues.timePeriod = Reddit.timePeriod;
             }
         };
+        int i = Reddit.defaultSorting == Sorting.HOT ? 0
+                : Reddit.defaultSorting == Sorting.NEW ? 1
+                : Reddit.defaultSorting == Sorting.RISING ? 2
+                : Reddit.defaultSorting == Sorting.TOP ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 3
+                        : Reddit.timePeriod == TimePeriod.DAY ? 4
+                        : Reddit.timePeriod == TimePeriod.WEEK ? 5
+                        : Reddit.timePeriod == TimePeriod.MONTH ? 6
+                        : Reddit.timePeriod == TimePeriod.YEAR ? 7
+                        : 8)
+                : Reddit.defaultSorting == Sorting.CONTROVERSIAL ?
+                (Reddit.timePeriod == TimePeriod.HOUR ? 9
+                        : 10)
+                : 0;
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(SubredditView.this);
         builder.setTitle("Choose a Sorting Type");
-        builder.setItems(
-                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, l2);
+        builder.setSingleChoiceItems(
+                new String[]{"Hot", "New", "Rising", "Top This Hour", "Top Today", "Top This Week", "Top This Month", "Top This Year", "Top All Time", "Controversial This Hour", "Controversial Today"}, i, l2);
         builder.show();
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -31,6 +31,7 @@ import me.ccrama.redditslide.ColorPreferences;
 import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Views.PreCachingLayoutManagerComments;
 import me.ccrama.redditslide.Visuals.Pallete;
 
@@ -71,20 +72,27 @@ public class CommentPage extends Fragment {
                         Reddit.defaultCommentSorting = CommentSort.OLD;
                         reloadSubs();
                         break;
-
                 }
+                SettingValues.prefs.edit().putString("defaultCommentSorting", Reddit.defaultCommentSorting.name()).apply();
+                SettingValues.defaultCommentSorting = Reddit.defaultCommentSorting;
             }
         };
+        int i = Reddit.defaultCommentSorting == CommentSort.CONFIDENCE ? 0
+                : Reddit.defaultCommentSorting == CommentSort.TOP ? 1
+                : Reddit.defaultCommentSorting == CommentSort.QA ? 2
+                : Reddit.defaultCommentSorting == CommentSort.NEW ? 3
+                : Reddit.defaultCommentSorting == CommentSort.CONTROVERSIAL ? 4
+                : Reddit.defaultCommentSorting == CommentSort.OLD ? 5
+                : 1;
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getContext());
         builder.setTitle("Choose a Sorting Type");
-        builder.setItems(
+        builder.setSingleChoiceItems(
                 new String[]{"Best",
                         "Top",
                         "Q&A (AMA)",
-
                         "New",
                         "Controversial",
-                        "Old"},
+                        "Old"}, i,
                 l2);
         builder.show();
 

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -87,6 +87,7 @@ public class Reddit extends Application implements Application.ActivityLifecycle
 
     public static boolean tabletUI;
     public static Sorting defaultSorting;
+    public static CommentSort defaultCommentSorting;
     public static TimePeriod timePeriod;
     public static SharedPreferences colors;
     public static int themeBack;
@@ -148,13 +149,12 @@ public class Reddit extends Application implements Application.ActivityLifecycle
     public void onCreate() {
         super.onCreate();
         registerActivityLifecycleCallbacks(this);
-        defaultSorting = Sorting.HOT;
-        timePeriod = TimePeriod.DAY;
         Authentication.authentication = getSharedPreferences("AUTH", 0);
         SubredditStorage.subscriptions = getSharedPreferences("SUBS", 0);
-
-
         SettingValues.setAllValues(getSharedPreferences("SETTINGS", 0));
+        defaultSorting = SettingValues.defaultSorting;
+        timePeriod = SettingValues.timePeriod;
+        defaultCommentSorting = SettingValues.defaultCommentSorting;
         colors = getSharedPreferences("COLOR", 0);
         seen = getSharedPreferences("SEEN", 0);
         hidden = getSharedPreferences("HIDDEN", 0);
@@ -273,8 +273,6 @@ public class Reddit extends Application implements Application.ActivityLifecycle
     }
 
     public boolean active;
-
-    public static CommentSort defaultCommentSorting;
 
     public static SharedPreferences seen;
     public LoadingData loader;

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -2,6 +2,10 @@ package me.ccrama.redditslide;
 
 import android.content.SharedPreferences;
 
+import net.dean.jraw.models.CommentSort;
+import net.dean.jraw.paginators.Sorting;
+import net.dean.jraw.paginators.TimePeriod;
+
 import me.ccrama.redditslide.Views.CreateCardView;
 import me.ccrama.redditslide.Visuals.Pallete;
 
@@ -15,6 +19,9 @@ public class SettingValues {
     public static boolean infoBar;
 
     public static CreateCardView.CardEnum defaultCardView;
+    public static Sorting defaultSorting;
+    public static TimePeriod timePeriod;
+    public static CommentSort defaultCommentSorting;
     public static boolean NSFWPreviews;
     public static ColorMatchingMode colorMatchingMode;
     public static ColorIndicator colorIndicator;
@@ -37,5 +44,8 @@ public class SettingValues {
         colorMatchingMode = ColorMatchingMode.valueOf(settings.getString("colorMatchingMode", "ALWAYS_MATCH"));
         colorIndicator = ColorIndicator.valueOf(settings.getString("colorIndicator", "CARD_BACKGROUND"));
         infoBar = settings.getBoolean("infoBar", true);
+        defaultSorting = Sorting.valueOf(settings.getString("defaultSorting", "HOT"));
+        timePeriod = TimePeriod.valueOf(settings.getString("timePeriod", "DAY"));
+        defaultCommentSorting = CommentSort.valueOf(settings.getString("defaultCommentSorting", "TOP"));
     }
 }


### PR DESCRIPTION
Hello, (resubmitting pull request; I had done it from my master by mistake)

This commit changes the comment and post sorting pop-up simple lists to radioButton lists, so it is possible to see what is the current sorting setting (image below), and also saves the sorting settings so on the next clean start they are still the same.

Best regards,
Joao
![screenshot_20151018-013921](https://cloud.githubusercontent.com/assets/7563634/10562603/b03fc984-7542-11e5-80f5-5804eab4cb00.png)
