### PR TITLE
Fix non-card submission thumbnails not being square

### DIFF
--- a/app/src/main/res/layout-v21/submission_list.xml
+++ b/app/src/main/res/layout-v21/submission_list.xml
@@ -206,8 +206,7 @@
                     <com.makeramen.roundedimageview.RoundedImageView
                         android:id="@+id/thumbimage2"
                         android:layout_width="70dp"
-                        android:layout_height="wrap_content"
-                        android:maxHeight="50dp"
+                        android:layout_height="70dp"
                         android:layout_alignParentRight="true"
                         android:layout_centerVertical="true"
                         android:layout_marginRight="8dp"

--- a/app/src/main/res/layout/submission_list.xml
+++ b/app/src/main/res/layout/submission_list.xml
@@ -206,8 +206,7 @@
                     <com.makeramen.roundedimageview.RoundedImageView
                         android:id="@+id/thumbimage2"
                         android:layout_width="70dp"
-                        android:layout_height="wrap_content"
-                        android:maxHeight="50dp"
+                        android:layout_height="70dp"
                         android:layout_alignParentRight="true"
                         android:layout_centerVertical="true"
                         android:layout_marginRight="8dp"


### PR DESCRIPTION
Here is a side by side comparison: 
![card_demo](https://cloud.githubusercontent.com/assets/1526881/12949224/b8e42a66-cfd4-11e5-83a8-e5aa6ddb5190.jpg)

This PR fixes the thumbnail on the top.
