### PR TITLE
Remove minHeight from Toolbar instances in layouts

### DIFF
--- a/app/src/main/res/layout/activity_createmulti.xml
+++ b/app/src/main/res/layout/activity_createmulti.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
         android:clipToPadding="false"
-        android:minHeight="56dp"
         android:paddingRight="16dp"
         android:theme="@style/Theme.AppCompat"
         app:layout_scrollFlags="scroll|enterAlways"

--- a/app/src/main/res/layout/activity_donate.xml
+++ b/app/src/main/res/layout/activity_donate.xml
@@ -16,7 +16,6 @@
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="56dp"
             android:background="@color/md_light_green_500"
 
             android:theme="@style/Theme.AppCompat">

--- a/app/src/main/res/layout/activity_filtercomments.xml
+++ b/app/src/main/res/layout/activity_filtercomments.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:background="?attr/card_background"
         android:clipToPadding="false"
-        android:minHeight="56dp"
         android:paddingRight="16dp"
         app:layout_scrollFlags="scroll|enterAlways"
 

--- a/app/src/main/res/layout/activity_fragmentinner.xml
+++ b/app/src/main/res/layout/activity_fragmentinner.xml
@@ -33,7 +33,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#00000000"
-            android:minHeight="56dp"
             android:theme="@style/ActionBarCompat" />
 
 

--- a/app/src/main/res/layout/activity_inbox.xml
+++ b/app/src/main/res/layout/activity_inbox.xml
@@ -32,8 +32,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#00000000"
-            android:clipToPadding="false"
-            android:minHeight="56dp">
+            android:clipToPadding="false">
             <ImageView
                 android:id="@+id/compose"
                 android:layout_width="48dp"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:background="@color/dblue"
         android:clipToPadding="false"
-        android:minHeight="56dp"
         android:paddingRight="16dp"
         android:theme="@style/Theme.AppCompat">
 

--- a/app/src/main/res/layout/activity_multireddits.xml
+++ b/app/src/main/res/layout/activity_multireddits.xml
@@ -35,8 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#00000000"
-            android:clipToPadding="false"
-            android:minHeight="56dp" />
+            android:clipToPadding="false"/>
 
         <android.support.design.widget.TabLayout
             android:id="@+id/sliding_tabs"

--- a/app/src/main/res/layout/activity_overview.xml
+++ b/app/src/main/res/layout/activity_overview.xml
@@ -31,7 +31,6 @@
             <android.support.v7.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:minHeight="56dp"
                 android:layout_height="?android:attr/actionBarSize"
                 android:theme="@style/ActionBarCompat"
                 android:title="@string/app_name" />

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -35,8 +35,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#00000000"
-            android:minHeight="56dp">
+            android:background="#00000000">
 
             <ImageView
                 android:id="@+id/info"

--- a/app/src/main/res/layout/activity_saved.xml
+++ b/app/src/main/res/layout/activity_saved.xml
@@ -23,7 +23,6 @@
                     android:layout_height="wrap_content"
                     android:background="#00000000"
                     android:clipToPadding="false"
-                    android:minHeight="56dp"
                     app:layout_scrollFlags="scroll|enterAlways">
                 </android.support.v7.widget.Toolbar>
 

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:background="?attr/card_background"
         android:clipToPadding="false"
-        android:minHeight="56dp"
         android:paddingRight="16dp"
         app:layout_scrollFlags="scroll|enterAlways">
 

--- a/app/src/main/res/layout/activity_sendmessage.xml
+++ b/app/src/main/res/layout/activity_sendmessage.xml
@@ -14,7 +14,6 @@
         android:background="@color/md_amber_500"
         android:clipToPadding="false"
         android:elevation="5dp"
-        android:minHeight="60dp"
         android:paddingRight="16dp"
         android:title="@string/editor_submit"
         android:theme="@style/Theme.AppCompat"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat"
         app:layout_scrollFlags="scroll|enterAlways">
 

--- a/app/src/main/res/layout/activity_settings_about.xml
+++ b/app/src/main/res/layout/activity_settings_about.xml
@@ -17,7 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat">
         </android.support.v7.widget.Toolbar>
 

--- a/app/src/main/res/layout/activity_settings_comments.xml
+++ b/app/src/main/res/layout/activity_settings_comments.xml
@@ -10,7 +10,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat">
     </android.support.v7.widget.Toolbar>
 

--- a/app/src/main/res/layout/activity_settings_datasaving.xml
+++ b/app/src/main/res/layout/activity_settings_datasaving.xml
@@ -14,7 +14,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat"/>
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_settings_filters.xml
+++ b/app/src/main/res/layout/activity_settings_filters.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat" />
 
     <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/activity_settings_font.xml
+++ b/app/src/main/res/layout/activity_settings_font.xml
@@ -17,8 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:theme="@style/Theme.AppCompat"
-            android:minHeight="56dp"/>
+            android:theme="@style/Theme.AppCompat"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings_general.xml
+++ b/app/src/main/res/layout/activity_settings_general.xml
@@ -14,8 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/Theme.AppCompat"
-            android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"/>
+            android:background="@color/md_light_blue_500"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings_handling.xml
+++ b/app/src/main/res/layout/activity_settings_handling.xml
@@ -14,8 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:theme="@style/Theme.AppCompat"
-            android:minHeight="56dp"/>
+            android:theme="@style/Theme.AppCompat"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings_history.xml
+++ b/app/src/main/res/layout/activity_settings_history.xml
@@ -14,7 +14,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat" />
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_settings_openexternal.xml
+++ b/app/src/main/res/layout/activity_settings_openexternal.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat" />
 
     <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/activity_settings_reddit.xml
+++ b/app/src/main/res/layout/activity_settings_reddit.xml
@@ -15,7 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat" />
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_settings_subreddit.xml
+++ b/app/src/main/res/layout/activity_settings_subreddit.xml
@@ -15,7 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_light_blue_500"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat">
 
             <ImageView

--- a/app/src/main/res/layout/activity_settings_synccit.xml
+++ b/app/src/main/res/layout/activity_settings_synccit.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat" />
 
     <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/activity_settings_theme.xml
+++ b/app/src/main/res/layout/activity_settings_theme.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat" />
 
     <ScrollView

--- a/app/src/main/res/layout/activity_settings_theme_card.xml
+++ b/app/src/main/res/layout/activity_settings_theme_card.xml
@@ -10,7 +10,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat">
 
         <TextView

--- a/app/src/main/res/layout/activity_singlesubreddit.xml
+++ b/app/src/main/res/layout/activity_singlesubreddit.xml
@@ -42,8 +42,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="#00000000"
-                android:theme="@style/ActionBarCompat"
-                android:minHeight="56dp" />
+                android:theme="@style/ActionBarCompat" />
 
 
         </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/layout/activity_slidetabs.xml
+++ b/app/src/main/res/layout/activity_slidetabs.xml
@@ -30,7 +30,6 @@
                 android:layout_height="wrap_content"
                 android:background="#00000000"
                 android:clipToPadding="false"
-                android:minHeight="56dp"
                 android:paddingRight="16dp"
                 app:layout_scrollFlags="scroll|enterAlways"
 

--- a/app/src/main/res/layout/activity_sort.xml
+++ b/app/src/main/res/layout/activity_sort.xml
@@ -12,8 +12,6 @@
         android:layout_height="wrap_content"
         android:background="?attr/tint"
         android:clipToPadding="false"
-        android:minHeight="56dp"
-
         android:theme="@style/Theme.AppCompat"
         app:layout_scrollFlags="scroll|enterAlways">
 
@@ -57,8 +55,6 @@
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
         android:clipToPadding="false"
-        android:minHeight="56dp"
-
         android:paddingRight="16dp"
         android:theme="@style/Theme.AppCompat"
         app:layout_scrollFlags="scroll|enterAlways"

--- a/app/src/main/res/layout/activity_submit.xml
+++ b/app/src/main/res/layout/activity_submit.xml
@@ -14,7 +14,6 @@
         android:background="@color/md_amber_500"
         android:clipToPadding="false"
         android:elevation="5dp"
-        android:minHeight="60dp"
         android:paddingRight="16dp"
         android:theme="@style/Theme.AppCompat"
         android:title="@string/editor_submit"

--- a/app/src/main/res/layout/activity_web.xml
+++ b/app/src/main/res/layout/activity_web.xml
@@ -19,7 +19,6 @@
             android:layout_height="56dp"
             android:clipToPadding="false"
             android:elevation="5dp"
-            android:minHeight="56dp"
             android:theme="@style/Theme.AppCompat"
             app:layout_scrollFlags="scroll|enterAlways">
 

--- a/app/src/main/res/layout/album.xml
+++ b/app/src/main/res/layout/album.xml
@@ -26,7 +26,6 @@
         android:background="#00000000"
         android:clipToPadding="false"
         android:elevation="5dp"
-        android:minHeight="60dp"
         android:theme="@style/Theme.AppCompat"
 
         >

--- a/app/src/main/res/layout/album_pager.xml
+++ b/app/src/main/res/layout/album_pager.xml
@@ -17,7 +17,6 @@
         android:layout_height="wrap_content"
         android:background="#aa000000"
         android:clipToPadding="false"
-        android:minHeight="60dp"
         android:theme="@style/Theme.AppCompat">
         <ImageView
             android:id="@+id/grid"

--- a/app/src/main/res/layout/fragment_tutorial_setup.xml
+++ b/app/src/main/res/layout/fragment_tutorial_setup.xml
@@ -13,7 +13,6 @@
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
         android:clipToPadding="false"
-        android:minHeight="56dp"
         android:paddingRight="16dp"
         android:theme="@style/Theme.AppCompat"
 

--- a/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
+++ b/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
@@ -35,8 +35,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clipToPadding="false"
-            android:minHeight="56dp" />
+            android:clipToPadding="false" />
 
         <TextView
             android:id="@+id/np"

--- a/app/src/noGPlay/res/layout/activity_settings_sync.xml
+++ b/app/src/noGPlay/res/layout/activity_settings_sync.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat"/>
 
     <ScrollView

--- a/app/src/withGPlay/res/layout/activity_settings_sync.xml
+++ b/app/src/withGPlay/res/layout/activity_settings_sync.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/md_light_blue_500"
-        android:minHeight="56dp"
         android:theme="@style/Theme.AppCompat"/>
 
     <ScrollView


### PR DESCRIPTION
This minHeight attribute was causing the toolbar to appear larger than necessary on some of my devices and causing the nav, up, and icons to appear above center.  My guess is this is used to serve some purpose but maybe isn't needed anymore?  If not, let me know.