### PR TITLE
Add spoiler functionality

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 
 import jp.wasabeef.recyclerview.animators.FadeInAnimator;
 import jp.wasabeef.recyclerview.animators.ScaleInLeftAnimator;
+import me.ccrama.redditslide.ActiveTextView;
 import me.ccrama.redditslide.Activities.Profile;
 import me.ccrama.redditslide.Activities.SubredditView;
 import me.ccrama.redditslide.Authentication;
@@ -623,7 +624,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (currentSelectedItem.contains(comment.getFullName())) {
             doUnHighlighted(holder, comment);
         } else {
-
             doOnClick(holder, baseNode, comment);
         }
     }
@@ -839,10 +839,13 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             holder.content.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    ActiveTextView activeTextView = (ActiveTextView)v;
                     if (Reddit.swap) {
                         doLongClick(holder, comment, baseNode, finalPos, finalPos1);
-                    } else {
+                    } else if (!activeTextView.isSpoilerClicked()) {
                         doOnClick(holder, comment, baseNode);
+                    } else if (activeTextView.isSpoilerClicked()) {
+                        activeTextView.resetSpoilerClicked();
                     }
                 }
             });

--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -171,9 +171,14 @@ public class ContentType {
 
     public static ImageType getImageType(String url) {
 
+        if (url.equals("#s") || url.equals("/s") || url.equals("/spoiler") || url.equals("/sp")) {
+            return ImageType.SPOILER;
+        }
+
         if (url.startsWith("/")) {
             url = "reddit.com" + url;
         }
+
         if ((url.contains("reddit.com") || url.contains("redd.it")) && !url.contains("/wiki") && !url.contains("/live")) {
             return ImageType.REDDIT;
         } else if (url.contains("youtube.com") || url.contains("youtu.be")) {
@@ -191,12 +196,30 @@ public class ContentType {
             return ImageType.GIF;
         } else {
             return ImageType.LINK;
-
         }
 
     }
 
     public enum ImageType {
-        NSFW_IMAGE, NSFW_GIF, NSFW_GFY, REDDIT, EMBEDDED, LINK, IMAGE_LINK, NSFW_LINK, SELF, GFY, ALBUM, IMAGE, GIF, NONE_GFY, NONE_GIF, NONE, NONE_IMAGE, VIDEO, NONE_URL
+        NSFW_IMAGE,
+        NSFW_GIF,
+        NSFW_GFY,
+        REDDIT,
+        EMBEDDED,
+        LINK,
+        IMAGE_LINK,
+        NSFW_LINK,
+        SELF,
+        GFY,
+        ALBUM,
+        IMAGE,
+        GIF,
+        NONE_GFY,
+        NONE_GIF,
+        NONE,
+        NONE_IMAGE,
+        VIDEO,
+        NONE_URL,
+        SPOILER
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Views/MakeTextviewClickable.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/MakeTextviewClickable.java
@@ -4,21 +4,31 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
 import android.support.customtabs.CustomTabsIntent;
 import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.CharacterStyle;
 import android.text.style.ClickableSpan;
+import android.text.style.ForegroundColorSpan;
 import android.text.style.TypefaceSpan;
 import android.text.style.URLSpan;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
+import android.widget.TextView;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import me.ccrama.redditslide.ActiveTextView;
 import me.ccrama.redditslide.Activities.Album;
@@ -37,11 +47,15 @@ import me.ccrama.redditslide.Visuals.Palette;
  */
 public class MakeTextviewClickable {
 
+    private static final String SPOILER_TEXT = "spoiler";
+    private static final int SPOILER_TEXT_LENGTH = SPOILER_TEXT.length();
     private Context c;
+    private List<CharacterStyle> storedSpoilerSpans = new ArrayList<>();
+    private List<Integer> storedSpoilerStarts = new ArrayList<>();
+    private List<Integer> storedSpoilerEnds = new ArrayList<>();
 
     private static void openImage(Activity contextActivity, String submission) {
         if (Reddit.image) {
-
             Intent myIntent = new Intent(contextActivity, FullscreenImage.class);
             myIntent.putExtra("url", submission);
             contextActivity.startActivity(myIntent);
@@ -52,7 +66,6 @@ public class MakeTextviewClickable {
     }
 
     private static void openGif(final boolean gfy, Activity contextActivity, String submission) {
-
         if (Reddit.gif) {
             Intent myIntent = new Intent(contextActivity, GifView.class);
             if (gfy) {
@@ -70,7 +83,6 @@ public class MakeTextviewClickable {
     }
 
     public static String trimTrailingWhitespace(String source) {
-
         if (source == null)
             return "";
 
@@ -84,7 +96,6 @@ public class MakeTextviewClickable {
     }
 
     private static String noTrailingwhiteLines(String text) {
-
         while (text.charAt(text.length() - 1) == '\n') {
             text = text.substring(0, text.length() - 1);
         }
@@ -164,8 +175,6 @@ public class MakeTextviewClickable {
         return html;
     }
 
-
-
     /**
      * Sets the styling for string with code segments.
      *
@@ -203,378 +212,414 @@ public class MakeTextviewClickable {
         return sequence;
     }
 
+    /**
+     * Set the necessary spans for each spoiler.
+     *
+     * The algorithm works in the same way as <code>setCodeFont</code>.
+     * @param sequence
+     * @return
+     */
+    private CharSequence setSpoilerStyle(SpannableStringBuilder sequence) {
+        int start = 0;
+        int end = 0;
+        for (int i = 0; i < sequence.length(); i++) {
+            if (sequence.charAt(i) == '[' && i < sequence.length() - 3) {
+                if (sequence.charAt(i + 1) == '[' && sequence.charAt(i + 2) == 's' && sequence.charAt(i + 3) == '[') {
+                    start = i;
+                }
+            } else if (sequence.charAt(i) == ']' && i < sequence.length() - 3) {
+                if (sequence.charAt(i + 1) == 's' && sequence.charAt(i + 2) == ']' && sequence.charAt(i + 3) == ']') {
+                    end = i;
+                }
+            }
+
+            if (end > start) {
+                sequence.delete(end, end + 4);
+                sequence.delete(start, start + 4);
+                BackgroundColorSpan backgroundColorSpan = new BackgroundColorSpan(Color.BLACK);
+                ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
+
+                URLSpan urlSpan = sequence.getSpans(start, start, URLSpan.class)[0];
+                sequence.setSpan(urlSpan, sequence.getSpanStart(urlSpan), start - 1, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+
+                // spoiler text has a space at the front
+                sequence.setSpan(backgroundColorSpan, start + 1, end - 4, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+                sequence.setSpan(foregroundColorSpan, start, end - 4, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+
+                storedSpoilerSpans.add(foregroundColorSpan);
+                storedSpoilerSpans.add(backgroundColorSpan);
+                // Shift 1 to account for remove of beginning "<"
+                storedSpoilerStarts.add(start - 1);
+                storedSpoilerStarts.add(start - 1);
+                storedSpoilerEnds.add(end - 5);
+                storedSpoilerEnds.add(end - 5);
+
+                sequence.delete(start - 2, start - 1); // remove the trailing <
+                start = 0;
+                end = 0;
+                i = i - 5; // move back to compensate for removal of [[s[
+            }
+        }
+
+        return sequence;
+    }
+
+    /**
+     * Moved the spoiler text inside of the "title" attribute to inside the link
+     * tag. Then surround the spoiler text with <code>[[s[</code> and <code>]s]]</code>.
+     *
+     * If there is no text inside of the link tag, insert "spoiler".
+     *
+     * @param html
+     * @return
+     */
+    private String parseSpoilerTags(String html) {
+        String spoilerText;
+        String tag;
+        String spoilerTeaser;
+        Pattern spoilerPattern = Pattern.compile("<a.*title=\"(.*)\".*>(.*[^\\]]?[^\\]]?)</a>");
+        Matcher matcher = spoilerPattern.matcher(html);
+
+        while (matcher.find()) {
+            tag = matcher.group(0);
+            spoilerText = matcher.group(1);
+            spoilerTeaser = matcher.group(2);
+            // Remove the last </a> tag, but keep the < for parsing.
+            html = html.replace(tag, tag.substring(0, tag.length() - 4) + (spoilerTeaser.isEmpty() ? "spoiler" : "") + "&lt; [[s[ " + spoilerText + "]s]]</a>");
+        }
+
+        return html;
+    }
+
     private CharSequence convertHtmlToCharSequence(String html) {
         html = parseCodeTags(html);
+        html = parseSpoilerTags(html);
         CharSequence sequence = trim(Html.fromHtml(noTrailingwhiteLines(html)));
         sequence = setCodeFont((SpannableStringBuilder)sequence);
+        sequence = setSpoilerStyle((SpannableStringBuilder)sequence);
         return sequence;
     }
 
     public void ParseTextWithLinksTextViewComment(String rawHTML, final ActiveTextView comm, final Activity c, final String subreddit) {
-        if (rawHTML.length() > 0) {
-            rawHTML = rawHTML.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"").replace("&apos;", "'").replace("&amp;", "&").replace("<li><p>", "<p>• ").replace("</li>", "<br>").replaceAll("<li.*?>", "• ").replace("<p>", "<div>").replace("</p>", "</div>").replace("</del>", "</strike>").replace("<del>", "<strike>");
-
-            try {
-                rawHTML = rawHTML.substring(0, rawHTML.lastIndexOf("\n"));
-
-            } catch (Exception ignored) {
-
-            }
-            this.c = c;
-
-            CharSequence sequence = convertHtmlToCharSequence(rawHTML);
-            comm.setText(sequence);
-
-            comm.setLinkClickedListener(new ActiveTextView.OnLinkClickedListener() {
-                @Override
-                public void onClick(String url) {
-                    // Decide what to do when a link is clicked.
-                    // (This is useful if you want to open an in app-browser)
-                    if (url != null) {
-                        ContentType.ImageType type = ContentType.getImageType(url);
-                        switch (type) {
-                            case NSFW_IMAGE:
-                                openImage(c, url);
-
-
-                                break;
-
-                            case NSFW_GIF:
-
-                                openGif(false, c, url);
-
-
-                                break;
-                            case NSFW_GFY:
-
-                                openGif(true, c, url);
-
-                                break;
-                            case REDDIT:
-                                new OpenRedditLink(c, url);
-                                break;
-                            case LINK:
-
-                            {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case IMAGE_LINK: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case NSFW_LINK: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case SELF:
-
-                                break;
-                            case GFY:
-                                openGif(true, c, url);
-
-                                break;
-                            case ALBUM:
-
-                                if (Reddit.album) {
-                                    Intent i = new Intent(c, Album.class);
-                                    i.putExtra("url", url);
-                                    c.startActivity(i);
-                                } else {
-                                    Reddit.defaultShare(url, c);
-
-                                }
-
-                                break;
-                            case IMAGE:
-                                openImage(c, url);
-
-                                break;
-                            case GIF:
-                                openGif(false, c, url);
-
-                                break;
-                            case NONE_GFY:
-                                openGif(true, c, url);
-
-                                break;
-                            case NONE_GIF:
-                                openGif(false, c, url);
-
-                                break;
-
-                            case NONE:
-
-                                break;
-                            case NONE_IMAGE:
-                                openImage(c, url);
-
-                                break;
-                            case NONE_URL: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case VIDEO:
-
-                                if (Reddit.video) {
-                                    Intent intent = new Intent(c, FullscreenVideo.class);
-                                    intent.putExtra("html", url);
-                                    c.startActivity(intent);
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-
-
-                        }
-
-                    }
-                }
-            });
-
-
-            comm.setLinkTextColor(new ColorPreferences(c).getColor(subreddit));
-
-
+        if (rawHTML.isEmpty()) {
+            return;
         }
 
+        this.c = c;
 
+        rawHTML = rawHTML.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"").replace("&apos;", "'").replace("&amp;", "&").replace("<li><p>", "<p>• ").replace("</li>", "<br>").replaceAll("<li.*?>", "• ").replace("<p>", "<div>").replace("</p>", "</div>").replace("</del>", "</strike>").replace("<del>", "<strike>");
+        if (rawHTML.contains("\n")) {
+            rawHTML = rawHTML.substring(0, rawHTML.lastIndexOf("\n"));
+        }
+
+        final CharSequence sequence = convertHtmlToCharSequence(rawHTML);
+        comm.setText(sequence, TextView.BufferType.SPANNABLE);
+
+        comm.setLinkClickedListener(new ActiveTextView.OnLinkClickedListener() {
+            @Override
+            public void onClick(String url, int xOffset) {
+                // Decide what to do when a link is clicked.
+                // (This is useful if you want to open an in app-browser)
+                if (url == null) {
+                    return;
+                }
+
+                ContentType.ImageType type = ContentType.getImageType(url);
+                switch (type) {
+                    case NSFW_IMAGE:
+                        openImage(c, url);
+                        break;
+                    case NSFW_GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NSFW_GFY:
+                        openGif(true, c, url);
+                        break;
+                    case REDDIT:
+                        new OpenRedditLink(c, url);
+                        break;
+                    case LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case IMAGE_LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case NSFW_LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case SELF:
+                        break;
+                    case GFY:
+                        openGif(true, c, url);
+                        break;
+                    case ALBUM:
+                        if (Reddit.album) {
+                            Intent i = new Intent(c, Album.class);
+                            i.putExtra("url", url);
+                            c.startActivity(i);
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case IMAGE:
+                        openImage(c, url);
+                        break;
+                    case GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NONE_GFY:
+                        openGif(true, c, url);
+                        break;
+                    case NONE_GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NONE:
+                        break;
+                    case NONE_IMAGE:
+                        openImage(c, url);
+                        break;
+                    case NONE_URL:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            builder.setToolbarColor(Palette.getColor(subreddit)).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case VIDEO:
+                        if (Reddit.video) {
+                            Intent intent = new Intent(c, FullscreenVideo.class);
+                            intent.putExtra("html", url);
+                            c.startActivity(intent);
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                    case SPOILER:
+                        setOrRemoveSpoilerSpans(comm, (Spannable) sequence, xOffset);
+                        break;
+                }
+
+            }
+        });
+        comm.setLinkTextColor(new ColorPreferences(c).getColor(subreddit));
+    }
+
+    public void setOrRemoveSpoilerSpans(ActiveTextView commentView, Spannable text, int endOfLink) {
+        // add 2 to end of link since there is a white space between the link text and the spoiler
+        ForegroundColorSpan[] foregroundColors = text.getSpans(endOfLink + 2, endOfLink + 2, ForegroundColorSpan.class);
+
+        if (foregroundColors.length > 0) {
+            text.removeSpan(foregroundColors[0]);
+            commentView.setText(text);
+        } else {
+            for (int i = 0; i < storedSpoilerStarts.size(); i++) {
+                if (storedSpoilerStarts.get(i) < endOfLink + 2 && storedSpoilerEnds.get(i) > endOfLink + 2) {
+                    text.setSpan(storedSpoilerSpans.get(i), storedSpoilerStarts.get(i), storedSpoilerEnds.get(i), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+                }
+            }
+            commentView.setText(text);
+        }
     }
 
     public void ParseTextWithLinksTextView(String rawHTML, final ActiveTextView comm, final Activity c, String subreddit) {
-        if (rawHTML.length() > 0) {
-            rawHTML = rawHTML.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"").replace("&apos;", "'").replace("&amp;", "&").replace("<li><p>", "<p>• ").replace("</li>", "<br>").replaceAll("<li.*?>", "• ").replace("<p>", "<div>").replace("</p>", "</div>").replace("</del>", "</strike>").replace("<del>", "<strike>");
-            rawHTML = rawHTML.substring(15, rawHTML.lastIndexOf("<!-- SC_ON -->"));
-
-
-            this.c = c;
-
-            CharSequence sequence = convertHtmlToCharSequence(rawHTML);
-            comm.setText(sequence);
-            comm.setLinkClickedListener(new ActiveTextView.OnLinkClickedListener() {
-                @Override
-                public void onClick(String url) {
-                    // Decide what to do when a link is clicked.
-                    // (This is useful if you want to open an in app-browser)
-                    if (url != null) {
-                        if (url.startsWith("/")) {
-                            url = "reddit.com" + url;
-                        }
-                        ContentType.ImageType type = ContentType.getImageType(url);
-                        switch (type) {
-                            case NSFW_IMAGE:
-                                openImage(c, url);
-
-
-                                break;
-
-                            case NSFW_GIF:
-
-                                openGif(false, c, url);
-
-
-                                break;
-                            case NSFW_GFY:
-
-                                openGif(true, c, url);
-
-                                break;
-                            case REDDIT:
-                                new OpenRedditLink(c, url);
-                                break;
-                            case LINK:
-
-                            {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case IMAGE_LINK: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case NSFW_LINK: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case SELF:
-
-                                break;
-                            case GFY:
-                                openGif(true, c, url);
-
-                                break;
-                            case ALBUM:
-                                if (Reddit.album) {
-                                    Intent i = new Intent(c, Album.class);
-                                    i.putExtra("url", url);
-                                    c.startActivity(i);
-                                } else {
-                                    Reddit.defaultShare(url, c);
-
-                                }
-
-
-                                break;
-                            case IMAGE:
-                                openImage(c, url);
-
-                                break;
-                            case GIF:
-                                openGif(false, c, url);
-
-                                break;
-                            case NONE_GFY:
-                                openGif(true, c, url);
-
-                                break;
-                            case NONE_GIF:
-                                openGif(false, c, url);
-
-                                break;
-
-                            case NONE:
-
-                                break;
-                            case NONE_IMAGE:
-                                openImage(c, url);
-
-                                break;
-                            case NONE_URL: {
-                                if (Reddit.web) {
-                                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
-                                    //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
-
-                                    builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
-                                    builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
-                                    CustomTabsIntent customTabsIntent = builder.build();
-                                    try {
-                                        customTabsIntent.launchUrl(c, Uri.parse(url));
-                                    } catch (ActivityNotFoundException anfe) {
-                                        Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
-                                    }
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-                            }
-                            break;
-                            case VIDEO:
-
-                                if (Reddit.video) {
-                                    Intent intent = new Intent(c, FullscreenVideo.class);
-                                    intent.putExtra("html", url);
-                                    c.startActivity(intent);
-                                } else {
-                                    Reddit.defaultShare(url, c);
-                                }
-
-
-                        }
-
-                    }
-                }
-            });
-            comm.setLinkTextColor(new ColorPreferences(c).getColor(subreddit));
-
-
+        if (rawHTML.isEmpty()) {
+            return;
         }
 
+        this.c = c;
 
+        rawHTML = rawHTML.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"").replace("&apos;", "'").replace("&amp;", "&").replace("<li><p>", "<p>• ").replace("</li>", "<br>").replaceAll("<li.*?>", "• ").replace("<p>", "<div>").replace("</p>", "</div>").replace("</del>", "</strike>").replace("<del>", "<strike>");
+        rawHTML = rawHTML.substring(15, rawHTML.lastIndexOf("<!-- SC_ON -->"));
+
+        CharSequence sequence = convertHtmlToCharSequence(rawHTML);
+        comm.setText(sequence);
+        comm.setLinkClickedListener(new ActiveTextView.OnLinkClickedListener() {
+            @Override
+            public void onClick(String url, int xOffset) {
+                // Decide what to do when a link is clicked.
+                // (This is useful if you want to open an in app-browser)
+                if (url == null) {
+                    return;
+                }
+
+                if (url.startsWith("/")) {
+                    url = "reddit.com" + url;
+                }
+                ContentType.ImageType type = ContentType.getImageType(url);
+                switch (type) {
+                    case NSFW_IMAGE:
+                        openImage(c, url);
+                        break;
+                    case NSFW_GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NSFW_GFY:
+                        openGif(true, c, url);
+                        break;
+                    case REDDIT:
+                        new OpenRedditLink(c, url);
+                        break;
+                    case LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case IMAGE_LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case NSFW_LINK:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case SELF:
+                        break;
+                    case GFY:
+                        openGif(true, c, url);
+                        break;
+                    case ALBUM:
+                        if (Reddit.album) {
+                            Intent i = new Intent(c, Album.class);
+                            i.putExtra("url", url);
+                            c.startActivity(i);
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case IMAGE:
+                        openImage(c, url);
+                        break;
+                    case GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NONE_GFY:
+                        openGif(true, c, url);
+                        break;
+                    case NONE_GIF:
+                        openGif(false, c, url);
+                        break;
+                    case NONE:
+                        break;
+                    case NONE_IMAGE:
+                        openImage(c, url);
+                        break;
+                    case NONE_URL:
+                        if (Reddit.web) {
+                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(Reddit.getSession());
+                            //COLOR todo  builder.setToolbarColor(Palette.getColor(submission.getSubredditName())).setShowTitle(true);
+
+                            builder.setStartAnimations(c, R.anim.slideright, R.anim.fading_out_real);
+                            builder.setExitAnimations(c, R.anim.fade_out, R.anim.fade_in_real);
+                            CustomTabsIntent customTabsIntent = builder.build();
+                            try {
+                                customTabsIntent.launchUrl(c, Uri.parse(url));
+                            } catch (ActivityNotFoundException anfe) {
+                                Log.w("MakeTextViewClickable", "Unknown url: " + anfe);
+                            }
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                        break;
+                    case VIDEO:
+                        if (Reddit.video) {
+                            Intent intent = new Intent(c, FullscreenVideo.class);
+                            intent.putExtra("html", url);
+                            c.startActivity(intent);
+                        } else {
+                            Reddit.defaultShare(url, c);
+                        }
+                }
+            }
+        });
+        comm.setLinkTextColor(new ColorPreferences(c).getColor(subreddit));
     }
 }


### PR DESCRIPTION
This took longer than I thought... I'm fairly confident it works, but I wouldn't be surprised if it breaks in places since spoilers are consistent between subreddits.

+++ COMMIT MESSAGE +++

This has been tested on subreddits that use
- #s
- /s
- /sp
- /spoiler

as spoiler identifiers. The effect is that the visible text is
displayed as a link, with a whitespace, then the spoiler text
blacked out. When the visible text the clicked, the text of the
spoiler text is reset to white, with the backgroud to stay black.

This is a bit fragile due to the fact that:
1. subreddits use different hrefs for spoiler tags,
2. the visible spoiler text is different per subreddit (and even
   per post).

Accordingly, there are a few assumptions. Firstly:

A1. Spoilers are identified by the presence of the "title" attribute
    within the <a> tag.

This seems consitent with the html that comes out of reddit, and
is used in the regex to find each spoiler.

A2. The text within the spoiler does not end in "]]".

The whole parsing token is "]s]]", but this is relaxed to just "]]"
since it may or may not happen. Should probably be strengthed in
the future.

A3. If the title attribue is empty, insert "spoiler" as the visible
    text.

This is fairly self-explanatory, since having no title will mean
there is nothing to click on.

If more patterns need to be added to identify spoilers, see
ImageType.getImageType(String url).

To prevent collapsing of the children tree when a spoiler link is pressed,
ActiveTextView.spoilerClicked is set to true and is checked in the onClick
function in CommentAdapter for the R.id.content element.

Some amount of code clean up was added, since there were a lot of
inconsitent spacing issues and a few indents which could be reduced
by re-wording if statements.

Fixes #692, #691 