### PR TITLE
Fix issue with multireddits no loading

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
@@ -85,7 +85,7 @@ public class CreateMulti extends BaseActivityAnim {
             String multi = getIntent().getExtras().getString(EXTRA_MULTI);
             old = multi;
             title.setText(multi.replace("%20", " "));
-            for (MultiReddit multiReddit : SubredditStorage.multireddits) {
+            for (MultiReddit multiReddit : SubredditStorage.getMultireddits()) {
                 if (multiReddit.getDisplayName().equals(multi)) {
                     for (MultiSubreddit sub : multiReddit.getSubreddits()) {
                         subs.add(sub.getDisplayName().toLowerCase());

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
@@ -75,7 +75,7 @@ public class MultiredditOverview extends BaseActivityAnim {
         switch (item.getItemId()) {
             case R.id.action_edit: {
                 Intent i = new Intent(MultiredditOverview.this, CreateMulti.class);
-                i.putExtra(CreateMulti.EXTRA_MULTI, SubredditStorage.multireddits.get(pager.getCurrentItem()).getDisplayName());
+                i.putExtra(CreateMulti.EXTRA_MULTI, SubredditStorage.getMultireddits().get(pager.getCurrentItem()).getDisplayName());
                 startActivity(i);
             }
                 return true;
@@ -137,7 +137,7 @@ public class MultiredditOverview extends BaseActivityAnim {
 
 
 
-        setDataSet(SubredditStorage.multireddits);
+        setDataSet(SubredditStorage.getMultireddits());
     }
 
     public void openPopup() {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -174,10 +174,10 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
         getActivity().getTheme().resolveAttribute(android.support.v7.appcompat.R.attr.actionBarSize, typed_value, true);
         refreshLayout.setProgressViewOffset(false, 0, getResources().getDimensionPixelSize(typed_value.resourceId));
 
-        refreshLayout.setColorSchemeColors(Palette.getColors(SubredditStorage.multireddits.get(id).getDisplayName(), getActivity()));
+        refreshLayout.setColorSchemeColors(Palette.getColors(SubredditStorage.getMultireddits().get(id).getDisplayName(), getActivity()));
 
         refreshLayout.setRefreshing(true);
-        posts = new MultiredditPosts(SubredditStorage.multireddits.get(id).getDisplayName());
+        posts = new MultiredditPosts(SubredditStorage.getMultireddits().get(id).getDisplayName());
         adapter = new MultiredditAdapter(getActivity(), posts, rv, refreshLayout);
         rv.setAdapter(adapter);
         if(SettingValues.animation)

--- a/app/src/main/java/me/ccrama/redditslide/SubredditStorage.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubredditStorage.java
@@ -15,6 +15,7 @@ import net.dean.jraw.paginators.UserSubredditsPaginator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import me.ccrama.redditslide.Activities.MultiredditOverview;
 import me.ccrama.redditslide.Activities.Shortcut;
@@ -27,7 +28,7 @@ import me.ccrama.redditslide.util.NetworkUtil;
 public class SubredditStorage {
     public static SharedPreferences subscriptions;
     public static ArrayList<String> modOf;
-    public static ArrayList<MultiReddit> multireddits;
+    private static ArrayList<MultiReddit> multireddits;
     public static ArrayList<String> subredditsForHome;
     public static ArrayList<String> alphabeticalSubreddits;
     public static Shortcut shortcut;
@@ -47,8 +48,19 @@ public class SubredditStorage {
 
     }
 
+    /**
+     *
+     * @return list of multireddits if they are available, null if could not fetch multireddits
+     */
+    public static List<MultiReddit> getMultireddits() {
+        if (multireddits == null) {
+            loadMultireddits();
+        }
+        return multireddits;
+    }
+
     public static MultiReddit getMultiredditByDisplayName(String displayName) {
-        for (MultiReddit multiReddit : SubredditStorage.multireddits) {
+        for (MultiReddit multiReddit : multireddits) {
             if (multiReddit.getDisplayName().equals(displayName)) {
                 return multiReddit;
             }
@@ -85,9 +97,7 @@ public class SubredditStorage {
                         if (Authentication.mod) {
                             doModOf();
                         }
-                        if (Authentication.isLoggedIn && Authentication.didOnline) {
-                            getMultireddits();
-                        }
+                        loadMultireddits();
                         return null;
                     }
                 }.execute();
@@ -215,17 +225,15 @@ public class SubredditStorage {
         return toReturn;
     }
 
-    private static void getMultireddits() {
-
-        try {
-            multireddits = new ArrayList<>(new MultiRedditManager(Authentication.reddit).mine());
-
-        } catch (ApiException e) {
-            multireddits = new ArrayList<>();
-            e.printStackTrace();
+    private static void loadMultireddits() {
+        if (Authentication.isLoggedIn && Authentication.didOnline) {
+            try {
+                    multireddits = new ArrayList<>(new MultiRedditManager(Authentication.reddit).mine());
+            } catch (ApiException e) {
+                multireddits = null;
+                e.printStackTrace();
+            }
         }
-
-
     }
 
     private static ArrayList<String> sortNoValue(ArrayList<String> subs) {


### PR DESCRIPTION
Reproducing the error is a bit hard, I was on data at the time and I could load my multireddits as described below.

There is one assumption in that if something wants multireddits, then they will want to load them if they have not been already.

Commit message:

Slide could get into a state where the SubredditStorage.multireddits
field would be empty due to a network error/some other error.

Attempting to view multireddits would result in a error dialog due to
a NullPointerException due to SubredditStorage.multireddits being null,
which would return you to the main activity. Attempting to view
multireddits again would lead to the exact same message, since there
is no attempt to reload the multireddits in this action.

Adding a getter for multireddis gives an opportunity to load
multireddits if it is null, which should only be if it failed in
the past.