### PR TITLE
Fixed synccit posts showing as unread upon a cold boot until refresh()

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Synccit/MySynccitReadTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/MySynccitReadTask.java
@@ -8,6 +8,7 @@ import com.synccit.android.SynccitReadTask;
 
 import java.util.HashSet;
 
+import me.ccrama.redditslide.HasSeen;
 import me.ccrama.redditslide.SettingValues;
 
 public class MySynccitReadTask extends SynccitReadTask {
@@ -23,9 +24,11 @@ public class MySynccitReadTask extends SynccitReadTask {
     protected void onVisited(HashSet<String> visitedThreadIds) {
         SynccitRead.visitedIds.addAll(visitedThreadIds);
 
-
+        //save the newly "seen" synccit posts to SEEN
+        for (String id : visitedThreadIds) {
+            HasSeen.addSeen(id);
+        }
     }
-
 
     @Override
     protected String getUsername() {


### PR DESCRIPTION
Now synccit posts that were sync'd will be added to your seen posts on that device