### PR TITLE
Removed \n string from Album View (Imgur)

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
@@ -120,7 +120,7 @@ public class AlbumView extends RecyclerView.Adapter<AlbumView.ViewHolder> {
         if (url.contains("gif")) {
             holder.body.setVisibility(View.VISIBLE);
             holder.body.setSingleLine(false);
-            holder.body.setText(holder.text.getText() + "\n" + main.getString(R.string.submission_tap_gif).toUpperCase());
+            holder.body.setText(holder.text.getText() + main.getString(R.string.submission_tap_gif).toUpperCase()); //got rid of the \n thing, because it didnt parse and it was already a new line so...
             holder.body.setOnClickListener(onGifImageClickListener);
         }
 

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -469,7 +469,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         @Override
         protected Void doInBackground(Void... params) {
             try {
-                mHelper = new IabHelper(Reddit.this, SecretConstants.base64EncodedPublicKey);
+                //mHelper = new IabHelper(Reddit.this, SecretConstants.base64EncodedPublicKey);
                 mHelper.startSetup(new IabHelper.OnIabSetupFinishedListener() {
                     public void onIabSetupFinished(IabResult result) {
                         if (!result.isSuccess()) {

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -469,7 +469,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         @Override
         protected Void doInBackground(Void... params) {
             try {
-                //mHelper = new IabHelper(Reddit.this, SecretConstants.base64EncodedPublicKey);
+                mHelper = new IabHelper(Reddit.this, SecretConstants.base64EncodedPublicKey);
                 mHelper.startSetup(new IabHelper.OnIabSetupFinishedListener() {
                     public void onIabSetupFinished(IabResult result) {
                         if (!result.isSuccess()) {


### PR DESCRIPTION
As seen in the Imgur Album view, when there is a GIF it says TAP TO LOAD GIF, In a new line, and the \n is not parsed to make a new line.

https://imgur.com/a/F1dd9

I removed the \n ~~(sorry, no after fix screenshot because my android studio is crapping on me)~~

EDIT: updated AS to 1.5.1, here is pic: http://i.imgur.com/NWsXgbA.jpg