### PR TITLE
Fix RecyclerView IndexOutOfBounds crash

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -201,7 +201,7 @@ public class CommentPage extends Fragment {
                     if (adapter.users != null) {
                         int pastVisiblesItems = ((LinearLayoutManager) rv.getLayoutManager()).findFirstVisibleItemPosition();
 
-                        for (int i = pastVisiblesItems; i < adapter.getItemCount(); i++) {
+                        for (int i = pastVisiblesItems; i + 1 < adapter.getItemCount(); i++) {
 
                             if (adapter.users.get(adapter.getRealPosition(i)).getCommentNode().isTopLevel()) {
                                 RecyclerView.SmoothScroller smoothScroller = new TopSnappedSmoothScroller(rv.getContext(), (PreCachingLayoutManagerComments) rv.getLayoutManager());


### PR DESCRIPTION
If I'm reading the code right, this should be a simple fix for #654 to prevent an ``IndexOutOfBoundsException`` from occurring.