### PR TITLE
Tinted EditText bar so it isn't colorful

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -255,7 +255,7 @@ public class CommentPage extends Fragment {
                 fabs.setMargins(fabs.leftMargin, fabs.topMargin, fabs.rightMargin, fabs.bottomMargin * 3);
                 fab.setLayoutParams(fabs);
             }
-            v.findViewById(R.id.comment_floating_action_button).setOnClickListener(new View.OnClickListener() {
+            fab.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     LayoutInflater inflater = (getActivity()).getLayoutInflater();
@@ -264,7 +264,6 @@ public class CommentPage extends Fragment {
                     final AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
 
                     final EditText e = (EditText) dialoglayout.findViewById(R.id.entry);
-
                     DoEditorActions.doActions(e, dialoglayout, getActivity().getSupportFragmentManager(), getActivity());
 
                     builder.setView(dialoglayout);

--- a/app/src/main/res/layout/comment_menu.xml
+++ b/app/src/main/res/layout/comment_menu.xml
@@ -87,11 +87,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/btn_reply"
-            android:textColor="#fff"
-            android:textColorHint="#fff"
+            android:textColor="@color/white"
+            android:textColorHint="@color/white"
             android:imeOptions="actionDone|flagNoEnterAction"
             android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
-            android:minHeight="30dp" />
+            android:minHeight="30dp"
+            android:theme="@style/ReplyEditTextTheme"/>
 
         <include
             layout="@layout/editor_items"/>

--- a/app/src/main/res/layout/edit_comment.xml
+++ b/app/src/main/res/layout/edit_comment.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-
         <LinearLayout
             android:layout_width="match_parent"
             android:orientation="vertical"
@@ -18,27 +17,22 @@
             <LinearLayout
                 android:id="@+id/sidebar"
                 android:layout_width="match_parent"
-
                 android:layout_height="wrap_content"
                 android:layout_margin="16dp"
                 android:background="?android:selectableItemBackground"
                 android:gravity="center_vertical"
-
                 android:orientation="horizontal">
-
 
                 <EditText
                     android:id="@+id/entry"
                     android:layout_width="match_parent"
-
                     android:layout_height="wrap_content"
+                    android:hint="@string/btn_reply"
                     android:gravity="center_vertical"
-
                     android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
                     android:textColor="?attr/font"
-
-                    android:textSize="16sp" />
-
+                    android:textSize="16sp"
+                    android:theme="@style/ReplyEditTextTheme"/>
             </LinearLayout>
 
             <include
@@ -51,7 +45,6 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-
                 android:orientation="horizontal">
 
                 <TextView
@@ -65,6 +58,7 @@
                     android:textAllCaps="true"
                     android:textSize="14sp"
                     android:textStyle="bold" />
+
                 <TextView
                     android:id="@+id/preview"
                     android:layout_width="0dp"
@@ -72,11 +66,11 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:padding="16dp"
-
                     android:text="@string/btn_preview"
                     android:textAllCaps="true"
                     android:textSize="14sp"
                     android:textStyle="bold" />
+
                 <TextView
                     android:id="@+id/submit"
                     android:layout_width="0dp"
@@ -84,12 +78,10 @@
                     android:layout_weight="1"
                     android:gravity="center"
                     android:padding="16dp"
-
                     android:text="@string/btn_submit"
                     android:textAllCaps="true"
                     android:textSize="14sp"
                     android:textStyle="bold" />
-
             </LinearLayout>
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values-v21/style.xml
+++ b/app/src/main/res/values-v21/style.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-
     <style name="AppTheme" parent="swipestyle">
         <item name="colorPrimary">#e64a19</item>
         <item name="android:alertDialogTheme">@style/Theme.AppCompat.Dialog.Alert</item>
@@ -9,26 +8,30 @@
         <item name="android:colorBackground">#000000</item>
         <item name="colorPrimaryDark">#000000</item>
         <item name="android:windowContentTransitions">true</item>
-
     </style>
+
     <style name="Ripple.List">
         <item name="android:background">?android:selectableItemBackgroundBorderless</item>
     </style>
-    <style name="swipestyle" parent="Theme.AppCompat.NoActionBar">
 
+    <style name="swipestyle" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowSharedElementsUseOverlay">false</item>
         <item name="android:alertDialogTheme">@style/Theme.AppCompat.Dialog.Alert</item>
         <item name="android:alertDialogStyle">@style/Theme.AppCompat.Dialog.Alert</item>
         <item name="colorAccent">@color/md_amber_A200</item>
-
     </style>
 
     <style name="swipestylelight" parent="Theme.AppCompat.Light.NoActionBar">
-
         <item name="android:windowSharedElementsUseOverlay">false</item>
         <item name="android:alertDialogTheme">@style/Theme.AppCompat.Light.Dialog.Alert</item>
         <item name="android:alertDialogStyle">@style/Theme.AppCompat.Light.Dialog.Alert</item>
         <item name="colorAccent">@color/md_amber_A200</item>
+    </style>
 
+    <!-- When replying or editing a comment, tint the EditText bar -->
+    <style name="ReplyEditTextTheme" parent="@style/Widget.AppCompat.EditText">
+        <item name="android:colorControlNormal">?attr/tint</item>
+        <item name="android:colorControlActivated">?attr/tint</item>
+        <item name="android:colorControlHighlight">?attr/tint</item>
     </style>
 </resources>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -2,11 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="AppTheme" parent="swipestyle">
-
-
-        <item name="android:spinnerItemStyle">
-            @style/spinnerItemStyle
-        </item>
+        <item name="android:spinnerItemStyle">@style/spinnerItemStyle</item>
     </style>
 
     <style name="Ripple" tools:keep="@style/Ripple" />
@@ -14,290 +10,249 @@
     <style name="Ripple.List" tools:keep="@style/Ripple_List">
         <item name="android:background">?android:selectableItemBackground</item>
     </style>
+
     <!-- From SwipeBackLayout !-->
+    <style name="SwipeBackLayout">
+        <item name="edge_size">50dip</item>
+        <item name="shadow_left">@drawable/shadow_left</item>
+        <item name="shadow_right">@drawable/shadow_right</item>
+        <item name="shadow_bottom">@drawable/shadow_bottom</item>
+    </style>
 
-        <style name="SwipeBackLayout">
-            <item name="edge_size">50dip</item>
-            <item name="shadow_left">@drawable/shadow_left</item>
-            <item name="shadow_right">@drawable/shadow_right</item>
-            <item name="shadow_bottom">@drawable/shadow_bottom</item>
-        </style>
-
-    <!-- !-->
     <style name="swipeable" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@null</item>
         <item name="android:windowIsTranslucent">true</item>
-
     </style>
 
     <style name="swipestyle" parent="Theme.AppCompat.NoActionBar">
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
     <style name="swipestylelight" parent="Theme.AppCompat.Light.NoActionBar">
-
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
-    <style name="popup" parent="Theme.AppCompat.Dialog.Alert"
-        >
+    <style name="popup" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:background">@color/transparent</item>
-        </style>
+    </style>
 
     <style name="spinnerItemStyle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
     </style>
 
-   
+    <!-- When replying or editing a comment, tint the EditText bar -->
+    <style name="ReplyEditTextTheme" parent="@style/Widget.AppCompat.EditText">
+        <item name="android:colorControlNormal">?attr/tint</item>
+        <item name="android:colorControlActivated">?attr/tint</item>
+        <item name="android:colorControlHighlight">?attr/tint</item>
+    </style>
+
 
     <style name="white_amoled" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_blue_grey_200</item>
-
     </style>
 
     <style name="white_light" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_blue_grey_200</item>
-
     </style>
+
     <style name="teal_light" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_teal_A200</item>
-
     </style>
 
     <style name="teal_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_teal_A200</item>
-
     </style>
 
     <style name="teal_amoled" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_teal_A200</item>
-
     </style>
+
     <style name="teal_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_teal_A200</item>
-
     </style>
+
     <style name="teal_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_teal_A200</item>
-
     </style>
+
     <style name="pink_amoled" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_pink_A200</item>
-
     </style>
 
     <style name="pink_light" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_pink_A200</item>
-
     </style>
 
     <style name="pink_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_pink_A200</item>
-
     </style>
+
     <style name="yellow_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_yellow_A700</item>
-
     </style>
 
     <style name="white_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_blue_grey_200</item>
-
     </style>
+
     <style name="amber_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_amber_A700</item>
-
+        <item name="android:editTextStyle">@style/ReplyEditTextTheme</item>
     </style>
 
     <style name="blue_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_blue_A700</item>
-
     </style>
 
     <style name="lightblue_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_light_blue_A700</item>
-
     </style>
 
     <style name="deeporange_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_deep_orange_A700</item>
-
     </style>
 
     <style name="cyan_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_cyan_A700</item>
-
     </style>
 
     <style name="green_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_green_A700</item>
-
     </style>
 
     <style name="indigo_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_indigo_A700</item>
-
     </style>
 
     <style name="lime_dark" parent="Theme.DARK">
         <item name="colorAccent">@color/md_lime_A700</item>
-
     </style>
-
 
     <style name="pink_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_pink_A200</item>
-
     </style>
+
     <style name="yellow_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_yellow_A700</item>
-
     </style>
 
     <style name="white_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_blue_grey_200</item>
-
     </style>
+
     <style name="amber_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
     <style name="blue_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_blue_A700</item>
-
     </style>
 
     <style name="lightblue_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_light_blue_A700</item>
-
     </style>
 
     <style name="deeporange_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_deep_orange_A700</item>
-
     </style>
 
     <style name="cyan_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_cyan_A700</item>
-
     </style>
 
     <style name="green_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_green_A700</item>
-
     </style>
 
     <style name="indigo_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_indigo_A700</item>
-
     </style>
 
     <style name="lime_blue" parent="Theme.DARK_BLUE">
         <item name="colorAccent">@color/md_lime_A700</item>
-
     </style>
+
     <style name="pink_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_pink_A200</item>
-
     </style>
+
     <style name="yellow_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_yellow_A700</item>
-
     </style>
 
     <style name="white_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_blue_grey_200</item>
-
     </style>
+
     <style name="amber_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
     <style name="blue_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_blue_A700</item>
-
     </style>
 
     <style name="lightblue_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_light_blue_A700</item>
-
     </style>
 
     <style name="deeporange_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_deep_orange_A700</item>
-
     </style>
 
     <style name="cyan_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_cyan_A700</item>
-
     </style>
 
     <style name="green_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_green_A700</item>
-
     </style>
 
     <style name="indigo_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_indigo_A700</item>
-
     </style>
 
     <style name="lime_AMOLED_lighter" parent="Theme.AMOLED_lighter">
         <item name="colorAccent">@color/md_lime_A700</item>
-
     </style>
 
     <style name="yellow_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_yellow_A700</item>
-
     </style>
 
     <style name="amber_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
     <style name="blue_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_blue_A700</item>
-
     </style>
 
     <style name="lightblue_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_light_blue_A700</item>
-
     </style>
 
     <style name="deeporange_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_deep_orange_A700</item>
-
     </style>
 
     <style name="cyan_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_cyan_A700</item>
-
     </style>
 
     <style name="green_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_green_A700</item>
-
     </style>
 
     <style name="indigo_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_indigo_A700</item>
-
     </style>
 
     <style name="lime_LIGHT" parent="Theme.LIGHT">
         <item name="colorAccent">@color/md_lime_A700</item>
-
     </style>
-
 
     <style name="yellow_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_yellow_A700</item>
@@ -305,48 +260,41 @@
 
     <style name="amber_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_amber_A700</item>
-
     </style>
 
     <style name="blue_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_blue_A700</item>
-
     </style>
 
     <style name="lightblue_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_light_blue_A700</item>
-
     </style>
 
     <style name="deeporange_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_deep_orange_A700</item>
-
     </style>
 
     <style name="cyan_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_cyan_A700</item>
-
     </style>
 
     <style name="green_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_green_A700</item>
-
     </style>
 
     <style name="indigo_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_indigo_A700</item>
-
     </style>
 
     <style name="lime_AMOLED" parent="Theme.AMOLED">
         <item name="colorAccent">@color/md_lime_A700</item>
-
     </style>
 
     <style name="FontStyle.MediumPost">
         <item name="font_cardtitle">20sp</item>
         <item name="font_cardinfo">12sp</item>
     </style>
+
     <style name="FontStyle.MediumComment">
         <item name="font_commenttitle">12sp</item>
         <item name="font_commentinfo">12sp</item>
@@ -359,6 +307,7 @@
         <item name="font_cardtitle">18sp</item>
         <item name="font_cardinfo">10sp</item>
     </style>
+
     <style name="FontStyle.SmallComment">
         <item name="font_commenttitle">10sp</item>
         <item name="font_commentinfo">10sp</item>
@@ -369,11 +318,13 @@
         <item name="font_cardtitle">16sp</item>
         <item name="font_cardinfo">10sp</item>
     </style>
+
     <style name="FontStyle.SmallerComment">
         <item name="font_commenttitle">8sp</item>
         <item name="font_commentinfo">8sp</item>
         <item name="font_commentbody">10sp</item>
     </style>
+
     <style name="FontStyle.TinyPost">
         <item name="font_cardtitle">14sp</item>
         <item name="font_cardinfo">10sp</item>
@@ -383,6 +334,7 @@
         <item name="font_cardtitle">22sp</item>
         <item name="font_cardinfo">14sp</item>
     </style>
+
     <style name="FontStyle.LargeComment">
         <item name="font_commenttitle">14sp</item>
         <item name="font_commentinfo">14sp</item>
@@ -393,21 +345,23 @@
         <item name="font_cardtitle">24sp</item>
         <item name="font_cardinfo">16sp</item>
     </style>
+
     <style name="FontStyle.LargestPost">
         <item name="font_cardtitle">26sp</item>
         <item name="font_cardinfo">18sp</item>
     </style>
+
     <style name="FontStyle.LargerComment">
         <item name="font_commenttitle">16sp</item>
         <item name="font_commentinfo">16sp</item>
         <item name="font_commentbody">18sp</item>
     </style>
+
     <style name="FontStyle.LargestComment">
         <item name="font_commenttitle">18sp</item>
         <item name="font_commentinfo">18sp</item>
         <item name="font_commentbody">20sp</item>
     </style>
-
 
     <style name="Theme.LIGHT" parent="swipestylelight">
         <item name="activity_background">#dedede</item>
@@ -423,7 +377,6 @@
         <item name="actionMenuTextColor">#DE000000</item>
         <item name="android:actionMenuTextColor">#DE000000</item>
         <item name="android:colorBackground">#dedede</item>
-
     </style>
 
     <style name="Theme.DARK" parent="swipestyle">
@@ -438,6 +391,7 @@
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
     </style>
+
     <style name="Theme.DARK_BLUE" parent="swipestyle">
         <item name="activity_background">#2F3D44</item>
         <item name="card_background">#37474F</item>
@@ -451,7 +405,6 @@
 
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
-
     </style>
 
     <style name="Theme.AMOLED" parent="swipestyle">
@@ -467,8 +420,8 @@
 
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
-
     </style>
+
     <style name="Theme.AMOLED_lighter" parent="swipestyle">
         <item name="activity_background">#121212</item>
         <item name="card_background">#000000</item>
@@ -482,12 +435,13 @@
 
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
-
     </style>
+
     <style name="ActionBarCompat">
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorSecondary">@android:color/white</item>
     </style>
+
     <style name="BottomSheet.StyleDialog.Dark" parent="BottomSheet.Dialog">
         <item name="android:textColorPrimary">#FFFFFFFF</item>
         <item name="android:textColorSecondary">#8Affffff</item>
@@ -495,6 +449,7 @@
         <item name="bs_dialogBackground">#424242</item>
         <item name="bs_dividerColor">#00000000</item>
     </style>
+
     <style name="BottomSheet.StyleDialog.Dark_Blue" parent="BottomSheet.Dialog">
         <item name="android:textColorPrimary">#FFFFFFFF</item>
         <item name="android:textColorSecondary">#8Affffff</item>
@@ -502,6 +457,7 @@
         <item name="bs_dialogBackground">#37474F</item>
         <item name="bs_dividerColor">#00000000</item>
     </style>
+
     <style name="BottomSheet.StyleDialog.Light" parent="BottomSheet.Dialog">
         <item name="android:textColorPrimary">#DE000000</item>
         <item name="android:textColorSecondary">#8A000000</item>
@@ -509,6 +465,7 @@
         <item name="bs_dialogBackground">#FFFFFF</item>
         <item name="bs_dividerColor">#00000000</item>
     </style>
+
     <style name="BottomSheet.StyleDialog.AMOLED" parent="BottomSheet.Dialog">
         <item name="android:textColorPrimary">#FFFFFFFF</item>
         <item name="android:textColorSecondary">#8Affffff</item>


### PR DESCRIPTION
So, after a few hours of playing around with this--the best we can do is use the `?attr/tint` to color the EditText's bar. There isn't a clean easy way to make all of them white without ruining visibility of the EditText field in 'edit_comment`'s layout when using the Light base theme. 

This will make them white for all themes except the Light theme--in which case, it tints them black. It works lol