### PR TITLE
Collapse comments when long pressing on a highlighted comment

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -2035,6 +2035,11 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
     public void doOnClick(CommentViewHolder holder, Comment comment, CommentNode baseNode) {
         if (currentSelectedItem.contains(comment.getFullName())) {
+            if (SettingValues.swap) {
+                //If the comment is highlighted and the user is long pressing the comment,
+                //hide the comment.
+                doOnClick(holder, baseNode, comment);
+            }
             doUnHighlighted(holder, comment, baseNode);
         } else {
             doOnClick(holder, baseNode, comment);


### PR DESCRIPTION
If the user has `SettingValues.swap` enabled, and they've highlighted a comment (i.e. single click), and then they long press the comment--it should collapse, not just hide the menu.