### PR TITLE
Require login to access notification settings. Fixes #559

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -37,7 +38,7 @@ import me.ccrama.redditslide.Visuals.Pallete;
  * Created by ccrama on 3/5/2015.
  */
 public class Settings extends BaseActivityNoAnim {
-
+    private View.OnClickListener mLoginOnClickListener;
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -78,6 +79,13 @@ public class Settings extends BaseActivityNoAnim {
         setSupportActionBar(b);
         getSupportActionBar().setTitle(R.string.title_settings);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        mLoginOnClickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent login = new Intent(Settings.this, Login.class);
+                startActivity(login);
+            }
+        };
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
@@ -203,6 +211,15 @@ public class Settings extends BaseActivityNoAnim {
         findViewById(R.id.notifications).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if (Reddit.notifications == null) {
+                    String errMsg = getString(R.string.err_login);
+                    String login = getString(R.string.general_login);
+                    Snackbar.make(findViewById(android.R.id.content), errMsg, Snackbar.LENGTH_LONG)
+                            .setAction(login, mLoginOnClickListener).
+                            show();
+                    return;
+                }
+
                 LayoutInflater inflater = getLayoutInflater();
                 final View dialoglayout = inflater.inflate(R.layout.inboxfrequency, null);
                 final AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(Settings.this);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="general_pro_msg">I have opted to make a few features of Slide (including multi-column mode) unlockable by purchasing a Pro Unlock key from the Play Store. \n\nThis is to keep development going, and in lieu of displaying ads in the free version of Slide!\n\nIncluded in this is MultiColumn mode, Shadowbox mode (for image subreddits), and much more coming soon!\n\nWould you like to unlock Slide for Reddit Pro?</string>
     <string name="general_open_settings">Open Subreddit Settings</string>
     <string name="general_sub_sync">Syncing Subscriptions</string>
+    <string name="general_login">Login</string>
 
     <!-- Used when viewing a thread -->
     <string name="submission_info_unsaved">Submission unsaved</string>
@@ -191,6 +192,7 @@
     <string name="err_general">Uh oh, an error occurred</string>
     <string name="err_no_connection">Reddit could not be reached. Would you like to try again?</string>
     <string name="err_retry_later">Try again in a minute!</string>
+    <string name="err_login">You have to log in to do that!</string>
 
 
     <!-- Gif -->


### PR DESCRIPTION
Pulls up a snackbar asking user to login if they try to access notification settings while not logged in.