### PR TITLE
Tint navigation bar

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
@@ -54,6 +54,7 @@ public class CommentsScreen extends BaseActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 Window window = getWindow();
                 window.setStatusBarColor(Pallete.getDarkerColor(posts.get(firstPage).getSubredditName()));
+                window.setNavigationBarColor(Pallete.getDarkerColor(posts.get(firstPage).getSubredditName()));
                 CommentsScreen.this.setTaskDescription(new ActivityManager.TaskDescription(posts.get(firstPage).getSubredditName(), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(posts.get(firstPage).getSubredditName())));
 
             }
@@ -77,6 +78,7 @@ public class CommentsScreen extends BaseActivity {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         Window window = getWindow();
                         window.setStatusBarColor(Pallete.getDarkerColor(posts.get(position).getSubredditName()));
+                        window.setNavigationBarColor(Pallete.getDarkerColor(posts.get(position).getSubredditName()));
                         CommentsScreen.this.setTaskDescription(new ActivityManager.TaskDescription(posts.get(position).getSubredditName(), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(posts.get(position).getSubredditName())));
 
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenPopup.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenPopup.java
@@ -47,6 +47,7 @@ public class CommentsScreenPopup extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(posts.get(firstPage).getSubredditName()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(posts.get(firstPage).getSubredditName()));
         }
         ViewPager pager = (ViewPager) findViewById(R.id.contentView);
         HasSeen.addSeen(posts.get(firstPage).getFullName());
@@ -65,6 +66,7 @@ public class CommentsScreenPopup extends BaseActivity {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     Window window = getWindow();
                     window.setStatusBarColor(Pallete.getDarkerColor(posts.get(position).getSubredditName()));
+                    window.setNavigationBarColor(Pallete.getDarkerColor(posts.get(position).getSubredditName()));
                 }
                 HasSeen.addSeen(posts.get(position).getFullName());
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
@@ -58,6 +58,7 @@ public class CommentsScreenSingle extends BaseActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 Window window = getWindow();
                 window.setStatusBarColor(Pallete.getDarkerColor(subreddit));
+                window.setNavigationBarColor(Pallete.getDarkerColor(subreddit));
                 CommentsScreenSingle.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(subreddit)));
 
             }
@@ -78,6 +79,7 @@ public class CommentsScreenSingle extends BaseActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 Window window = getWindow();
                 window.setStatusBarColor(Pallete.getDarkerColor(subreddit));
+                window.setNavigationBarColor(Pallete.getDarkerColor(subreddit));
                 CommentsScreenSingle.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(subreddit)));
 
             }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
@@ -92,6 +92,7 @@ public class CreateMulti extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             CreateMulti.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_create_multi), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
         title = (EditText) findViewById(R.id.name);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/DonateView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/DonateView.java
@@ -82,6 +82,7 @@ public class DonateView extends AppCompatActivity {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             window.setStatusBarColor(Pallete.getDarkerColor(getResources().getColor(R.color.md_light_green_500)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(getResources().getColor(R.color.md_light_green_500)));
         }
         final Slider sl_discrete = (Slider) findViewById(R.id.slider_sl_discrete);
         final TextView ads = (TextView) findViewById(R.id.ads);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
@@ -47,6 +47,7 @@ public class EditCardsLayout extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getColor(subreddit)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
         }
 
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/FullscreenVideo.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/FullscreenVideo.java
@@ -55,6 +55,7 @@ public class FullscreenVideo extends BaseActivity {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             window.setStatusBarColor(Color.BLACK);
+            window.setNavigationBarColor(Color.BLACK);
         }
         if (!data.contains("cdn.embedly.com")) {
             if (data.contains("?v=")) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Inbox.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Inbox.java
@@ -56,6 +56,7 @@ public class Inbox extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
         }
         pager.setAdapter(new OverviewPagerAdapter(getSupportFragmentManager()));
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ModQueue.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ModQueue.java
@@ -48,6 +48,7 @@ public class ModQueue extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
         }
         pager.setAdapter(new OverviewPagerAdapter(getSupportFragmentManager()));
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
@@ -57,6 +57,7 @@ public class MultiredditOverview extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getDefaultColor())));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getDefaultColor())));
         }
         findViewById(R.id.header).setBackgroundColor(Pallete.getDefaultColor());
         tabs = (TabLayout) findViewById(R.id.sliding_tabs);
@@ -230,6 +231,7 @@ public class MultiredditOverview extends BaseActivity {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     Window window = this.getWindow();
                     window.setStatusBarColor(Pallete.getDarkerColor(usedArray.get(0).getDisplayName()));
+                    window.setNavigationBarColor(Pallete.getDarkerColor(usedArray.get(0).getDisplayName()));
                 }
 
                 findViewById(R.id.header).setBackgroundColor(Pallete.getColor(usedArray.get(0).getDisplayName()));
@@ -271,6 +273,7 @@ public class MultiredditOverview extends BaseActivity {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         Window window = getWindow();
                         window.setStatusBarColor(Pallete.getDarkerColor(usedArray.get(position).getDisplayName()));
+                        window.setNavigationBarColor(Pallete.getDarkerColor(usedArray.get(position).getDisplayName()));
                     }
                 }
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/OverviewBase.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/OverviewBase.java
@@ -277,6 +277,7 @@ public class OverviewBase extends AppCompatActivity {
                                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                     Window window = getWindow();
                                     window.setStatusBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
+                                    window.setNavigationBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
                                     OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), colorPicker2.getColor()));
 
                                 }
@@ -298,6 +299,7 @@ public class OverviewBase extends AppCompatActivity {
                                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                         Window window = getWindow();
                                         window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+                                        window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
                                         OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), colorPicker2.getColor()));
 
                                     }
@@ -527,6 +529,7 @@ public class OverviewBase extends AppCompatActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 Window window = this.getWindow();
                 window.setStatusBarColor(Pallete.getDarkerColor(usedArray.get(0)));
+                window.setNavigationBarColor(Pallete.getDarkerColor(usedArray.get(0)));
                 OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(usedArray.get(0), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(usedArray.get(0))));
 
             }
@@ -1038,6 +1041,7 @@ public class OverviewBase extends AppCompatActivity {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     Window window = getWindow();
                     window.setStatusBarColor(Pallete.getDarkerColor(color));
+                    window.setNavigationBarColor(Pallete.getDarkerColor(color));
                     OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(subToDo, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), color));
 
                 }
@@ -1601,6 +1605,7 @@ public class OverviewBase extends AppCompatActivity {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             Window window = getWindow();
                             window.setStatusBarColor(Pallete.getDarkerColor(usedArray.get(position)));
+                            window.setNavigationBarColor(Pallete.getDarkerColor(usedArray.get(position)));
                             OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(usedArray.get(position), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(usedArray.get(position))));
 
                         }
@@ -1613,6 +1618,7 @@ public class OverviewBase extends AppCompatActivity {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             Window window = getWindow();
                             window.setStatusBarColor(Pallete.getDarkerColor(usedArray.get(position)));
+                            window.setNavigationBarColor(Pallete.getDarkerColor(usedArray.get(position)));
                             OverviewBase.this.setTaskDescription(new ActivityManager.TaskDescription(usedArray.get(position), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(usedArray.get(position))));
 
                         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
@@ -68,6 +68,7 @@ public class Profile extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getColorUser(name))));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getColorUser(name))));
         }
 
         tabs = (TabLayout) findViewById(R.id.sliding_tabs);
@@ -202,6 +203,7 @@ public class Profile extends BaseActivity {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             Window window = getWindow();
                             window.setStatusBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
+                            window.setNavigationBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
                         }
                         title.setBackgroundColor(colorPicker2.getColor());
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SavedView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SavedView.java
@@ -52,6 +52,7 @@ public class SavedView extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getColorUser(id)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getColorUser(id)));
             SavedView.this.setTaskDescription(new ActivityManager.TaskDescription(where + " posts", ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColorUser(id)));
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Sendmessage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Sendmessage.java
@@ -108,6 +108,7 @@ public class Sendmessage extends AppCompatActivity {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getColorUser(name)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getColorUser(name)));
         }
         setSupportActionBar(b);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -75,6 +75,7 @@ public class Settings extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             Settings.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_settings), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
@@ -39,6 +39,7 @@ public class SettingsAbout extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsAbout.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.settings_title_about),
                     ((BitmapDrawable) ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsBackup.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsBackup.java
@@ -128,6 +128,7 @@ public class SettingsBackup extends BaseActivityNoAnim implements GoogleApiClien
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsBackup.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.settings_title_backup), ((BitmapDrawable) ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
         if (Reddit.tabletUI) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFab.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFab.java
@@ -37,6 +37,7 @@ public class SettingsFab extends BaseActivityNoAnim  {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsFab.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.settings_title_fab),
                     ((BitmapDrawable) ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
@@ -46,6 +46,7 @@ public class SettingsGeneral extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsGeneral.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.settings_title_general), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsHandling.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsHandling.java
@@ -39,6 +39,7 @@ public class SettingsHandling extends BaseActivityNoAnim implements
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsHandling.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.settings_link_handling),
                     ((BitmapDrawable) ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSubreddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSubreddit.java
@@ -66,6 +66,7 @@ public class SettingsSubreddit extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsSubreddit.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_settings), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
 
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsTheme.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsTheme.java
@@ -48,6 +48,7 @@ public class SettingsTheme extends BaseActivityNoAnim {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             SettingsTheme.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_theme_settings), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
 
@@ -343,6 +344,7 @@ public class SettingsTheme extends BaseActivityNoAnim {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             Window window = getWindow();
                             window.setStatusBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
+                            window.setNavigationBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
                             SettingsTheme.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_theme_settings), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), colorPicker2.getColor()));
 
                         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SingleView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SingleView.java
@@ -50,6 +50,7 @@ public class SingleView extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(subreddit)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(subreddit)));
             SingleView.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor(subreddit)));
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Submit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Submit.java
@@ -88,6 +88,7 @@ public class Submit extends AppCompatActivity {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getColor("asldkfj")));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getColor("asldkfj")));
         }
         setSupportActionBar(b);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditOverviewSingle.java
@@ -123,6 +123,7 @@ public class SubredditOverviewSingle extends OverviewBase {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getDefaultColor())));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(Pallete.getDefaultColor())));
             SubredditOverviewSingle.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_default), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getColor("")));
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -108,6 +108,7 @@ public class SubredditView extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = this.getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(subreddit)));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDarkerColor(subreddit)));
         }
         drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         setResult(3);
@@ -783,6 +784,7 @@ public class SubredditView extends BaseActivity {
                                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                     Window window = getWindow();
                                     window.setStatusBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
+                                    window.setNavigationBarColor(Pallete.getDarkerColor(colorPicker2.getColor()));
                                     SubredditView.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), colorPicker2.getColor()));
 
                                 }
@@ -803,6 +805,7 @@ public class SubredditView extends BaseActivity {
                                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                         Window window = getWindow();
                                         window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+                                        window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
                                         SubredditView.this.setTaskDescription(new ActivityManager.TaskDescription(subreddit, ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), colorPicker2.getColor()));
 
                                     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tutorial.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tutorial.java
@@ -69,6 +69,7 @@ public class Tutorial extends FragmentActivity {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
             window.setStatusBarColor(Pallete.getDarkerColor(Color.parseColor("#FF5252")));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Color.parseColor("#FF5252")));
         }
         final RadioGroup radioGroup = (RadioGroup) findViewById(R.id.radiogroup);
         radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Wiki.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Wiki.java
@@ -63,6 +63,7 @@ public class Wiki extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(subreddit));
+            window.setNavigationBarColor(Pallete.getDarkerColor(subreddit));
         }
 
         new AsyncGetWiki().execute();

--- a/app/src/main/java/me/ccrama/redditslide/DragSort/ListViewDraggingAnimation.java
+++ b/app/src/main/java/me/ccrama/redditslide/DragSort/ListViewDraggingAnimation.java
@@ -70,6 +70,7 @@ public class ListViewDraggingAnimation extends BaseActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.setStatusBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
+            window.setNavigationBarColor(Pallete.getDarkerColor(Pallete.getDefaultColor()));
             ListViewDraggingAnimation.this.setTaskDescription(new ActivityManager.TaskDescription(getString(R.string.title_reorder_pins), ((BitmapDrawable) getResources().getDrawable(R.drawable.ic_launcher)).getBitmap(), Pallete.getDefaultColor()));
         }
 


### PR DESCRIPTION
Tint the navigation bar to match the status bar. This is one of the features I missed from other clients. It also helps prevent some navbar burn-in on amoled displays if you spend most of your time on Reddit.