### PR TITLE
Moved secret constant to properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ Thumbs.db
 cd
 
 
-/app/src/main/java/me/ccrama/redditslide/SecretConstants.java
+/app/src/main/assets/secretconstants.properties

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -452,7 +452,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         @Override
         protected Void doInBackground(Void... params) {
             try {
-                mHelper = new IabHelper(Reddit.this, SecretConstants.base64EncodedPublicKey);
+                mHelper = new IabHelper(Reddit.this, SecretConstants.getBase64EncodedPublicKey(getBaseContext()));
                 mHelper.startSetup(new IabHelper.OnIabSetupFinishedListener() {
                     public void onIabSetupFinished(IabResult result) {
                         if (!result.isSuccess()) {

--- a/app/src/main/java/me/ccrama/redditslide/SecretConstants.java
+++ b/app/src/main/java/me/ccrama/redditslide/SecretConstants.java
@@ -1,0 +1,32 @@
+package me.ccrama.redditslide;
+
+import android.content.Context;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Created by Deadl on 26/11/2015.
+ */
+public class SecretConstants {
+
+    private static String base64EncodedPublicKey;
+
+    public static String getBase64EncodedPublicKey(Context context) {
+        if (base64EncodedPublicKey == null) {
+            InputStream input = null;
+            try {
+                input = context.getAssets().open("secretconstants.properties");
+                Properties properties = new Properties();
+                properties.load(input);
+                base64EncodedPublicKey = properties.getProperty("base64EncodedPublicKey");
+            } catch (IOException e) {
+                // file not found
+                base64EncodedPublicKey = "";
+            }
+
+        }
+        return base64EncodedPublicKey;
+    }
+}


### PR DESCRIPTION
To get this to work, create the file

/app/src/main/assets/secretconstants.properties

with contents

base64EncodedPublicKey=asdkajsnkasi2h2379r1

(but with the actual key of course). If the file is not present,
the constant is set to an empty string.

Fixes #558.