### PR TITLE
Fix Gradle plugin version (1.3.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5+'
+        classpath 'com.android.tools.build:gradle:1.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
See http://developer.android.com/tools/revisions/gradle-plugin.html
Gradle plugin v1.5+ does not exist (1.3.1 is latest), and using an incorrect version number can cause Gradle sync errors on rare occasions.