### PR TITLE
Fix crash when all subreddit posts are loaded

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -15,6 +15,7 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.support.v7.widget.RecyclerView;
@@ -56,6 +57,9 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public SubredditPosts dataSet;
     public ArrayList<Submission> seen;
     public ArrayList<RecyclerView.ViewHolder> views;
+    private final int LOADING_SPINNER = 5;
+    private final int SUBMISSION = 1;
+    private final int NO_MORE = 3;
 
     public SubmissionAdapter(Activity mContext, SubredditPosts dataSet, RecyclerView listView, String subreddit) {
         this.views = new ArrayList<>();
@@ -82,20 +86,22 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Override
     public int getItemViewType(int position) {
-
-        if (position == dataSet.posts.size()  &&dataSet.posts.size() != 0 &&!dataSet.offline) {
-
-            return 5;
+        if (position == dataSet.posts.size() && dataSet.posts.size() != 0 && !dataSet.offline && !dataSet.nomore) {
+            return LOADING_SPINNER;
+        } else if (position == dataSet.posts.size() && (dataSet.offline || dataSet.nomore)) {
+            return NO_MORE;
         }
-        return 1;
+        return SUBMISSION;
     }
 
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
-
-        if (i == 5) {
+        if (i == LOADING_SPINNER) {
             View v = LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.loadingmore, viewGroup, false);
-            return new ContributionAdapter.EmptyViewHolder(v);
+            return new SubmissionFooterViewHolder(v);
+        } else if (i == NO_MORE) {
+            View v = LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.nomoreposts, viewGroup, false);
+            return new SubmissionFooterViewHolder(v);
         } else {
             View v = CreateCardView.CreateView(viewGroup, custom, subreddit);
             return new SubmissionViewHolder(v);
@@ -272,30 +278,41 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 }
             });
         }
+        if (holder2 instanceof SubmissionFooterViewHolder) {
+            Handler handler = new Handler();
+
+            final Runnable r = new Runnable() {
+                public void run() {
+                    notifyItemChanged(dataSet.posts.size() + 1); // the loading spinner to replaced by nomoreposts.xml
+                }
+            };
+
+            handler.post(r);
+        }
         views.add(holder2);
+    }
+
+    public class SubmissionFooterViewHolder extends RecyclerView.ViewHolder {
+        public SubmissionFooterViewHolder(View itemView) {
+            super(itemView);
+        }
     }
 
     @Override
     public int getItemCount() {
         if (dataSet.posts == null || dataSet.posts.size() == 0) {
             return 0;
-        } else if (dataSet.nomore || dataSet.offline ) {
-
-            return dataSet.posts.size();
         } else {
-            return dataSet.posts.size() + 1;
-
+            return dataSet.posts.size() + 1; // Always account for footer
         }
     }
 
     public static class AsyncSave extends AsyncTask<Submission, Void, Void> {
-
         View v;
 
         public AsyncSave(View v) {
             this.v = v;
         }
-
 
         @Override
         protected Void doInBackground(Submission... submissions) {
@@ -306,15 +323,12 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                     submissions[0].saved = false;
                     v = null;
-
                 } else {
                     new AccountManager(Authentication.reddit).save(submissions[0]);
                     Snackbar.make(v, R.string.submission_info_saved, Snackbar.LENGTH_SHORT).show();
 
                     submissions[0].saved = true;
                     v = null;
-
-
                 }
             } catch (Exception e) {
                 return null;
@@ -352,6 +366,4 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             fixSliding(position - 1);
         }
     }
-
-
 }

--- a/app/src/main/res/layout/nomoreposts.xml
+++ b/app/src/main/res/layout/nomoreposts.xml
@@ -1,0 +1,24 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+
+    android:layout_margin="12dp"
+    android:paddingBottom="24dp"
+    app:cardBackgroundColor="?attr/card_background"
+
+    >
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:text="@string/misc_no_more_posts"
+        android:id="@+id/textView"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true" />
+
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,6 +293,7 @@
     <string name="misc_subscribed">Subscribed</string>
     <string name="misc_continue">Continue</string>
     <string name="misc_unsubscribed">Unsubscribed</string>
+    <string name="misc_no_more_posts">No more posts!</string>
 
 
     <!-- Goto User -->


### PR DESCRIPTION
When the app loaded all posts for a subreddit, SubredditPosts.nomore
is set to true, which in turn alters the output of SubmissionAdapter.getItemCount
to just be {number of posts} (not {number of posts + 1} or 0).

However, the ViewHolder with the loading spinner still exists in the
RecyclerView, so the exception is thrown since our reported number of
items is {number of posts}, but the RecyclerView has {number of posts + 1}
items.

This solution adds the nomoreposts.xml which replaces loading spinner
with a "No more posts!" message, and alters the SubmissionAdapter.getItemCount
method return either 0 or posts.size() + 1 (so it always accounts for
footer element).

Some refactoring was also applied to make code a bit more readable.

This seems to works well, except in the case of where if 
1. you go to the subreddit view though search (/r/fleksy)
2. scroll to bottom (and maybe top)
3. press the back button (to go back to home view)
4. go back the /r/fleksy through search

As you enter the subreddit in 4., the app freezes for a few seconds. I don't know if it's related to this commit, or its another issue.

Fixes #615.