### PR TITLE
Fix typo causing title font unable to be set to Light

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
@@ -82,6 +82,7 @@ public class SettingsFont extends BaseActivityAnim {
             case Regular:
                 ((RobotoRadioButton) findViewById(R.id.creg)).setChecked(true);
                 break;
+
             case Slab:
                 ((RobotoRadioButton) findViewById(R.id.cslab)).setChecked(true);
 
@@ -123,8 +124,11 @@ public class SettingsFont extends BaseActivityAnim {
             case Regular:
                 ((RobotoRadioButton) findViewById(R.id.sreg)).setChecked(true);
                 break;
+
             case Light:
                 ((RobotoRadioButton) findViewById(R.id.sregl)).setChecked(true);
+                break;
+
             case Slab:
                 ((RobotoRadioButton) findViewById(R.id.sslabl)).setChecked(true);
 
@@ -148,7 +152,7 @@ public class SettingsFont extends BaseActivityAnim {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.CondensedReg);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.CondensedReg);
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sslab)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -156,14 +160,14 @@ public class SettingsFont extends BaseActivityAnim {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
 
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.SlabReg);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.SlabReg);
             }
         });
         ((RobotoRadioButton) findViewById(R.id.scondl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.Condensed);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Condensed);
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sslabl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -171,7 +175,7 @@ public class SettingsFont extends BaseActivityAnim {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
 
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.Slab);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Slab);
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sreg)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -179,7 +183,7 @@ public class SettingsFont extends BaseActivityAnim {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
 
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.Regular);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Regular);
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sregl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -187,7 +191,7 @@ public class SettingsFont extends BaseActivityAnim {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked)
 
-                    new FontPreferences(SettingsFont.this).setTitlFont(FontPreferences.FontTypeTitle.Light);
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Light);
             }
         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
+++ b/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
@@ -59,7 +59,7 @@ public class FontPreferences {
     public void setCommentFont(FontTypeComment style) {
         edit().putString(FONT_COMMENT, style.name()).commit();
     }
-    public void setTitlFont(FontTypeTitle style) {
+    public void setTitleFont(FontTypeTitle style) {
         edit().putString(FONT_TITLE, style.name()).commit();
     }
     public enum FontStyle {


### PR DESCRIPTION
I noticed this while using the app. Looks like someone forgot a `break` in a switch statement. Also fixed a typo in a method name.