### PR TITLE
Tag external links with the application name that opens them

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -3,7 +3,6 @@ package me.ccrama.redditslide;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.net.Uri;
 
@@ -11,6 +10,7 @@ import net.dean.jraw.models.Submission;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 
 /**
  * Created by ccrama on 5/26/2015.
@@ -242,24 +242,46 @@ public class ContentType {
         return R.string.type_link;
     }
 
+    static HashMap<String, String> contentDescriptions = new HashMap<>();
+
+    /**
+     * Returns a description of the submission, for example "Link", "NSFW link", if the link is set
+     * to open externally it returns the package name of the app that opens it, or "External"
+     *
+     * @param submission The submission to describe
+     * @param context Current context
+     * @return The content description
+     */
     public static String getContentDescription(Submission submission, Context context) {
         final int generic = getContentID(submission);
         final Resources res = context.getResources();
+        final String domain = submission.getDomain();
 
         if (generic != R.string.type_external) {
             return res.getString(generic);
+        }
+
+        if (contentDescriptions.containsKey(domain)) {
+            return contentDescriptions.get(domain);
         }
 
         try {
             final PackageManager pm = context.getPackageManager();
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(submission.getUrl()));
             final String packageName = pm.resolveActivity(intent, 0).activityInfo.packageName;
+            String description;
+
             if (!packageName.equals("android")) {
-                return pm.getApplicationLabel(pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA)).toString();
+                description = pm.getApplicationLabel(pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA)).toString();
             } else {
-                return res.getString(generic);
+                description = res.getString(generic);
             }
+
+            // Looking up a package name takes a long time (3~10ms), memoize it
+            contentDescriptions.put(domain, description);
+            return description;
         } catch (PackageManager.NameNotFoundException|NullPointerException e) {
+            contentDescriptions.put(domain, res.getString(generic));
             return res.getString(generic);
         }
     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
@@ -36,6 +36,7 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Views.TransparentTagTextView;
+import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 
 /**
@@ -318,7 +319,7 @@ public class HeaderImageLinkView extends RelativeLayout {
                 ((TransparentTagTextView) title).init(getContext());
             }
 
-            title.setText(ContentType.getContentDescription(submission));
+            title.setText(ContentType.getContentDescription(submission, getContext()));
 
             if (info != null)
                 info.setText(submission.getDomain());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="type_nsfw_emb">NSFW embedded</string>
     <string name="type_imgur">Imgur content</string>
     <string name="type_nsfw_imgur">NSFW Imgur content</string>
+    <string name="type_external">External</string>
 
 
     <!-- Reply to message -->

--- a/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
@@ -1,24 +1,35 @@
 package me.ccrama.redditslide.test;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.ContentType.Type;
+import me.ccrama.redditslide.SettingValues;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 
 public class ContentTypeTest {
+
+    @BeforeClass
+    public static void setUp() {
+        SettingValues.alwaysExternal = "twitter.com,github.com";
+    }
 
     @Test
     public void detectsAlbum() {
         assertThat(ContentType.getContentType("http://www.imgur.com/a/duARTe"), is(Type.ALBUM));
         assertThat(ContentType.getContentType("https://imgur.com/gallery/DmXJ4"), is(Type.ALBUM));
         assertThat(ContentType.getContentType("http://imgur.com/82UIrJk,dIjBFjv"), is(Type.ALBUM));
+    }
+
+    @Test
+    public void detectsExternal() {
+        assertThat(ContentType.getContentType("https://twitter.com/jaffathecake/status/718071903378735105?s=09"), is(Type.EXTERNAL));
+        assertThat(ContentType.getContentType("https://github.com/ccrama/Slide"), is(Type.EXTERNAL));
     }
 
     @Test


### PR DESCRIPTION
The tagging is memoized per domain as the few ms it takes on the main thread would cause some jank. If there is no app or the URL can't be parsed correctly it uses R.string.type_external

Example:

![image](https://cloud.githubusercontent.com/assets/1830331/14512273/714117b8-01d5-11e6-9ace-54958b10b720.png)
