### PR TITLE
Correct offset for pull-to-refresh in SubmissionsView--hacky

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -242,8 +242,13 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         mSwipeRefreshLayout = (SwipeRefreshLayout) v.findViewById(R.id.activity_main_swipe_refresh_layout);
         mSwipeRefreshLayout.setColorSchemeColors(Palette.getColors(id, getContext()));
 
-        mSwipeRefreshLayout.setProgressViewOffset(false, Reddit.pxToDp(104, getContext()), Reddit.pxToDp(140, getContext()));
-
+        int headerHeight = getActivity().findViewById(R.id.header).getMeasuredHeight();
+        if (headerHeight == 0) {
+            headerHeight = 334; //default is rather large height to compensate for a header with tabs
+        }
+        mSwipeRefreshLayout.setProgressViewOffset(false,
+                headerHeight - Reddit.pxToDp(42, getContext()),
+                headerHeight + Reddit.pxToDp(42, getContext()));
 
         if (SettingValues.fab) {
             fab = (FloatingActionButton) v.findViewById(R.id.post_floating_action_button);


### PR DESCRIPTION
In my opinion, this seems hacky.

If you launch the app with a clean start--`getActivity().findViewById(R.id.header).getMeasuredHeight()` will return 0. However, once you're in the app and you navigate to another tab or single subreddit, then the height will be reported correctly until you enter a cold start again.

To curtail the returned 0, I set the `headerHeight` to default to `334`--after testing it on a Nexus 4, Pixel C, and Nexus 6P--this seems like a good middle ground to default to.

Furthermore, `mSwipeRefreshLayout.getProgressCircleDiameter()` will always return 0 no matter what; no idea why; instead, I just used `42` as the offset height from the `headerHeight`--which seems to look nice.

This is only for the `SubmissionsView`; I wanted to see what you had to say about it before carrying on with the remainder of the layouts.