### PR TITLE
Travis CI: don't compile Dev build flavour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 
 env:
   global:
-    - MALLOC_ARENA_MAX=2
+  - MALLOC_ARENA_MAX=2
 
 android:
   components:
@@ -23,4 +23,4 @@ jdk:
 - oraclejdk8
 
 script:
-- ./gradlew build -PdisablePreDex
+- ./gradlew -PdisablePreDex assembleProd lintProd{With,No}GPlay{Debug,Release} testProd{With,No}GPlay{Debug,Release}UnitTest


### PR DESCRIPTION
drops about 5 minutes off the run times for CI

Only difference between Prod and Release is the minSdkVersion, and I can't think of a good reason to run CI on a higher version than we're using for releases