### PR TITLE
Fixed NSFW Imgur links not being tagged correctly; fixed missing tags

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -53,10 +53,12 @@ public class ContentType {
      * @return True if the URL encompasses the domain
      */
     public static Boolean isDomain(String url, String domain) {
+        if (!url.matches("\\w+://.*")) url = "https://" + url;
+
         try {
             URI uri = new URI(url);
             return uri.getHost().endsWith(domain);
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException|NullPointerException e) {
             return false;
         }
     }

--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -35,6 +35,17 @@ public class ContentType {
     }
 
     /**
+     * Returns whether or not the url in question is an Imgur image
+     * This method differs from isImgurLink() in the sense that the url needs to be an Imgur domain,
+     * and not a GIF or an album
+     * @param url of submission content
+     * @return whether or not this is an Imgur image
+     */
+    private static boolean isImgurImage(String url) {
+        return (isDomain(url, "imgur.com") && !isGif(url) && !isAlbum(url));
+    }
+
+    /**
      * Check if the provided URL encompasses the domain - e.g. https://i.imgur.com/
      *
      * @param url URL to check for the presence of a domain
@@ -115,22 +126,22 @@ public class ContentType {
             if (isAlbum(url)) {
                 return ImageType.ALBUM;
             }
-            if (isImgurLink(url)) {
-                if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
-                    url = url.substring(0, url.lastIndexOf("?"));
-                    return getImageType(url);
-                }
-                return ImageType.IMGUR;
-            }
             if (!s.isNsfw()) {
-
-
-
+                if (isImgurLink(url)) {
+                    if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
+                        url = url.substring(0, url.lastIndexOf("?"));
+                        return getImageType(url);
+                    }
+                    return ImageType.IMGUR;
+                }
 
                 switch (t) {
                     case DEFAULT:
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
+                        }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
                         }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
@@ -160,6 +171,9 @@ public class ContentType {
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
                         }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
+                        }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
                         } else if (isGif(url)) {
@@ -176,7 +190,7 @@ public class ContentType {
                 }
             } else {
                 //if the submission is NSFW
-                if (isImage(url) && !url.contains("gif")) {
+                if ((isImage(url) && !url.contains("gif")) || isImgurLink(url) || isImgurImage(url)) {
                     return ImageType.NSFW_IMAGE;
                 } else if (isGif(url)) {
                     if (isDomain(url, "gfycat.com"))

--- a/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
@@ -7,47 +7,65 @@ import me.ccrama.redditslide.ContentType.ImageType;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
 public class ContentTypeTest {
 
     @Test
-    public void testContentType_Album() {
+    public void checksDomains() {
+        assertTrue(ContentType.isDomain("https://i.imgur.com/33YIg0B", "imgur.com"));
+        assertFalse(ContentType.isDomain("http://example.com/#imgur.com", "imgur.com"));
+    }
+
+    @Test
+    public void detectsAlbum() {
         assertThat(ContentType.getImageType("http://www.imgur.com/a/duARTe"), is(ImageType.ALBUM));
         assertThat(ContentType.getImageType("https://imgur.com/gallery/DmXJ4"), is(ImageType.ALBUM));
     }
 
     @Test
-    public void testContentType_Gif() {
+    public void detectsGif() {
         assertThat(ContentType.getImageType("https://i.imgur.com/33YIg0B.gifv"), is(ImageType.GIF));
         assertThat(ContentType.getImageType("https://i.imgur.com/33YIg0B.gif"), is(ImageType.GIF));
         assertThat(ContentType.getImageType("https://i.imgur.com/33YIg0B.gifnot"), is(not(ImageType.GIF)));
     }
 
     @Test
-    public void testContentType_Gfy() {
+    public void detectsGfy() {
         assertThat(ContentType.getImageType("https://fat.gfycat.com/EcstaticLegitimateAnemone.webm"), is(ImageType.GFY));
         assertThat(ContentType.getImageType("https://thumbs.gfycat.com/EcstaticLegitimateAnemone-mobile.mp4"), is(ImageType.GFY));
     }
 
     @Test
-    public void testContentType_Image() {
+    public void detectsImage() {
         assertThat(ContentType.getImageType("https://i.imgur.com/FGtUo6c.jpg"), is(ImageType.IMAGE));
         assertThat(ContentType.getImageType("https://i.imgur.com/FGtUo6c.png"), is(ImageType.IMAGE));
+        assertThat(ContentType.getImageType("https://i.imgur.com/FGtUo6c.png?moo=1"), is(ImageType.IMAGE));
     }
 
     @Test
-    public void testContentType_Imgur() {
+    public void detectsImgur() {
         assertThat(ContentType.getImageType("https://i.imgur.com/33YIg0B"), is(ImageType.IMGUR));
     }
 
     @Test
-    public void testContentType_Reddit() {
+    public void detectsSpoiler() {
+        assertThat(ContentType.getImageType("/s"), is(ImageType.SPOILER));
+        assertThat(ContentType.getImageType("/sp"), is(ImageType.SPOILER));
+        assertThat(ContentType.getImageType("/spoiler"), is(ImageType.SPOILER));
+        assertThat(ContentType.getImageType("#s"), is(ImageType.SPOILER));
+    }
+
+    @Test
+    public void detectsReddit() {
         assertThat(ContentType.getImageType("https://www.reddit.com/r/todayilearned/comments/42wgbg/til_the_tshirt_was_invented_in_1904_and_marketed/"), is(ImageType.REDDIT));
         assertThat(ContentType.getImageType("https://www.reddit.com/42wgbg/"), is(ImageType.REDDIT));
         assertThat(ContentType.getImageType("https://www.reddit.com/r/live/"), is(ImageType.REDDIT));
         assertThat(ContentType.getImageType("redd.it/eorhm"), is(ImageType.REDDIT));
+        assertThat(ContentType.getImageType("/r/Android"), is(ImageType.REDDIT));
 
 
         assertThat(ContentType.getImageType("https://www.reddit.com/live/wbjbjba8zrl6"), is(not(ImageType.REDDIT)));
@@ -55,12 +73,17 @@ public class ContentTypeTest {
     }
 
     @Test
-    public void testContentType_Link() {
+    public void detectsStreamable() {
+        assertThat(ContentType.getImageType("https://streamable.com/l41f"), is(ImageType.STREAMABLE));
+    }
+
+    @Test
+    public void detectsLink() {
         assertThat(ContentType.getImageType("https://stackoverflow.com/"), is(ImageType.LINK));
     }
 
     @Test
-    public void testContentType_None() {
+    public void detectsNone() {
         assertThat(ContentType.getImageType(""), is(ImageType.NONE));
     }
 }

--- a/app/src/test/java/me/ccrama/redditslide/test/OpenRedditLinkTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/OpenRedditLinkTest.java
@@ -11,89 +11,107 @@ import static org.junit.Assert.assertThat;
 
 public class OpenRedditLinkTest {
 
-    //Less characters
-    private String shortUrl(String url) {
+    // Less characters
+    private String formatURL(String url) {
         return OpenRedditLink.formatRedditUrl(url);
     }
-
-    @Test
-    public void testLinkType_Shortened() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://redd.it/eorhm/")), is(RedditLinkType.SHORTENED));
+    private OpenRedditLink.RedditLinkType getType(String url) {
+        return OpenRedditLink.getRedditLinkType(url);
     }
 
     @Test
-    public void testLinkType_Wiki() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://www.reddit.com/r/Android/wiki/index")), is(RedditLinkType.WIKI));
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://ww.reddit.com/r/Android/help")), is(RedditLinkType.WIKI));
+    public void detectsShortened() {
+        assertThat(getType(formatURL("https://redd.it/eorhm/")), is(RedditLinkType.SHORTENED));
     }
 
     @Test
-    public void testLinkType_Comment() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                        shortUrl("https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/c19qk6j")),
+    public void detectsWiki() {
+        assertThat(getType(formatURL("https://www.reddit.com/r/Android/wiki/index")), is(RedditLinkType.WIKI));
+        assertThat(getType(formatURL("https://www.reddit.com/r/Android/help")), is(RedditLinkType.WIKI));
+        assertThat(getType(formatURL("https://reddit.com/help")), is(RedditLinkType.WIKI));
+    }
+
+    @Test
+    public void detectsComment() {
+        assertThat(getType(formatURL("https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/c19qk6j")),
+                is(RedditLinkType.COMMENT_PERMALINK));
+        assertThat(getType(formatURL("https://www.reddit.com/r/announcements/comments/eorhm//c19qk6j")),
                 is(RedditLinkType.COMMENT_PERMALINK));
     }
 
     @Test
-    public void testLinkType_Submission() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                        shortUrl("https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/")),
+    public void detectsSubmission() {
+        assertThat(getType(formatURL("https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/")),
                 is(RedditLinkType.SUBMISSION));
     }
 
     @Test
-    public void testLinkType_SubmissionWithoutSub() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                        shortUrl("https://www.reddit.com/comments/eorhm/reddit_30_less_typing/")),
+    public void detectsSubmissionWithoutSub() {
+        assertThat(getType(formatURL("https://www.reddit.com/comments/eorhm/reddit_30_less_typing/")),
                 is(RedditLinkType.SUBMISSION_WITHOUT_SUB));
     }
 
     @Test
-    public void testLinkType_Subreddit() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://www.reddit.com/r/android")), is(RedditLinkType.SUBREDDIT));
+    public void detectsSubreddit() {
+        assertThat(getType(formatURL("https://www.reddit.com/r/android")), is(RedditLinkType.SUBREDDIT));
     }
 
     @Test
-    public void testLinkType_User() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://www.reddit.com/u/l3d00m")), is(RedditLinkType.USER));
+    public void detectsSearch() {
+//        assertThat(getType(formatURL("https://www.reddit.com/search?q=test")),
+//                is(RedditLinkType.SEARCH));
+        assertThat(getType(formatURL("https://www.reddit.com/r/Android/search?q=test&restrict_sr=on&sort=relevance&t=all")),
+                is(RedditLinkType.SEARCH));
     }
 
     @Test
-    public void testLinkType_Other() {
-        assertThat(OpenRedditLink.getRedditLinkType(
-                shortUrl("https://www.reddit.com/live/wbjbjba8zrl6")), is(RedditLinkType.OTHER));
-    }
-
-
-    @Test
-    public void testUrlFormatter_Basic() {
-        assertThat(shortUrl("https://www.reddit.com/live/wbjbjba8zrl6"), is("reddit.com/live/wbjbjba8zrl6"));
+    public void detectsUser() {
+        assertThat(getType(formatURL("https://www.reddit.com/u/l3d00m")), is(RedditLinkType.USER));
     }
 
     @Test
-    public void testUrlFormatter_Np() {
-        assertThat(shortUrl("https://np.reddit.com/live/wbjbjba8zrl6"), is("npreddit.com/live/wbjbjba8zrl6"));
+    public void detectsOther() {
+        assertThat(getType(formatURL("https://www.reddit.com/live/wbjbjba8zrl6")), is(RedditLinkType.OTHER));
     }
 
     @Test
-    public void testUrlFormatter_Prefix() {
-        assertThat(shortUrl("https://blog.reddit.com/"), is(""));
+    public void formatsBasic() {
+        assertThat(formatURL("https://www.reddit.com/live/wbjbjba8zrl6"), is("reddit.com/live/wbjbjba8zrl6"));
     }
 
     @Test
-    public void testUrlFormatter_Subreddit() {
-        assertThat(shortUrl("/r/android"), is("reddit.com/r/android"));
+    public void formatsNp() {
+        assertThat(formatURL("https://np.reddit.com/live/wbjbjba8zrl6"), is("npreddit.com/live/wbjbjba8zrl6"));
     }
 
     @Test
-    public void testURLFormatter_Wiki() {
-        assertThat(shortUrl("https://reddit.com/help"), is("reddit.com/r/reddit.com/wiki"));
-        assertThat(shortUrl("https://reddit.com/help/registration"), is("reddit.com/r/reddit.com/wiki/registration"));
-        assertThat(shortUrl("https://www.reddit.com/r/android/wiki/index"), is("reddit.com/r/android/wiki/index"));
+    public void formatsSubdomains() {
+        assertThat(formatURL("https://beta.reddit.com/"), is(""));
+        assertThat(formatURL("https://blog.reddit.com/"), is(""));
+        assertThat(formatURL("https://code.reddit.com/"), is(""));
+        assertThat(formatURL("https://store.reddit.com/"), is(""));
+        assertThat(formatURL("https://pay.reddit.com/"), is("reddit.com"));
+        assertThat(formatURL("https://ssl.reddit.com/"), is("reddit.com"));
+        assertThat(formatURL("https://en-gb.reddit.com/"), is("reddit.com"));
+        assertThat(formatURL("https://us.reddit.com/"), is("reddit.com"));
+    }
+
+    @Test
+    public void formatsSubreddit() {
+        assertThat(formatURL("/r/android"), is("reddit.com/r/android"));
+        assertThat(formatURL("https://android.reddit.com"), is("reddit.com/r/android"));
+    }
+
+    @Test
+    public void formatsWiki() {
+        assertThat(formatURL("https://reddit.com/help"), is("reddit.com/r/reddit.com/wiki"));
+        assertThat(formatURL("https://reddit.com/help/registration"), is("reddit.com/r/reddit.com/wiki/registration"));
+        assertThat(formatURL("https://www.reddit.com/r/android/wiki/index"), is("reddit.com/r/android/wiki/index"));
+    }
+
+    @Test
+    public void formatsProtocol() {
+        assertThat(formatURL("http://reddit.com"), is("reddit.com"));
+        assertThat(formatURL("https://reddit.com"), is("reddit.com"));
     }
 }


### PR DESCRIPTION
NSFW Imgur links will now be labelled as "NSFW Image".

I created a new method `isImgurImage()` to check if it was in-fact an image from Imgur. This alternate method is needed as some Imgur images aren't tagged as `ImageType.IMGUR` because of the check that goes on in `isImgurLink()`; specifically, the `!isImage(url)`. This caused some Imgur images to not get tagged at all, despite being an Imgur image. If I edit the `isImgurLink()` method, then we have issues--hence, the new method.

Other posts of type URL weren't being properly tagged as Images either; this PR uses the new method into the `switch` statement for `URL` and `DEFAULT` types.

Of my testing, everything appeared to be correctly labeled, no wonkiness with double opening of images in the browser--it all just works.

If you want some good examples of the types of posts this fixes, head over to /r/BlackPeopleTwitter without this PR. I find that most posts there aren't tagged with anything.

Couple of sample URLS of content not tagged (this PR will properly tag these posts as "Imgur content"):
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c1fy6/bey_memes/
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c24sv/always_have_been_and_always_will_be_more_than/