### PR TITLE
Changed style of sorting strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,12 +159,12 @@
     <string name="sorting_old">Old</string>
     <string name="sorting_controversial">Controversial</string>
     <string name="sorting_rising">Rising</string>
-    <string name="sorting_hour">Past hour</string>
-    <string name="sorting_day">Past 24 hours</string>
-    <string name="sorting_week">Past week</string>
-    <string name="sorting_month">Past month</string>
-    <string name="sorting_year">Past year</string>
-    <string name="sorting_all">All time</string>
+    <string name="sorting_hour">&#8250; hour</string>
+    <string name="sorting_day">&#8250; 24 hours</string>
+    <string name="sorting_week">&#8250; week</string>
+    <string name="sorting_month">&#8250; month</string>
+    <string name="sorting_year">&#8250; year</string>
+    <string name="sorting_all">&#8250; all time</string>
 
 
     <!-- Editor (save/submit a post) actions -->


### PR DESCRIPTION
Looks like that now. As opposed to "past year", "past 24 hours", etc. I think it looks cleaner.
![screenshot_20160417-162119](https://cloud.githubusercontent.com/assets/2940826/14589791/bf8098c8-04b8-11e6-9960-d934da889e7b.png)
