### PR TITLE
Added Medium font setting for titles

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsFont.java
@@ -187,6 +187,9 @@ public class SettingsFont extends BaseActivityAnim {
             case Bold:
                 ((RobotoRadioButton) findViewById(R.id.sbold)).setChecked(true);
                 break;
+            case Medium:
+                ((RobotoRadioButton) findViewById(R.id.smed)).setChecked(true);
+                break;
             case System:
                 ((RobotoRadioButton) findViewById(R.id.snone)).setChecked(true);
                 break;
@@ -224,6 +227,15 @@ public class SettingsFont extends BaseActivityAnim {
                 if (isChecked) {
                     SettingsTheme.changed = true;
                     new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Bold);
+                }
+            }
+        });
+        ((RobotoRadioButton) findViewById(R.id.smed)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (isChecked) {
+                    SettingsTheme.changed = true;
+                    new FontPreferences(SettingsFont.this).setTitleFont(FontPreferences.FontTypeTitle.Medium);
                 }
             }
         });

--- a/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
+++ b/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
@@ -144,6 +144,7 @@ public class FontPreferences {
         Light(RobotoTypefaceManager.Typeface.ROBOTO_LIGHT, "Light"),
         Regular(RobotoTypefaceManager.Typeface.ROBOTO_REGULAR, "Regular"),
         Bold(RobotoTypefaceManager.Typeface.ROBOTO_BOLD, "Bold"),
+        Medium(RobotoTypefaceManager.Typeface.ROBOTO_MEDIUM, "Medium"),
         CondensedBold(RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_BOLD, "Condensed Bold"),
         System(-1, "System");
 

--- a/app/src/main/res/layout/activity_settings_font.xml
+++ b/app/src/main/res/layout/activity_settings_font.xml
@@ -219,6 +219,7 @@
                     android:textColor="?attr/font"
                     android:text="@string/settings_font_regular"
                     app:typeface="roboto_regular" />
+
                 <com.devspark.robototextview.widget.RobotoRadioButton
                     android:id="@+id/sbold"
                     android:layout_width="match_parent"
@@ -227,6 +228,16 @@
                     android:textColor="?attr/font"
                     android:text="@string/settings_font_bold"
                     app:typeface="roboto_bold" />
+
+                <com.devspark.robototextview.widget.RobotoRadioButton
+                    android:id="@+id/smed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:selectableItemBackground"
+                    android:textColor="?attr/font"
+                    android:text="@string/settings_font_medium"
+                    app:typeface="roboto_medium" />
+
                 <com.devspark.robototextview.widget.RobotoRadioButton
                     android:id="@+id/sregl"
                     android:layout_width="match_parent"
@@ -271,6 +282,7 @@
                     android:background="?android:selectableItemBackground"
                     android:text="@string/settings_font_condensed_light"
                     app:typeface="roboto_condensed_light" />
+
                 <com.devspark.robototextview.widget.RobotoRadioButton
                     android:id="@+id/scondb"
                     android:layout_width="match_parent"
@@ -279,6 +291,7 @@
                     android:background="?android:selectableItemBackground"
                     android:text="@string/settings_font_condensed_bold"
                     app:typeface="roboto_condensed_bold" />
+
                 <com.devspark.robototextview.widget.RobotoRadioButton
                     android:id="@+id/snone"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -22,6 +22,7 @@
     <string name="settings_font_slab_light">Slab Light</string>
     <string name="settings_font_light">Light</string>
     <string name="settings_font_bold">Bold</string>
+    <string name="settings_font_medium">Medium</string>
     <string name="settings_font_condensed_bold">Condensed Bold</string>
     <string name="settings_general_force_en">Force English language</string>
     <string name="settings_general_force_en_desc">Applies everywhere</string>


### PR DESCRIPTION
I think we should remove "Bold" and replace it with "Medium" entirely--but that's up to you.

Medium is a middle-ground between Bold and Regular. I think it looks more "material-y"