### PR TITLE
Don't allow comments with 0 childs to collapse

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -892,29 +892,23 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             isClicking = false;
             holder.menuArea.removeAllViews();
             isHolder.itemView.findViewById(R.id.menu).setVisibility(View.GONE);
-
         } else {
-
             if (hiddenPersons.contains(comment.getFullName())) {
                 unhideAll(baseNode, holder.getAdapterPosition() + 1);
                 hiddenPersons.remove(comment.getFullName());
-                //todo maybe         holder.content.setVisibility(View.VISIBLE);
-
+                holder.children.setVisibility(View.GONE);
+                //todo maybe holder.content.setVisibility(View.VISIBLE);
             } else {
-                hideAll(baseNode, holder.getAdapterPosition() + 1
-                );
-                //todo maybe   holder.content.setVisibility(View.GONE);
-
-                hiddenPersons.add(comment.getFullName());
+                int childNumber = getChildNumber(baseNode);
+                if (childNumber > 0) {
+                    hideAll(baseNode, holder.getAdapterPosition() + 1);
+                    hiddenPersons.add(comment.getFullName());
+                    holder.children.setVisibility(View.VISIBLE);
+                    ((TextView) holder.children.findViewById(R.id.flairtext)).setText("+" + childNumber);
+                    //todo maybe holder.content.setVisibility(View.GONE);
+                }
             }
             clickpos = holder.getAdapterPosition() + 1;
-            if (hiddenPersons.contains(comment.getFullName())) {
-                holder.children.setVisibility(View.VISIBLE);
-                ((TextView) holder.children.findViewById(R.id.flairtext)).setText("+" + getChildNumber(baseNode));
-            } else {
-                holder.children.setVisibility(View.GONE);
-
-            }
         }
     }
 
@@ -1030,7 +1024,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         listView.setItemAnimator(new FadeInAnimator());
 
         notifyItemRangeRemoved(i, counter);
-
 
     }
 


### PR DESCRIPTION
I find that quite annoying.

I've tried this for a bit and it doesn't seems to introduce any problems.
I don't know if this is the way you want to go, but I rather have a comment do nothing on tap than just put a "+0" label to it.

As a side note, I can't really understand what the whole isClicking branch or clickpos do - I've left them, but I can't find them used anywhere. It's for future usage?