### PR TITLE
Cancel loading when swiping through multireddits

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditPosts.java
@@ -33,7 +33,7 @@ public class MultiredditPosts implements PostLoader {
     private MultiReddit multiReddit;
     public boolean nomore = false;
     public MultiredditAdapter adapter;
-
+    private LoadData loadData;
     public boolean skipOne;
     /**
      *
@@ -52,13 +52,22 @@ public class MultiredditPosts implements PostLoader {
     public void loadMore(Context context, SubmissionDisplay displayer, boolean reset) {
         new LoadData(context, displayer, reset).execute(multiReddit);
     }
+
     public void loadMore(Context context, SubmissionDisplay displayer, boolean reset, MultiredditAdapter adapter) {
         this.adapter = adapter;
-        new LoadData(context, displayer, reset).execute(multiReddit);
+        loadData = new LoadData(context, displayer, reset);
+        loadData.execute(multiReddit);
     }
+
     @Override
     public List<Submission> getPosts() {
         return posts;
+    }
+
+    public void cancelLoad() {
+        if (loadData != null) {
+            loadData.cancel(true);
+        }
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -280,6 +280,12 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
     }
 
     @Override
+    public void onPause() {
+        super.onPause();
+        posts.cancelLoad();
+    }
+
+    @Override
     public void onConfigurationChanged(Configuration newConfig) {
 
         super.onConfigurationChanged(newConfig);


### PR DESCRIPTION
Fixes an issue where if you swipe through a number of multireddits
it can take a while to load the submissions for the final multireddit,
since the submissions for all of the other multireddits are being
loaded first.