### PR TITLE
Fixed some more ContentType tags

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -189,10 +189,7 @@ public class ContentType {
                 }
             } else {
                 //if the submission is NSFW
-                if (isImgurImage(url) || isImgurLink(url)) {
-                    return ImageType.NSFW_IMAGE;
-                }
-                if (isImage(url) && !url.contains("gif")) {
+                if ((isImage(url) && !url.contains("gif")) || isImgurLink(url) || isImgurImage(url)) {
                     return ImageType.NSFW_IMAGE;
                 } else if (isGif(url)) {
                     if (isDomain(url, "gfycat.com"))

--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -50,6 +50,17 @@ public class ContentType {
         }
     }
 
+    /**
+     * Returns whether or not the url in question is an Imgur image
+     * This method differs from isImgurLink() in the sense that the url only needs to contain
+     * "imgur" and not be a gif or album to return true
+     * @param url of submission content
+     * @return whether or not this is an Imgur image
+     */
+    private static boolean isImgurImage(String url) {
+        return (url.contains("imgur") && !isGif(url) && !isAlbum(url));
+    }
+
     public static String getFixedUrlThumb(String s2) {
         String s = s2;
         if (s == null || s.isEmpty()) {
@@ -111,26 +122,25 @@ public class ContentType {
             if (isDomain(url, "youtube.co") && !isDomain(url, "youtu.be") && s.getDataNode().has("media_embed") && s.getDataNode().get("media_embed").has("content") && !isAlbum(url) && !isImage(url) && !isGif(url)) {
                 return ImageType.EMBEDDED;
             }
-
             if (isAlbum(url)) {
                 return ImageType.ALBUM;
             }
-            if (isImgurLink(url)) {
-                if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
-                    url = url.substring(0, url.lastIndexOf("?"));
-                    return getImageType(url);
-                }
-                return ImageType.IMGUR;
-            }
             if (!s.isNsfw()) {
-
-
-
+                if (isImgurLink(url)) {
+                    if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
+                        url = url.substring(0, url.lastIndexOf("?"));
+                        return getImageType(url);
+                    }
+                    return ImageType.IMGUR;
+                }
 
                 switch (t) {
                     case DEFAULT:
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
+                        }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
                         }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
@@ -160,6 +170,9 @@ public class ContentType {
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
                         }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
+                        }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
                         } else if (isGif(url)) {
@@ -176,6 +189,9 @@ public class ContentType {
                 }
             } else {
                 //if the submission is NSFW
+                if (isImgurImage(url) || isImgurLink(url)) {
+                    return ImageType.NSFW_IMAGE;
+                }
                 if (isImage(url) && !url.contains("gif")) {
                     return ImageType.NSFW_IMAGE;
                 } else if (isGif(url)) {


### PR DESCRIPTION
NSFW Imgur links will now be labelled as "NSFW Image".

I created a new method `isImgurImage()` to check if it was in-fact an image from Imgur. This alternate method is needed as some Imgur images aren't tagged as `ImageType.IMGUR` because of the check that goes on in `isImgurLink()`; specifically, the `!isImage(url)`. This caused some Imgur images to not get tagged at all, despite being an Imgur image. If I edit the `isImgurLink()` method, then we have issues--hence, the new method.

Other posts of type URL weren't being properly tagged as Images either; this PR uses the new method into the `switch` statement for `URL` and `DEFAULT` types.

Of my testing, everything appeared to be correctly labeled, no wonkiness with double opening of images in the browser--it all just works.

If you want some good examples of the types of posts this fixes, head over to /r/BlackPeopleTwitter without this PR. I find that most posts there aren't tagged with anything.

Couple of sample URLS of content not tagged (this PR will properly tag these posts as "Imgur content"):
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c1fy6/bey_memes/
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c24sv/always_have_been_and_always_will_be_more_than/


