### PR TITLE
Fix horizontal scrolling in sidebar

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -48,6 +48,7 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -98,6 +99,7 @@ import me.ccrama.redditslide.Synccit.SynccitRead;
 import me.ccrama.redditslide.TimeUtils;
 import me.ccrama.redditslide.Views.CommentOverflow;
 import me.ccrama.redditslide.Views.PreCachingLayoutManager;
+import me.ccrama.redditslide.Views.SidebarLayout;
 import me.ccrama.redditslide.Views.ToggleSwipeViewPager;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.AlbumUtils;
@@ -674,7 +676,6 @@ public class MainActivity extends BaseActivity {
             return;
         }
 
-
         List<String> blocks = SubmissionParser.getBlocks(rawHTML);
 
         int startIndex = 0;
@@ -693,6 +694,13 @@ public class MainActivity extends BaseActivity {
                 commentOverflow.setViews(blocks, subredditName);
             } else {
                 commentOverflow.setViews(blocks.subList(startIndex, blocks.size()), subredditName);
+            }
+            SidebarLayout sidebar = (SidebarLayout) findViewById(R.id.drawer_layout);
+            for (int i = 0; i < commentOverflow.getChildCount(); i++) {
+                View maybeScrollable = commentOverflow.getChildAt(i);
+                if (maybeScrollable instanceof HorizontalScrollView) {
+                    sidebar.addScrollable(maybeScrollable);
+                }
             }
         } else {
             commentOverflow.removeAllViews();

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -32,6 +32,7 @@ import android.view.Window;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -60,6 +61,7 @@ import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.SubredditStorage;
 import me.ccrama.redditslide.Views.CommentOverflow;
 import me.ccrama.redditslide.Views.PreCachingLayoutManager;
+import me.ccrama.redditslide.Views.SidebarLayout;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.handler.ToolbarScrollHideHandler;
 import me.ccrama.redditslide.util.LogUtil;
@@ -450,6 +452,13 @@ public class SubredditView extends BaseActivityAnim implements SubmissionDisplay
                 commentOverflow.setViews(blocks, subreddit);
             } else {
                 commentOverflow.setViews(blocks.subList(startIndex, blocks.size()), subreddit);
+            }
+            SidebarLayout sidebar = (SidebarLayout) findViewById(R.id.drawer_layout);
+            for (int i = 0; i < commentOverflow.getChildCount(); i++) {
+                View maybeScrollable = commentOverflow.getChildAt(i);
+                if (maybeScrollable instanceof HorizontalScrollView) {
+                    sidebar.addScrollable(maybeScrollable);
+                }
             }
         } else {
             commentOverflow.removeAllViews();

--- a/app/src/main/java/me/ccrama/redditslide/Views/SidebarLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/SidebarLayout.java
@@ -1,0 +1,71 @@
+package me.ccrama.redditslide.Views;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.support.v4.widget.DrawerLayout;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.ccrama.redditslide.R;
+
+/**
+ * Drawer that allows for horizontal scrolling views.
+ * <p/>
+ * Required since if the drawer is on the right, swiping right would close
+ * the drawer instead of scrolling horizontally.
+ * <p/>
+ * Only supports R.id.commentOverflow for now, but could be updated to support
+ * any view.
+ */
+public class SidebarLayout extends DrawerLayout {
+    private List<View> scrollableViews = new ArrayList<>();
+
+    public SidebarLayout(Context context) {
+        super(context);
+    }
+
+    public SidebarLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public SidebarLayout(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public void addScrollable(View view) {
+        scrollableViews.add(view);
+    }
+
+    /**
+     * Override to check if the pressed location corresponds to a scrollable
+     * view.
+     * <p/>
+     * Since the sidebar is a ScrollView, the absolute event position is
+     * the scroll y position + ev.getY(). The absolute position of the
+     * horizontal scrolling views is the View.getHitRect position (relative
+     * to the parent commentOverflow) + commentOverflow.getTop().
+     * <p/>
+     * See activity_overview.xml to get an idea of the view structure.
+     *
+     * @param ev
+     * @return false if the event corresponds to a scrollable, super otherwise.
+     */
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        View sidebarScrollView = findViewById(R.id.sidebar_scroll);
+        View commentOverflow = findViewById(R.id.commentOverflow);
+        int yOffset = sidebarScrollView.getScrollY();
+        for (View view : scrollableViews) {
+            Rect rect = new Rect();
+            view.getHitRect(rect);
+            if (rect.contains((int) ev.getX(), (int) ev.getY() - commentOverflow.getTop() + yOffset)) {
+                return false;
+            }
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+}

--- a/app/src/main/res/layout/activity_overview.xml
+++ b/app/src/main/res/layout/activity_overview.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout
+<me.ccrama.redditslide.Views.SidebarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
@@ -55,4 +55,4 @@
         android:layout_height="match_parent"
         android:layout_gravity="end"/>
 
-</android.support.v4.widget.DrawerLayout>
+</me.ccrama.redditslide.Views.SidebarLayout>

--- a/app/src/main/res/layout/activity_singlesubreddit.xml
+++ b/app/src/main/res/layout/activity_singlesubreddit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<me.ccrama.redditslide.Views.SidebarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -68,4 +69,4 @@
         android:layout_width="300dp"
         android:layout_height="match_parent"
         android:layout_gravity="end" />
-</android.support.v4.widget.DrawerLayout>
+</me.ccrama.redditslide.Views.SidebarLayout>

--- a/app/src/main/res/layout/subinfo.xml
+++ b/app/src/main/res/layout/subinfo.xml
@@ -2,6 +2,7 @@
 
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/sidebar_scroll"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/card_background">


### PR DESCRIPTION
The DrawerLayout captures the close swipe action before it is propagated to its children. Overriding DrawerLayout.onInterceptTouchEvent allows the sidebar to check if the event coordinates hits a scrollable view, and stops the SidebarLayout from capturing the event if it does.

Fixes #1036.