### PR TITLE
Share Intent uses EXTRA_SUBJECT for title

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -440,7 +440,7 @@ public class AlbumPager extends FullScreenActivity implements FolderChooserDialo
                     }
                     break;
                     case (5): {
-                        Reddit.defaultShareText(contentUrl, AlbumPager.this);
+                        Reddit.defaultShareText("", contentUrl, AlbumPager.this);
                     }
                     case (4): {
                         if (!isGif) {
@@ -799,7 +799,7 @@ public class AlbumPager extends FullScreenActivity implements FolderChooserDialo
         dialoglayout.findViewById(R.id.share_link).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Reddit.defaultShareText(url, AlbumPager.this);
+                Reddit.defaultShareText("", url, AlbumPager.this);
             }
         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/FullscreenImage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/FullscreenImage.java
@@ -372,7 +372,7 @@ public class FullscreenImage extends FullScreenActivity implements FolderChooser
         dialoglayout.findViewById(R.id.share_link).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Reddit.defaultShareText(url, FullscreenImage.this);
+                Reddit.defaultShareText("", url, FullscreenImage.this);
             }
         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/GifView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/GifView.java
@@ -87,7 +87,7 @@ public class GifView extends FullScreenActivity implements FolderChooserDialog.F
         findViewById(R.id.share).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Reddit.defaultShareText(dat, GifView.this);
+                Reddit.defaultShareText("", dat, GifView.this);
 
             }
         });

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -126,7 +126,7 @@ public class MediaView extends FullScreenActivity implements FolderChooserDialog
                         break;
                     }
                     case (5): {
-                        Reddit.defaultShareText(contentUrl, MediaView.this);
+                        Reddit.defaultShareText("", contentUrl, MediaView.this);
                         break;
                     }
                     case (4): {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
@@ -226,8 +226,8 @@ public class Profile extends BaseActivityAnim {
                 dialoglayout.findViewById(R.id.share).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Reddit.defaultShareText(getString(R.string.profile_share, name)
-                                + "\n" + "https://www.reddit.com/u/" + name, Profile.this);
+                        Reddit.defaultShareText(getString(R.string.profile_share, name),
+                                                "https://www.reddit.com/u/" + name, Profile.this);
                     }
                 });
                 final int currentColor = Palette.getColorUser(name);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -73,7 +73,7 @@ public class Website extends BaseActivityAnim {
                 startActivity(Intent.createChooser(browserIntent, getDomainName(v.getUrl())));
                 return true;
             case R.id.share:
-                Reddit.defaultShareText(v.getUrl(), Website.this);
+                Reddit.defaultShareText(v.getTitle(), v.getUrl(), Website.this);
 
                 return true;
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -3017,8 +3017,8 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                    Toast.makeText(mContext, "Comment text copied", Toast.LENGTH_SHORT).show();
                                    break;
                                case 4:
-                                   Reddit.defaultShareText("https://reddit.com" + submission.getPermalink() +
-                                                   n.getFullName().substring(3, n.getFullName().length()) + "?context=3"
+                                   Reddit.defaultShareText(submission.getTitle(),"https://reddit.com" + submission.getPermalink() +
+                                                                   n.getFullName().substring(3, n.getFullName().length()) + "?context=3"
                                            , mContext);
                                    break;
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
@@ -248,7 +248,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         @Override
                         public void onClick(View v) {
                             if (submission.isSelfPost())
-                                Reddit.defaultShareText("https://reddit.com" + submission.getPermalink(), mContext);
+                                Reddit.defaultShareText("", "https://reddit.com" + submission.getPermalink(), mContext);
                             else {
                                 new BottomSheet.Builder(mContext)
                                         .title(R.string.submission_share_title)
@@ -259,10 +259,10 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                                             public void onClick(DialogInterface dialog, int which) {
                                                 switch (which) {
                                                     case R.id.reddit_url:
-                                                        Reddit.defaultShareText("https://reddit.com" + submission.getPermalink(), mContext);
+                                                        Reddit.defaultShareText("", "https://reddit.com" + submission.getPermalink(), mContext);
                                                         break;
                                                     case R.id.link_url:
-                                                        Reddit.defaultShareText(submission.getUrl(), mContext);
+                                                        Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);
                                                         break;
                                                 }
                                             }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
@@ -242,7 +242,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         @Override
                         public void onClick(View v) {
                             if (submission.isSelfPost())
-                                Reddit.defaultShareText("https://reddit.com" + submission.getPermalink(), mContext);
+                                Reddit.defaultShareText(submission.getTitle(), "https://reddit.com" + submission.getPermalink(), mContext);
                             else {
                                 new BottomSheet.Builder(mContext)
                                         .title(R.string.submission_share_title)
@@ -253,10 +253,10 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                                             public void onClick(DialogInterface dialog, int which) {
                                                 switch (which) {
                                                     case R.id.reddit_url:
-                                                        Reddit.defaultShareText("https://reddit.com" + submission.getPermalink(), mContext);
+                                                        Reddit.defaultShareText(submission.getTitle(), "https://reddit.com" + submission.getPermalink(), mContext);
                                                         break;
                                                     case R.id.link_url:
-                                                        Reddit.defaultShareText(submission.getUrl(), mContext);
+                                                        Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);
                                                         break;
                                                 }
                                             }

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -118,11 +118,12 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         return px;
     }
 
-    public static void defaultShareText(String url, Context c) {
+    public static void defaultShareText(String title, String url, Context c) {
         Intent sharingIntent = new Intent(Intent.ACTION_SEND);
         sharingIntent.setType("text/plain");
         /* Decode html entities */
-        url = StringEscapeUtils.unescapeHtml4(url);
+        title = StringEscapeUtils.unescapeHtml4(title);
+        sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, title);
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, url);
         c.startActivity(Intent.createChooser(sharingIntent, c.getString(R.string.title_share)));
     }

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -401,7 +401,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             getContext().startActivity(Intent.createChooser(intent, "Open externally"));
                             break;
                         case R.id.share_link:
-                            Reddit.defaultShareText(url, finalActivity);
+                            Reddit.defaultShareText("", url, finalActivity);
                             break;
                         case R.id.copy_link:
                             ClipboardManager clipboard = (ClipboardManager) finalActivity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
@@ -394,7 +394,7 @@ public class HeaderImageLinkView extends RelativeLayout {
                                     getContext().startActivity(browserIntent);
                                     break;
                                 case R.id.share_link:
-                                    Reddit.defaultShareText(url, activity);
+                                    Reddit.defaultShareText("", url, activity);
                                     break;
                                 case R.id.copy_link:
                                     ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
@@ -324,7 +324,7 @@ public class PopulateShadowboxInfo {
                                 mContext.startActivity(browserIntent);
                                 break;
                             case 4:
-                                Reddit.defaultShareText(submission.getTitle() + "\n" + submission.getUrl(), mContext);
+                                Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);
                                 break;
                             case 12:
                                 reportReason = "";
@@ -366,7 +366,7 @@ public class PopulateShadowboxInfo {
 
                                 break;
                             case 8:
-                                Reddit.defaultShareText(submission.getTitle() + " \n" + "https://reddit.com" + submission.getPermalink(), mContext);
+                                Reddit.defaultShareText(submission.getTitle(), "https://reddit.com" + submission.getPermalink(), mContext);
                                 break;
                             case 6: {
                                 ClipboardManager clipboard = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -472,7 +472,7 @@ public class PopulateSubmissionViewHolder {
                                 mContext.startActivity(browserIntent);
                                 break;
                             case 4:
-                                Reddit.defaultShareText(Html.fromHtml(submission.getTitle()) + "\n" + submission.getUrl(), mContext);
+                                Reddit.defaultShareText(Html.fromHtml(submission.getTitle()).toString(), submission.getUrl(), mContext);
                                 break;
                             case 12:
                                 reportReason = "";
@@ -514,7 +514,7 @@ public class PopulateSubmissionViewHolder {
 
                                 break;
                             case 8:
-                                Reddit.defaultShareText(Html.fromHtml(submission.getTitle()) + " \n" + "https://reddit.com" + submission.getPermalink(), mContext);
+                                Reddit.defaultShareText(Html.fromHtml(submission.getTitle()).toString(), "https://reddit.com" + submission.getPermalink(), mContext);
                                 break;
                             case 6: {
                                 ClipboardManager clipboard = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);


### PR DESCRIPTION
Other android applications can understand a share Intent's title passed in via the EXTRA_SUBJECT parameter instead of concatenating them to EXTRA_TEXT