### PR TITLE
Fix guilded post icon alignment

### DIFF
--- a/app/src/main/res/layout-v21/submission_largecard.xml
+++ b/app/src/main/res/layout-v21/submission_largecard.xml
@@ -307,7 +307,8 @@
                         android:orientation="horizontal"
                         android:paddingLeft="8dp"
                         android:layout_alignParentLeft="true"
-                        android:layout_centerInParent="true"/>
+                        android:layout_centerInParent="true"
+                        android:layout_marginLeft="8dp" />
 
                     <ImageView
                         android:id="@+id/hide"

--- a/app/src/main/res/layout/submission_largecard.xml
+++ b/app/src/main/res/layout/submission_largecard.xml
@@ -306,7 +306,7 @@
                         android:padding="8dp"
                         android:layout_centerInParent="true"
                         android:layout_alignParentLeft="true"
-                       />
+                        android:layout_marginLeft="8dp" />
 
                     <ImageView
                         android:id="@+id/hide"


### PR DESCRIPTION
These changes realign the icon added in #562, so that it lines up with the positioning of the other layout elements. Currently it looks a little out of place, being all the way off to the left. I didn't see an issue, but I figured that since this is a minor cosmetic change, I'd just create the pull request right away.

(I think these are all the layout files that needed to be modified)