### PR TITLE
Made overflow Refresh action consistent

### DIFF
--- a/app/src/main/res/menu/menu_comment_items.xml
+++ b/app/src/main/res/menu/menu_comment_items.xml
@@ -2,6 +2,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".SubredditOverview">
+
     <item
         android:id="@+id/search"
         android:icon="@drawable/search"
@@ -13,15 +14,17 @@
         android:icon="@drawable/sort"
         android:title="@string/sorting_change_sorting"
         app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/content"
-        android:icon="@drawable/link"
-        android:title="@string/btn_open_content"
-        app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/reload"
         android:icon="@drawable/ic_refresh"
         android:title="@string/btn_refresh"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/content"
+        android:icon="@drawable/link"
+        android:title="@string/btn_open_content"
         app:showAsAction="ifRoom" />
 
     <item


### PR DESCRIPTION
In `SubmissionsView`--the refresh action is at the top of the overflow menu; in comments, it wasn't. This will keep refresh at the same position between those two views.