### PR TITLE
Add support for custom sub emotes to display inline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,10 +85,6 @@ dependencies {
     compile 'com.android.support:multidex:1.0.1'
     compile 'org.jsoup:jsoup:1.8.3'
     compile 'it.sephiroth.android.library.targettooltip:target-tooltip-library:+'
-    compile 'com.github.NightWhistler:HtmlSpanner:0.4'
-    //Resolves test and main app version conflict
-    compile 'org.apache.ant:ant-launcher:1.8.0'
-    compile 'org.apache.ant:ant:1.8.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,10 @@ dependencies {
     compile 'com.android.support:multidex:1.0.1'
     compile 'org.jsoup:jsoup:1.8.3'
     compile 'it.sephiroth.android.library.targettooltip:target-tooltip-library:+'
+    compile 'com.github.NightWhistler:HtmlSpanner:0.4'
+    //Resolves test and main app version conflict
+    compile 'org.apache.ant:ant-launcher:1.8.0'
+    compile 'org.apache.ant:ant:1.8.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip


### PR DESCRIPTION
Some subs, like /r/mylittlepony, have custom emotes they use inside comments and posts. An Android app was made to sync these large collections offline and some apps, like Relay for Reddit, read them to display in app. This just brings this functionality to Slide for Reddit.

p.s. at some point, SpoilerRobotoTextView should be renamed to match the fact it's the text renderer for most the app.