### PR TITLE
Fix the comment sorting to reflect reddit defaults

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -97,7 +97,7 @@ public class CommentPage extends Fragment {
                     : Reddit.defaultCommentSorting == CommentSort.NEW ? 3
                     : Reddit.defaultCommentSorting == CommentSort.CONTROVERSIAL ? 4
                     : Reddit.defaultCommentSorting == CommentSort.OLD ? 5
-                    : 1;
+                    : 0;
             AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getContext());
             builder.setTitle(R.string.sorting_choose);
             Resources res = getActivity().getBaseContext().getResources();
@@ -306,6 +306,7 @@ public class CommentPage extends Fragment {
         if (context.isEmpty()) {
 
             comments = new SubmissionComments(fullname, this, mSwipeRefreshLayout);
+            comments.setSorting(Reddit.defaultCommentSorting);
             if (DataShare.sharedSubreddit != null)
                 adapter = new CommentAdapter(this, comments, rv, DataShare.sharedSubreddit.get(page), getFragmentManager());
             rv.setAdapter(adapter);
@@ -313,9 +314,11 @@ public class CommentPage extends Fragment {
         } else {
             if (context.equals("NOTHING")) {
                 comments = new SubmissionComments(fullname, this, mSwipeRefreshLayout);
+                comments.setSorting(Reddit.defaultCommentSorting);
 
             } else {
                 comments = new SubmissionComments(fullname, this, mSwipeRefreshLayout, context);
+                comments.setSorting(Reddit.defaultCommentSorting);
             }
 
 

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -40,7 +40,7 @@ public class SettingValues {
         colorIndicator = ColorIndicator.valueOf(settings.getString("colorIndicatorNew", "CARD_BACKGROUND"));
         defaultSorting = Sorting.valueOf(settings.getString("defaultSorting", "HOT"));
         timePeriod = TimePeriod.valueOf(settings.getString("timePeriod", "DAY"));
-        defaultCommentSorting = CommentSort.valueOf(settings.getString("defaultCommentSorting", "TOP"));
+        defaultCommentSorting = CommentSort.valueOf(settings.getString("defaultCommentSorting", "CONFIDENCE"));
     }
 
     public enum ColorIndicator {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@
     <string name="sorting_best">Best</string>
     <string name="sorting_top">Top</string>
     <string name="sorting_hot">Hot</string>
-    <string name="sorting_ama">Q&amp;A (AMA)></string>
+    <string name="sorting_ama">Q&amp;A (AMA)</string>
     <string name="sorting_new">New</string>
     <string name="sorting_old">Old</string>
     <string name="sorting_controversial">Controversial</string>


### PR DESCRIPTION
This commit changes the default sorting in the preferences to "Best" (issue #610), which is the ``Confidence`` option for ``default_comment_sort`` defined in the reddit Oauth API . In addition, an extra ``>`` in the ``Q&A (AMA)`` string resource in ``strings.xml`` was removed (not sure how that got in there in the first place).

Now the default sorting is set to ``confidence``, and logging in should keep whatever sorting option you selected.