### PR TITLE
Change "pts" to color of vote on comments

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -729,12 +729,15 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             scoreColor = (holder.textColorRegular);
         }
 
-        if (score == null || score.toString().isEmpty()) score = new SpannableStringBuilder("0");
+        if (score == null || score.toString().isEmpty()) {
+            score = new SpannableStringBuilder("0");
+        }
+        if (!scoreText.contains("[")) {
+            score.append(mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
+        }
         score.setSpan(new ForegroundColorSpan(scoreColor), 0, score.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
         titleString.append(score);
-        if (!scoreText.contains("["))
-            titleString.append(mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
         titleString.append((comment.isControversial() ? "†" : ""));
 
         titleString.append(spacer);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -733,7 +733,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             score = new SpannableStringBuilder("0");
         }
         if (!scoreText.contains("[")) {
-            score.append(mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
+            score.append(" " + mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
         }
         score.setSpan(new ForegroundColorSpan(scoreColor), 0, score.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 


### PR DESCRIPTION
On a comment, the vote count is like: "22pts". Currently, if I upvote a comment, the "22" will become orange--but the "pts" won't. This makes it so the entire score span's color is reflected by the vote.