### PR TITLE
Collapse parent comments regardless of settings

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -726,10 +726,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (hiddenPersons.contains(comment.getFullName())) {
                 holder.children.setVisibility(View.VISIBLE);
                 holder.childrenNumber.setText("+" + getChildNumber(baseNode));
-                if (SettingValues.collapseComments) {
-                    holder.firstTextView.setVisibility(View.GONE);
-                    holder.commentOverflow.setVisibility(View.GONE);
-                }
             } else {
                 holder.children.setVisibility(View.GONE);
                 holder.firstTextView.setVisibility(View.VISIBLE);

--- a/app/src/main/res/menu/menu_comment_items.xml
+++ b/app/src/main/res/menu/menu_comment_items.xml
@@ -26,7 +26,7 @@
 
     <item
         android:id="@+id/collapse"
-        android:title="@string/btn_collapse_parent_all"
+        android:title="@string/btn_collapse_children_all"
         app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/menu/menu_comment_items.xml
+++ b/app/src/main/res/menu/menu_comment_items.xml
@@ -26,7 +26,7 @@
 
     <item
         android:id="@+id/collapse"
-        android:title="@string/btn_collapse_all"
+        android:title="@string/btn_collapse_parent_all"
         app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -535,7 +535,7 @@
   <string name="view_type_tabs">Subreddit tabs</string>
   <string name="view_type_none">No subreddit tabs</string>
   <string name="view_type_comments">Comment pane</string>
-  <string name="btn_collapse_all">Collapse comments</string>
+  <string name="btn_collapse_parent_all">Collapse comments</string>
   <string name="btn_open_content">Open content</string>
   <string name="btn_report">Report</string>
   <string name="input_reason_for_report">Reason for reporting</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -535,7 +535,7 @@
   <string name="view_type_tabs">Subreddit tabs</string>
   <string name="view_type_none">No subreddit tabs</string>
   <string name="view_type_comments">Comment pane</string>
-  <string name="btn_collapse_parent_all">Collapse comments</string>
+  <string name="btn_collapse_children_all">Collapse comments</string>
   <string name="btn_open_content">Open content</string>
   <string name="btn_report">Report</string>
   <string name="input_reason_for_report">Reason for reporting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -611,7 +611,7 @@
     <string name="view_type_tabs">Subreddit tabs</string>
     <string name="view_type_none">No subreddit tabs</string>
     <string name="view_type_comments">Comment pane</string>
-    <string name="btn_collapse_parent_all">Collapse parent comments</string>
+    <string name="btn_collapse_children_all">Collapse children comments</string>
     <string name="btn_open_content">Open content</string>
     <string name="btn_report">Report</string>
     <string name="input_reason_for_report">Reason for reporting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -611,7 +611,7 @@
     <string name="view_type_tabs">Subreddit tabs</string>
     <string name="view_type_none">No subreddit tabs</string>
     <string name="view_type_comments">Comment pane</string>
-    <string name="btn_collapse_all">Collapse comments</string>
+    <string name="btn_collapse_parent_all">Collapse parent comments</string>
     <string name="btn_open_content">Open content</string>
     <string name="btn_report">Report</string>
     <string name="input_reason_for_report">Reason for reporting</string>


### PR DESCRIPTION
When the user is viewing comments and presses the "Collapse Comments" menu overflow item, it would take into account if the user had "Fully collapse comments" enabled. I find this useless when trying to collapse all comments, as the user is probably trying to hide all children comments.

This renames the overflow item action to "Collapse children comments" and does so regardless of the value of `SettingValues.collapseComments`.

In my testing--I couldn't find any issues with this approach. Everything seems to work properly. 

PS: I gave an incorrect description to my commit--I meant to say "children comments".