### PR TITLE
Fix formatting issue with adjacent code blocks (issue #636)

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Views/MakeTextviewClickable.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/MakeTextviewClickable.java
@@ -178,10 +178,6 @@ public class MakeTextviewClickable {
      * @return  the message with monospace font applied to code fragments
      */
     private CharSequence setCodeFont(SpannableStringBuilder sequence) {
-        final String startSeq = "[[<[";
-        final String endSeq = "]>]]";
-
-
         int start = 0;
         int end = 0;
         for (int i = 0; i < sequence.length(); i++) {
@@ -201,6 +197,7 @@ public class MakeTextviewClickable {
                 sequence.setSpan(new TypefaceSpan("monospace"), start, end - 4, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
                 start = 0;
                 end = 0;
+                i = i - 4; // move back to compensate for removal of [[<[
             }
         }
 


### PR DESCRIPTION
When the "[[<[" sequence is removed from the message, the position
pointer is not moved back 4 spaces to compensate for this. This
leads to 4 characters being missed on the next iteration. If the
"[[<[" sequence lies in this space, it will be missed.

Fixes issue #636