### PR TITLE
IMPORTANT - Fix not being able to open comment menu

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -1421,7 +1421,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
         // If a comment is hidden and (Swap long press == true), then a single click will un-hide the comment
         // and expand to show all children comments
-        if (SettingValues.swap) {
+        if (SettingValues.swap && holder.firstTextView.getVisibility() == View.GONE) {
             unhideAll(baseNode, holder.getAdapterPosition() + 1);
             hiddenPersons.remove(n.getFullName());
             hideChildrenObject(holder.children);


### PR DESCRIPTION
If the user has `SettingValues.swap == true`, because of my last PR, it's now impossible to tap on a comment to open the comment menu.

I'm so sorry that happened. -_-