### PR TITLE
Slim down Play Services dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile 'com.github.rey5137:material:1.2.1'
     compile 'jp.wasabeef:recyclerview-animators:2.0.0'
     compile 'com.sothree.slidinguppanel:library:3.2.0'
-    compile 'com.google.android.gms:play-services:8.3.0'
+    compile 'com.google.android.gms:play-services-drive:8.3.0'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
     compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.4.1'
     compile 'com.android.support:cardview-v7:23.1.1'


### PR DESCRIPTION
See https://developers.google.com/android/guides/setup

Rather than including the massive play-services library, it is possible to pick out only the parts you need as dependencies. This app only uses the Google Drive functionality, so play-services can be replaced with play-services-drive. This results in a large decrease in APK size.

Before:
```
-rw-r--r-- 1 owner owner  11M Nov 21 10:55 app-debug.apk
-rw-r--r-- 1 owner owner  11M Nov 21 10:55 app-debug-unaligned.apk
```

After:
```
-rw-r--r-- 1 owner owner 9.3M Nov 21 11:08 app-debug.apk
-rw-r--r-- 1 owner owner 9.3M Nov 21 11:08 app-debug-unaligned.apk
```