### PR TITLE
Prevent app from restarting when debug or cAT package is installed

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/CheckInstall.java
+++ b/app/src/main/java/me/ccrama/redditslide/CheckInstall.java
@@ -15,7 +15,7 @@ public class CheckInstall extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String packageName = intent.getDataString();
-        if (((packageName.contains("me.ccrama") || packageName.contains("ccrama.me"))) && !packageName.equals("me.ccrama.redditslide")){
+        if (packageName.contains("me.ccrama.") && !packageName.startsWith("me.ccrama.redditslide")) {
             ProcessPhoenix.triggerRebirth(context.getApplicationContext());
         }
     }


### PR DESCRIPTION
Fixes #1502

Not sure what the ccrama.me was for, AFAIK that will never be in a packagename unless you have something like me.ccrama.me, so I'll open a PR for it.

Also - what's the purpose of this class?