### PR TITLE
Fixed all theme issues regarding editor's EditText fields

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
@@ -11,6 +11,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -23,6 +24,8 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.github.rjeschke.txtmark.Processor;
 
 import org.json.JSONException;
@@ -254,40 +257,32 @@ public class DoEditorActions {
         baseView.findViewById(R.id.link).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                LinearLayout layout = new LinearLayout(editText.getContext());
-                layout.setOrientation(LinearLayout.VERTICAL);
+                final LayoutInflater inflater = LayoutInflater.from(a);
+                final LinearLayout layout = (LinearLayout) inflater.inflate(R.layout.insert_link, null);
+
                 int[] attrs = {R.attr.font};
 
                 TypedArray ta = baseView.getContext().obtainStyledAttributes(new ColorPreferences(baseView.getContext()).getFontStyle().getBaseId(), attrs);
-
-                final EditText titleBox = new EditText(editText.getContext());
-                titleBox.setHint(R.string.editor_url);
-                titleBox.setEnabled(true);
-                titleBox.setTextColor(ta.getColor(0, Color.WHITE));
-                layout.addView(titleBox);
-
-                final EditText descriptionBox = new EditText(editText.getContext());
-                descriptionBox.setHint(R.string.editor_text);
-                descriptionBox.setEnabled(true);
-                descriptionBox.setTextColor(ta.getColor(0, Color.WHITE));
-                layout.addView(descriptionBox);
-                layout.setPadding(16, 16, 16, 16);
-
                 ta.recycle();
-                new AlertDialogWrapper.Builder(editText.getContext())
-                        .setTitle(R.string.editor_title_link)
-                        .setView(layout)
-                        .setPositiveButton(R.string.editor_action_link,
-                                new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int which) {
-                                        dialog.dismiss();
-                                        String s = "[" + descriptionBox.getText().toString() + "](" + titleBox.getText().toString() + ")";
-                                        int start = Math.max(editText.getSelectionStart(), 0);
-                                        int end = Math.max(editText.getSelectionEnd(), 0);
-                                        editText.getText().insert(Math.max(start, end), s);
-                                    }
-                                }).show();
+
+                final MaterialDialog dialog = new MaterialDialog.Builder(editText.getContext())
+                        .title(R.string.editor_title_link)
+                        .customView(layout, false)
+                        .positiveColorAttr(R.attr.tint)
+                        .positiveText(R.string.editor_action_link)
+                        .onPositive(new MaterialDialog.SingleButtonCallback() {
+                            @Override
+                            public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                final EditText titleBox = (EditText) dialog.findViewById(R.id.title_box);
+                                final EditText descriptionBox = (EditText) dialog.findViewById(R.id.description_box);
+                                dialog.dismiss();
+                                String s = "[" + descriptionBox.getText().toString() + "](" + titleBox.getText().toString() + ")";
+                                int start = Math.max(editText.getSelectionStart(), 0);
+                                int end = Math.max(editText.getSelectionEnd(), 0);
+                                editText.getText().insert(Math.max(start, end), s);
+                            }
+                        }).build();
+                dialog.show();
             }
         });
     }

--- a/app/src/main/res/layout/comment_menu_right_handed.xml
+++ b/app/src/main/res/layout/comment_menu_right_handed.xml
@@ -91,7 +91,8 @@
             android:textColorHint="#fff"
             android:imeOptions="actionDone|flagNoEnterAction"
             android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
-            android:minHeight="30dp" />
+            android:minHeight="30dp"
+            android:theme="@style/ReplyEditTextTheme"/>
 
         <include
             layout="@layout/editor_items"/>

--- a/app/src/main/res/layout/insert_link.xml
+++ b/app/src/main/res/layout/insert_link.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
+
+    <EditText
+        android:id="@+id/title_box"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/editor_url"
+        android:enabled="true"
+        android:textColor="?attr/font"
+        android:theme="@style/ReplyEditTextTheme"/>
+
+    <EditText
+        android:id="@+id/description_box"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/editor_text"
+        android:enabled="true"
+        android:textColor="?attr/font"
+        android:theme="@style/ReplyEditTextTheme"/>
+</LinearLayout>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -36,6 +36,13 @@
         <item name="android:background">@color/transparent</item>
     </style>
 
+    <!-- When replying or editing a comment, tint the EditText bar -->
+    <style name="ReplyEditTextTheme">
+        <item name="android:colorControlNormal">?attr/tint</item>
+        <item name="android:colorControlActivated">?attr/tint</item>
+        <item name="android:colorControlHighlight">?attr/tint</item>
+    </style>
+
     <style name="spinnerItemStyle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -36,13 +36,6 @@
         <item name="android:background">@color/transparent</item>
     </style>
 
-    <!-- When replying or editing a comment, tint the EditText bar -->
-    <style name="ReplyEditTextTheme">
-        <item name="android:colorControlNormal">?attr/tint</item>
-        <item name="android:colorControlActivated">?attr/tint</item>
-        <item name="android:colorControlHighlight">?attr/tint</item>
-    </style>
-
     <style name="spinnerItemStyle">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
I'd like to start off by saying I tested this on every base theme.

- Changed the "Insert Link" dialog to use Material Dialog builder
- Made positive button color on the dialog dependent on the base theme (this used to stay colored to the accent in some cases--this just makes it a uniform color across all instances of the dialog)
- Have the dialog use a layout.xml as opposed to doing it programmatically

This shouldn't break anything while just making everything more consistent.

PS: I know of the bug where the edit text fields would be missing--and I saw that you fixed it. You shouldn't have needed to remove the style from the `styles.xml`; you only needed to remove the line inside the `amber` style theme--that was my mistake