### PR TITLE
Use regex for URL handling (fixes #619)

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -11,13 +11,11 @@ import me.ccrama.redditslide.Activities.Profile;
 import me.ccrama.redditslide.Activities.SubredditView;
 import me.ccrama.redditslide.Activities.Wiki;
 
-/**
- * Created by ccrama on 9/27/2015.
- */
 public class OpenRedditLink {
-    public OpenRedditLink(Context c, String url) {
+    private final static String TAG = "OpenRedditLink";
 
-        boolean np = url.contains("np");
+    public OpenRedditLink(Context context, String url) {
+        boolean np = url.contains("np.");
         url = url.replace("np.", "");
         url = url.replace("www.", "");
         url = url.replace("http://", "");
@@ -26,7 +24,7 @@ public class OpenRedditLink {
         if (url.startsWith("/")) {
             url = "reddit.com" + url;
         }
-        Log.v("Slide", url);
+        Log.v(TAG, url);
         if (url.endsWith("/")) {
             url = url.substring(0, url.length() - 1);
 
@@ -39,63 +37,51 @@ public class OpenRedditLink {
 
 
         }
-        if (url.contains("/wiki")) {
-            Intent i = new Intent(c, Wiki.class);
+
+        if (!url.contains("reddit.com") && !url.contains("redd.it")) { // not a valid link
+            Log.v(TAG, "Invalid link");
+            return;
+        }
+
+        if (url.matches("redd\\.it.*")) { // redd.it post link
+            Intent i = new Intent(context, CommentsScreenSingle.class);
+            i.putExtra("subreddit", "NOTHING");
+            i.putExtra("context", "NOTHING");
+            i.putExtra("np", np);
+            i.putExtra("submission", parts[1]);
+            context.startActivity(i);
+        } else if (url.matches("reddit\\.com/r/\\w*/wiki/.*")) { // wiki link
+            Intent i = new Intent(context, Wiki.class);
             i.putExtra("subreddit", parts[2]);
-            c.startActivity(i);
-        } else if (url.contains("subreddit")) {
-            Intent intent = new Intent(c, SubredditView.class);
+            context.startActivity(i);
+        } else if (url.matches("reddit\\.com/r/\\w*")) { // subreddit link
+            Intent intent = new Intent(context, SubredditView.class);
             intent.putExtra("subreddit", parts[2]);
-            c.startActivity(intent);
-        } else if (((parts.length == 3 && !url.contains("/u/") && !url.contains("/user/"))) || url.contains("search?")) {
-            Intent intent = new Intent(c, SubredditView.class);
-            intent.putExtra("subreddit", parts[2]);
-            c.startActivity(intent);
-        } else if (url.contains("/u/") || url.contains("/user/")) {
+            context.startActivity(intent);
+        } else if (url.matches("reddit\\.com/u(ser)?/.*")) { // user link
             String name = parts[2];
             if (name.equals("me")) name = Authentication.name;
-            Intent myIntent = new Intent(c, Profile.class);
+            Intent myIntent = new Intent(context, Profile.class);
             myIntent.putExtra("profile", name);
-            c.startActivity(myIntent);
-        } else if (url.contains("reddit.com") || url.contains("redd.it")) {
-            if (parts.length == 7) {
-
-
-                Intent i = new Intent(c, CommentsScreenSingle.class);
+            context.startActivity(myIntent);
+        } else if (parts.length == 7) { // post link with context
+                Intent i = new Intent(context, CommentsScreenSingle.class);
                 i.putExtra("subreddit", parts[2]);
                 i.putExtra("submission", parts[4]);
                 i.putExtra("np", np);
                 i.putExtra("loadmore", true);
                 String end = parts[6];
-                if (end.contains("?")) {
-                    end = end.substring(0, end.indexOf("?"));
-                }
+                if (end.contains("?")) end = end.substring(0, end.indexOf("?"));
                 i.putExtra("context", end);
-                c.startActivity(i);
-
-            } else if (parts.length == 2) {
-                Intent i = new Intent(c, CommentsScreenSingle.class);
-                i.putExtra("subreddit", "NOTHING");
-                i.putExtra("context", "NOTHING");
-                i.putExtra("np", np);
-
-                i.putExtra("submission", parts[1]);
-                c.startActivity(i);
-
-            } else {
-
-
-                Intent i = new Intent(c, CommentsScreenSingle.class);
-                i.putExtra("subreddit", parts[2]);
-                i.putExtra("context", "NOTHING");
-                i.putExtra("np", np);
-                i.putExtra("submission", parts[4]);
-                c.startActivity(i);
-
-            }
+                context.startActivity(i);
+        } else { // post link without context
+            Intent i = new Intent(context, CommentsScreenSingle.class);
+            i.putExtra("subreddit", parts[2]);
+            i.putExtra("context", "NOTHING");
+            i.putExtra("np", np);
+            i.putExtra("submission", parts[4]);
+            context.startActivity(i);
         }
-
-
     }
 
     public OpenRedditLink(Context c, String submission, String subreddit, String id) {

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -65,15 +65,15 @@ public class OpenRedditLink {
             myIntent.putExtra("profile", name);
             context.startActivity(myIntent);
         } else if (parts.length == 7) { // post link with context
-                Intent i = new Intent(context, CommentsScreenSingle.class);
-                i.putExtra("subreddit", parts[2]);
-                i.putExtra("submission", parts[4]);
-                i.putExtra("np", np);
-                i.putExtra("loadmore", true);
-                String end = parts[6];
-                if (end.contains("?")) end = end.substring(0, end.indexOf("?"));
-                i.putExtra("context", end);
-                context.startActivity(i);
+            Intent i = new Intent(context, CommentsScreenSingle.class);
+            i.putExtra("subreddit", parts[2]);
+            i.putExtra("submission", parts[4]);
+            i.putExtra("np", np);
+            i.putExtra("loadmore", true);
+            String end = parts[6];
+            if (end.contains("?")) end = end.substring(0, end.indexOf("?"));
+            i.putExtra("context", end);
+            context.startActivity(i);
         } else { // post link without context
             Intent i = new Intent(context, CommentsScreenSingle.class);
             i.putExtra("subreddit", parts[2]);


### PR DESCRIPTION
Before, a link to any post that contained the word 'subreddit' (i.e. https://reddit.com/r/AskReddit/comments/3pc6rf/what_are_the_best_textbased_subreddits_to_kill) would cause Slide to open the subreddit instead of the post. Now, with more precise regex handling, this is prevented.