### PR TITLE
Reference static variable through a static context

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
@@ -179,7 +179,7 @@ public class SubredditPosts {
 
                     adapter.setError(true);
                 }
-                (adapter.mContext).runOnUiThread(new Runnable() {
+                (SubmissionAdapter.mContext).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
                         if (refreshLayout != null) {


### PR DESCRIPTION
Static variables should not be referenced in a non-static context.