### PR TITLE
Fixed force close when clicking the slide view before all content is loaded

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverview.java
@@ -171,8 +171,7 @@ public class SubredditOverview extends OverviewBase {
                 {
 
                     if (Reddit.tabletUI) {
-
-                        if (((SubmissionsView) adapter.getCurrentFragment()).posts.posts != null) {
+                        if (((SubmissionsView) adapter.getCurrentFragment()).posts.posts != null && !((SubmissionsView) adapter.getCurrentFragment()).posts.posts.isEmpty()) {
                             DataShare.sharedSubreddit = ((SubmissionsView) adapter.getCurrentFragment()).posts.posts;
                             Intent i = new Intent(SubredditOverview.this, Shadowbox.class);
                             i.putExtra("position", pager.getCurrentItem());

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
@@ -163,7 +163,7 @@ public class SubredditOverviewSingle extends OverviewBase {
                 {
 
                     if (Reddit.tabletUI) {
-                        if (((SubmissionsView) adapter.getCurrentFragment()).posts.posts != null) {
+                        if (((SubmissionsView) adapter.getCurrentFragment()).posts.posts != null && !((SubmissionsView) adapter.getCurrentFragment()).posts.posts.isEmpty()) {
                             DataShare.sharedSubreddit = ((SubmissionsView) adapter.getCurrentFragment()).posts.posts;
                             Intent i = new Intent(SubredditOverviewSingle.this, Shadowbox.class);
                             i.putExtra("position", pager.getCurrentItem());

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -196,7 +196,7 @@ public class SubredditView extends BaseActivity {
             public void onClick(View v) {
                 {
                     if (Reddit.tabletUI) {
-                        if (posts.posts != null) {
+                        if (posts.posts != null && !posts.posts.isEmpty()) {
                             DataShare.sharedSubreddit = posts.posts;
                             Intent i = new Intent(SubredditView.this, Shadowbox.class);
                             i.putExtra("position", 0);


### PR DESCRIPTION
If you would click the slide view button in the menu before the content is loaded the app would crash.