### PR TITLE
Fixed NSFW Imgur links not being tagged correctly; fixed missing tags

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -35,6 +35,17 @@ public class ContentType {
     }
 
     /**
+     * Returns whether or not the url in question is an Imgur image
+     * This method differs from isImgurLink() in the sense that the url needs to be an Imgur domain,
+     * and not a GIF or an album
+     * @param url of submission content
+     * @return whether or not this is an Imgur image
+     */
+    private static boolean isImgurImage(String url) {
+        return (isDomain(url, "imgur.com") && !isGif(url) && !isAlbum(url));
+    }
+
+    /**
      * Check if the provided URL encompasses the domain - e.g. https://i.imgur.com/
      *
      * @param url URL to check for the presence of a domain
@@ -117,22 +128,22 @@ public class ContentType {
             if (isAlbum(url)) {
                 return ImageType.ALBUM;
             }
-            if (isImgurLink(url)) {
-                if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
-                    url = url.substring(0, url.lastIndexOf("?"));
-                    return getImageType(url);
-                }
-                return ImageType.IMGUR;
-            }
             if (!s.isNsfw()) {
-
-
-
+                if (isImgurLink(url)) {
+                    if (url.contains("?") && (url.contains(".png") || url.contains(".gif") || url.contains(".jpg"))) {
+                        url = url.substring(0, url.lastIndexOf("?"));
+                        return getImageType(url);
+                    }
+                    return ImageType.IMGUR;
+                }
 
                 switch (t) {
                     case DEFAULT:
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
+                        }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
                         }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
@@ -162,6 +173,9 @@ public class ContentType {
                         if (isAlbum(url)) {
                             return ImageType.ALBUM;
                         }
+                        if (isImgurImage(url)) {
+                            return ImageType.IMGUR;
+                        }
                         if (isImage(url) && !url.contains("gif")) {
                             return ImageType.IMAGE;
                         } else if (isGif(url)) {
@@ -178,7 +192,7 @@ public class ContentType {
                 }
             } else {
                 //if the submission is NSFW
-                if (isImage(url) && !url.contains("gif")) {
+                if ((isImage(url) && !url.contains("gif")) || isImgurLink(url) || isImgurImage(url)) {
                     return ImageType.NSFW_IMAGE;
                 } else if (isGif(url)) {
                     if (isDomain(url, "gfycat.com"))


### PR DESCRIPTION
NSFW Imgur links will now be labelled as "NSFW Image".

I created a new method `isImgurImage()` to check if it was in-fact an image from Imgur. This alternate method is needed as some Imgur images aren't tagged as `ImageType.IMGUR` because of the check that goes on in `isImgurLink()`; specifically, the `!isImage(url)`. This caused some Imgur images to not get tagged at all, despite being an Imgur image. If I edit the `isImgurLink()` method, then we have issues--hence, the new method.

Other posts of type URL weren't being properly tagged as Images either; this PR uses the new method into the `switch` statement for `URL` and `DEFAULT` types.

Of my testing, everything appeared to be correctly labeled, no wonkiness with double opening of images in the browser--it all just works.

If you want some good examples of the types of posts this fixes, head over to /r/BlackPeopleTwitter without this PR. I find that most posts there aren't tagged with anything.

Couple of sample URLS of content not tagged (this PR will properly tag these posts as "Imgur content"):
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c1fy6/bey_memes/
* https://www.reddit.com/r/BlackPeopleTwitter/comments/4c24sv/always_have_been_and_always_will_be_more_than/