### PR TITLE
Prevent a webpage to keep running (with sound) in the background when custom tab is closed

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/util/CustomTabUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/CustomTabUtil.java
@@ -57,7 +57,9 @@ public class CustomTabUtil {
                 CustomTabsIntent customTabsIntent = builder.build();
 
                 customTabsIntent.intent.setPackage(packageName);
+                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                 customTabsIntent.launchUrl(contextActivity, Uri.parse(url));
+
             } catch (ActivityNotFoundException anfe) {
                 Log.w(LogUtil.getTag(), "Unknown url: " + anfe);
                 Reddit.defaultShare(url, contextActivity);


### PR DESCRIPTION
Set FLAG_ACTIVITY_NO_HISTORY on the Chrome CustomTab Intent prior to launch. This prevents the webpage to keep running when the Activity is moved to the background.

Sorry for not submitting a bug report prior to making this PR, I really wanted to tackle this issue myself to get started :smile: 