### PR TITLE
Fixed visibility of smaller content tag on lightly colored backgrounds

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Views/TransparentTagTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/TransparentTagTextView.java
@@ -6,7 +6,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
-import android.graphics.PorterDuffXfermode;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
@@ -41,7 +40,6 @@ public class TransparentTagTextView extends TextView {
     public void init(Context context) {
         mSetBoundsOnSizeAvailable = true;
         mPaint = new Paint();
-        mPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
         super.setTextColor(Color.BLACK);
         super.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         setBackgroundDrawable(context.getResources().getDrawable(R.drawable.flairback));
@@ -51,7 +49,6 @@ public class TransparentTagTextView extends TextView {
     Drawable backdrop;
     public void resetBackground(Context context) {
         mPaint = new Paint();
-        mPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
         super.setTextColor(Color.BLACK);
         super.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         backdrop = context.getResources().getDrawable(R.drawable.flairback);


### PR DESCRIPTION
You couldn't even read the smaller content tags on white backgrounds--this fixes that so now you can read it on any color background.