### PR TITLE
Fix crash loading app with disabled notifications

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -16,6 +16,7 @@ import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.rey.material.widget.Slider;
 
 import me.ccrama.redditslide.Authentication;
+import me.ccrama.redditslide.Notifications.NotificationJobScheduler;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.TimeUtils;
@@ -202,6 +203,9 @@ public class Settings extends BaseActivity {
                             if (checkBox.isChecked()) {
                                 Reddit.notificationTime = landscape.getValue() * 15;
                                 Reddit.seen.edit().putInt("notificationOverride", landscape.getValue() * 15).apply();
+                                if (Reddit.notifications == null) {
+                                    Reddit.notifications = new NotificationJobScheduler(getApplication());
+                                }
                                 Reddit.notifications.cancel(getApplication());
                                 Reddit.notifications.start(getApplication());
                             }
@@ -213,6 +217,9 @@ public class Settings extends BaseActivity {
                             if (checkBox.isChecked()) {
                                 Reddit.notificationTime = landscape.getValue() * 15;
                                 Reddit.seen.edit().putInt("notificationOverride", landscape.getValue() * 15).apply();
+                                if (Reddit.notifications == null) {
+                                    Reddit.notifications = new NotificationJobScheduler(getApplication());
+                                }
                                 Reddit.notifications.cancel(getApplication());
                                 Reddit.notifications.start(getApplication());
                                 dialog.dismiss();


### PR DESCRIPTION
When the app is started with the user having no notifications,
Reddit.notifications is null because the code that would initialize
it checks if Reddit.notificationTime (== -1) != -1.

All we have to do is check if it is not null, and instantiate it if
it is.

Fixes #598.