### PR TITLE
add a rate snackbar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
         transitive = true
     }
     compile 'com.jakewharton:process-phoenix:1.0.2'
+    compile 'org.ligi:snackengage:0.5'
     compile 'com.android.support:design:23.3.0'
     compile 'com.koushikdutta.ion:ion:2.1.6'
     compile 'com.android.support:customtabs:23.3.0'

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -18,12 +18,20 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 
+import org.ligi.snackengage.SnackEngage;
+import org.ligi.snackengage.conditions.AfterNumberOfOpportunities;
+import org.ligi.snackengage.conditions.NeverAgainWhenClickedOnce;
+import org.ligi.snackengage.conditions.WithLimitedNumberOfTimes;
+import org.ligi.snackengage.snacks.BaseSnack;
+import org.ligi.snackengage.snacks.RateSnack;
+
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.DragSort.ReorderSubreddits;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.NetworkUtil;
 
 
 /**
@@ -88,6 +96,22 @@ public class Settings extends BaseActivity {
                 });
             }
         });
+        if (Authentication.isLoggedIn && NetworkUtil.isConnected(Settings.this)) {
+            // Display an snackbar that asks the user to rate the app after this
+            // activity was created 6 times, never again when once clicked or with a maximum of
+            // two times.
+            SnackEngage.from(Settings.this).withSnack(
+                    new RateSnack().withConditions(new NeverAgainWhenClickedOnce(),
+                            new AfterNumberOfOpportunities(6), new WithLimitedNumberOfTimes(2))
+                            .overrideActionText(getString(R.string.misc_rate_msg))
+                            .overrideTitleText(getString(R.string.misc_rate_title))
+                            .withDuration(BaseSnack.DURATION_INDEFINITE))
+                    /*.withSnack(new CustomSnack(new Intent(MainActivity.this, SettingsReddit.class), "Thumbnails are disabled", "Change", "THUMBNAIL_INFO")
+                            .withConditions(new AfterNumberOfOpportunities(2),
+                                    new WithLimitedNumberOfTimes(2), new NeverAgainWhenClickedOnce())
+                            .withDuration(BaseSnack.DURATION_LONG))*/
+                    .build().engageWhenAppropriate();
+        }
     }
 
     private void setSettingItems() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -753,4 +753,6 @@
     <string name="cache_wifi_only">Only cache on WiFi</string>
     <string name="settings_font_bold">Bold</string>
     <string name="settings_font_condensed_bold">Condensed Bold</string>
+    <string name="misc_rate_title">Like Slide?</string>
+    <string name="misc_rate_msg">Rate it!</string>
 </resources>


### PR DESCRIPTION
This shows a snackbar which asks the user to rate if he likes Slide. It's shown after Settings were created 6 times, never again when once clicked rate or when it was ignored 2 times.

Maybe we have to adjust this numbers a little bit, I'm not sure. This doesn't work on debug builds, because it has a wrong package name.