### PR TITLE
Improved Settings organization

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
@@ -98,25 +98,28 @@ public class SettingsFont extends BaseActivityAnim {
         ((RobotoRadioButton) findViewById(R.id.ccond)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setCommentFont(FontPreferences.FontTypeComment.Condensed);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.cslab)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setCommentFont(FontPreferences.FontTypeComment.Slab);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.creg)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setCommentFont(FontPreferences.FontTypeComment.Regular);
+                }
             }
         });
 
@@ -152,51 +155,56 @@ public class SettingsFont extends BaseActivityAnim {
         ((RobotoRadioButton) findViewById(R.id.scond)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.CondensedReg);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sslab)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.SlabReg);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.scondl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Condensed);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sslabl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Slab);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sreg)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Regular);
+                }
             }
         });
         ((RobotoRadioButton) findViewById(R.id.sregl)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked)
-
+                if (isChecked) {
+                    SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Light);
+                }
             }
         });
-
     }
-
-
 }

--- a/app/src/main/res/layout/activity_settings_comments.xml
+++ b/app/src/main/res/layout/activity_settings_comments.xml
@@ -17,6 +17,16 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/displayHeader"
+                android:text="@string/display"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -36,13 +46,13 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/settings_comments_swap_long"
+                        android:text="@string/settings_comment_crop"
                         android:textColor="?attr/font"
                         android:textSize="16sp" />
                 </LinearLayout>
 
                 <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/swapGesture"
+                    android:id="@+id/cropimage"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:background="?android:selectableItemBackground"
@@ -59,6 +69,139 @@
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginRight="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_comment_hide_selftext_image"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/selftextcomment"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
+            </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:background="?attr/tint"
+                android:alpha=".25"
+                android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginRight="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_comment_color"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/color"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
+            </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:background="?attr/tint"
+                android:alpha=".25"
+                android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginRight="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_fab_create"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/fab"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
+            </RelativeLayout>
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/navigationHeader"
+                android:text="@string/navigation"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -129,132 +272,6 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/settings_comment_crop"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/cropimage"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-            </RelativeLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:background="?android:selectableItemBackground"
-                android:paddingEnd="16dp"
-                android:paddingStart="16dp">
-
-                <LinearLayout
-                    android:layout_marginRight="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/settings_comment_hide_selftext_image"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/selftextcomment"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-            </RelativeLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:background="?android:selectableItemBackground"
-                android:paddingEnd="16dp"
-                android:paddingStart="16dp">
-
-                <LinearLayout
-                    android:layout_marginRight="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/settings_comment_color"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/color"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-            </RelativeLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:background="?android:selectableItemBackground"
-                android:paddingEnd="16dp"
-                android:paddingStart="16dp">
-
-                <LinearLayout
-                    android:layout_marginRight="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
                         android:text="@string/settings_volume_nav_comments"
                         android:textColor="?attr/font"
                         android:textSize="16sp" />
@@ -273,11 +290,59 @@
                     android:textColorHint="?attr/font" />
             </RelativeLayout>
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/collapseCommentsHeader"
+                android:text="@string/collapse_comments"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginRight="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_comments_swap_long"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/swapGesture"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
+            </RelativeLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -321,53 +386,13 @@
                     android:textColor="?attr/font"
                     android:textColorHint="?attr/font" />
             </RelativeLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:background="?android:selectableItemBackground"
-                android:paddingEnd="16dp"
-                android:paddingStart="16dp">
 
-                <LinearLayout
-                    android:layout_marginRight="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/settings_fab_create"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/fab"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-            </RelativeLayout>
-            <View
-                android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"

--- a/app/src/main/res/layout/activity_settings_general.xml
+++ b/app/src/main/res/layout/activity_settings_general.xml
@@ -16,6 +16,16 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/displayHeader"
+                android:text="@string/display"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -48,11 +58,13 @@
                         android:textSize="13sp" />
                 </LinearLayout>
             </RelativeLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -98,11 +110,13 @@
                     android:textColorHint="?attr/font" />
 
             </RelativeLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
+
             <RelativeLayout
                 android:id="@+id/fab"
                 android:layout_width="match_parent"
@@ -135,20 +149,24 @@
                         android:textSize="13sp" />
                 </LinearLayout>
             </RelativeLayout>
-            <View
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/notificationsHeader"
+                android:text="@string/title_inbox"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:id="@+id/notifications"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:background="?android:selectableItemBackground"
                 android:gravity="center_vertical"
-                android:orientation="horizontal"
-                >
-
+                android:orientation="horizontal">
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -172,58 +190,18 @@
                         android:textColor="?attr/font"
                         android:textSize="13sp" />
                 </LinearLayout>
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_alignParentBottom="true"
-                    android:background="?attr/tint"
-                    android:alpha=".25"
-                    android:layout_height="0.25dp"/>
             </RelativeLayout>
 
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:background="?android:selectableItemBackground"
-                android:orientation="horizontal"
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/sortingHeader"
+                android:text="@string/sorting"
+                android:paddingStart="16dp"
                 android:paddingEnd="16dp"
-                android:paddingStart="16dp">
-
-                <LinearLayout
-                    android:layout_marginRight="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/settings_confirm_exit"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/exitcheck"
-                    android:layout_width="match_parent"
-
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-
-            </RelativeLayout>
-            <View
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:id="@+id/sorting"
                 android:layout_width="match_parent"
@@ -256,11 +234,13 @@
                         android:textSize="13sp" />
                 </LinearLayout>
             </RelativeLayout>
+
             <View
                 android:layout_width="match_parent"
                 android:background="?attr/tint"
                 android:alpha=".25"
                 android:layout_height="0.25dp"/>
+
             <RelativeLayout
                 android:id="@+id/sorting_comment"
                 android:layout_width="match_parent"
@@ -293,11 +273,17 @@
                         android:textSize="13sp" />
                 </LinearLayout>
             </RelativeLayout>
-            <View
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/downloadsHeader"
+                android:text="@string/image_downloads"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -330,11 +316,17 @@
                         android:textSize="13sp" />
                 </LinearLayout>
             </RelativeLayout>
-            <View
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/miscHeader"
+                android:text="@string/settings_section_other"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
+                android:layout_height="wrap_content" />
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
@@ -378,7 +370,49 @@
                     android:hapticFeedbackEnabled="true"
                     android:textColor="?attr/font"
                     android:textColorHint="?attr/font" />
+            </RelativeLayout>
 
+            <View
+                android:layout_width="match_parent"
+                android:background="?attr/tint"
+                android:alpha=".25"
+                android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginRight="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_confirm_exit"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/exitcheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
             </RelativeLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_settings_theme.xml
+++ b/app/src/main/res/layout/activity_settings_theme.xml
@@ -39,6 +39,16 @@
                 android:layout_marginTop="-24dp"
                 app:srcCompat="@drawable/more" />
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/appThemeHeader"
+                android:text="@string/app_theme"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
             <LinearLayout
                 android:id="@+id/main"
                 android:layout_width="match_parent"
@@ -111,11 +121,15 @@
                     android:textSize="16sp" />
             </LinearLayout>
 
-            <View
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body2"
+                android:id="@+id/tintingHeader"
+                android:text="@string/tinting"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
-                android:layout_height="0.25dp"
-                android:alpha=".25"
-                android:background="?attr/tint" />
+                android:layout_height="wrap_content" />
 
             <RelativeLayout
                 android:id="@+id/dotint"

--- a/app/src/main/res/layout/activity_settings_theme_card.xml
+++ b/app/src/main/res/layout/activity_settings_theme_card.xml
@@ -20,11 +20,8 @@
                 android:id="@+id/card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-
                 android:layout_marginBottom="20dp"
-
                 android:orientation="vertical">
-
             </LinearLayout>
 
             <LinearLayout
@@ -32,6 +29,16 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
                 android:orientation="vertical">
+
+                <TextView
+                    style="@style/TextAppearance.AppCompat.Body2"
+                    android:id="@+id/displayHeader"
+                    android:text="@string/display"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:paddingTop="16dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
 
                 <RelativeLayout
                     android:id="@+id/view"
@@ -146,11 +153,16 @@
                             android:textSize="13sp" />
                     </LinearLayout>
                 </RelativeLayout>
-                <View
+
+                <TextView
+                    style="@style/TextAppearance.AppCompat.Body2"
+                    android:id="@+id/postInfoHeader"
+                    android:text="@string/post_info"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:paddingTop="16dp"
                     android:layout_width="match_parent"
-                    android:layout_height="0.25dp"
-                    android:alpha=".25"
-                    android:background="?attr/tint" />
+                    android:layout_height="wrap_content" />
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -174,7 +186,6 @@
                             android:text="@string/settings_card_show_selftext"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.SwitchCompat
@@ -188,8 +199,8 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.25dp"
@@ -218,7 +229,6 @@
                             android:text="@string/settings_layout_small_content_tag"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.SwitchCompat
@@ -232,8 +242,8 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.25dp"
@@ -262,7 +272,6 @@
                             android:text="@string/settings_layout_show_domain"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.SwitchCompat
@@ -276,8 +285,8 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.25dp"
@@ -306,13 +315,11 @@
                             android:text="@string/card_right_thumb"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.SwitchCompat
                         android:id="@+id/action"
                         android:layout_width="match_parent"
-
                         android:layout_height="match_parent"
                         android:background="?android:selectableItemBackground"
                         android:backgroundTint="?attr/tint"
@@ -321,13 +328,14 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
+
                 <View
                     android:layout_width="match_parent"
                     android:background="?attr/tint"
                     android:alpha=".25"
                     android:layout_height="0.25dp"/>
+
                 <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="56dp"
@@ -350,7 +358,6 @@
                             android:text="@string/settings_general_comment_last_visit"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.SwitchCompat
@@ -364,14 +371,17 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="0.25dp"
-                    android:alpha=".25"
-                    android:background="?attr/tint" />
 
+                <TextView
+                    style="@style/TextAppearance.AppCompat.Body2"
+                    android:id="@+id/postButtonsHeader"
+                    android:text="@string/post_buttons"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:paddingTop="16dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -410,7 +420,6 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
 
                 <View
@@ -418,7 +427,6 @@
                     android:layout_height="0.25dp"
                     android:alpha=".25"
                     android:background="?attr/tint" />
-
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -442,7 +450,6 @@
                             android:text="@string/card_save_button"
                             android:textColor="?attr/font"
                             android:textSize="16sp" />
-
                     </LinearLayout>
 
                     <android.support.v7.widget.AppCompatCheckBox
@@ -457,7 +464,6 @@
                         android:hapticFeedbackEnabled="true"
                         android:textColor="?attr/font"
                         android:textColorHint="?attr/font" />
-
                 </RelativeLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,6 @@
     <string name="sorting_year">Past year</string>
     <string name="sorting_all">All time</string>
 
-
     <!-- Editor (save/submit a post) actions -->
     <string name="editor_url">URL</string>
     <string name="editor_text">Text</string>
@@ -420,10 +419,20 @@
     <string name="settings_title_comments">Comments</string>
     <string name="settings_title_filter">Filters</string>
     <string name="settings_title_font">Font</string>
-
     <string name="settings_section_general">General</string>
     <string name="settings_section_appearance">Appearance</string>
     <string name="settings_section_other">Other</string>
+
+    <!-- Setting subheaders -->
+    <string name="sorting">Sorting</string>
+    <string name="display">Display</string>
+    <string name="image_downloads">Images</string>
+    <string name="app_theme">App theme</string>
+    <string name="tinting">Tinting</string>
+    <string name="post_info">Post information</string>
+    <string name="post_buttons">Post buttons</string>
+    <string name="navigation">Navigation</string>
+    <string name="collapse_comments">Collapse actions</string>
 
 
     <!-- Titles displayed in action bar / head / recents overview-->
@@ -624,7 +633,7 @@
     <string name="thread_continue">Continue this thread</string>
     <string name="type_selftext">Selftext</string>
     <string name="mail_re">re: %1$s</string>
-    <string name="settings_fab_create">Show create comment FAB</string>
+    <string name="settings_fab_create">Show \"create comment\" floating action button</string>
     <string name="submission_unhide">Unhide post</string>
     <string name="submission_info_unhidden">Submission unhidden</string>
     <string name="settings_handling_external_desc">Domains entered below will always open externally</string>


### PR DESCRIPTION
Added subheadings to some Settings activity; this greatly improves the "glanceability" of the settings list.
This was done for the following settings sections:

- General
- Main theme
- Post layout
- Comments

[Screenshot of new General Settings](http://i.imgur.com/jRWQga9.png)

This should alleviate #1347 :) 

Also fixed the `MainActivity` not refreshing when changing the font style.