### PR TITLE
Lots of cleanup with Settings

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
@@ -63,7 +63,7 @@ public class CommentsScreen extends BaseActivityAnim implements SubmissionDispla
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         int keyCode = event.getKeyCode();
-        if (SettingValues.commentNav) {
+        if (SettingValues.commentVolumeNav) {
             switch (keyCode) {
                 case KeyEvent.KEYCODE_VOLUME_UP:
                     return ((CommentPage) comments.getCurrentFragment()).onKeyDown(keyCode, event);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
@@ -64,7 +64,7 @@ public class CommentsScreenSingle extends BaseActivityAnim {
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         int keyCode = event.getKeyCode();
-        if (SettingValues.commentNav) {
+        if (SettingValues.commentVolumeNav) {
 
             switch (keyCode) {
                 case KeyEvent.KEYCODE_VOLUME_UP:

--- a/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
@@ -20,7 +20,7 @@ import me.ccrama.redditslide.Views.CreateCardView;
 /**
  * Created by ccrama on 9/17/2015.
  */
-public class EditCardsLayout extends BaseActivity {
+public class EditCardsLayout extends BaseActivityAnim {
     @Override
     public void onCreate(Bundle savedInstance) {
         overrideRedditSwipeAnywhere();

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -2437,9 +2437,9 @@ public class MainActivity extends BaseActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (pager != null && SettingValues.commentPager && pager.getCurrentItem() == toOpenComments && SettingValues.commentNav && pager.getAdapter() instanceof OverviewPagerAdapterComment) {
+        if (pager != null && SettingValues.commentPager && pager.getCurrentItem() == toOpenComments && SettingValues.commentVolumeNav && pager.getAdapter() instanceof OverviewPagerAdapterComment) {
             int keyCode = event.getKeyCode();
-            if (SettingValues.commentNav) {
+            if (SettingValues.commentVolumeNav) {
                 switch (keyCode) {
                     case KeyEvent.KEYCODE_VOLUME_UP:
                         return ((OverviewPagerAdapterComment) pager.getAdapter()).mCurrentComments.onKeyDown(keyCode, event);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -348,7 +348,7 @@ public class Settings extends BaseActivity {
             });
         } else {
             findViewById(R.id.reddit_settings).setEnabled(false);
-            findViewById(R.id.reddit_settings).setAlpha((float) 0.25);
+            findViewById(R.id.reddit_settings).setAlpha(0.25f);
         }
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsComments.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsComments.java
@@ -16,13 +16,23 @@ public class SettingsComments extends BaseActivityAnim {
         setContentView(R.layout.activity_settings_comments);
         setupAppBar(R.id.toolbar, R.string.settings_title_comments, true, true);
         {
-            SwitchCompat single = (SwitchCompat) findViewById(R.id.fastscroll);
+            SwitchCompat single = (SwitchCompat) findViewById(R.id.commentnav);
             single.setChecked(SettingValues.fastscroll);
             single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                     SettingValues.fastscroll = isChecked;
                     SettingValues.prefs.edit().putBoolean(SettingValues.PREF_FASTSCROLL, isChecked).apply();
+
+                    //Disable autohidenav if commentNav isn't checked
+                    if (!isChecked) {
+                        findViewById(R.id.autohidenav).setEnabled(false);
+                        ((SwitchCompat) findViewById(R.id.autohidenav)).setChecked(SettingValues.commentAutoHide);
+                        findViewById(R.id.auto_hide_the_comment_nav_bar_text).setAlpha(0.25f);
+                    } else {
+                        findViewById(R.id.autohidenav).setEnabled(true);
+                        findViewById(R.id.auto_hide_the_comment_nav_bar_text).setAlpha(1f);
+                    }
                 }
             });
         }
@@ -73,6 +83,12 @@ public class SettingsComments extends BaseActivityAnim {
         {
             SwitchCompat single = (SwitchCompat) findViewById(R.id.autohidenav);
             single.setChecked(SettingValues.commentAutoHide);
+
+            if (!((SwitchCompat) findViewById(R.id.commentnav)).isChecked()) {
+                single.setEnabled(false);
+                findViewById(R.id.auto_hide_the_comment_nav_bar_text).setAlpha(0.25f);
+            }
+
             single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -124,20 +140,18 @@ public class SettingsComments extends BaseActivityAnim {
             }
         });
         {
-            SwitchCompat single = (SwitchCompat) findViewById(R.id.navcomments);
-
-            single.setChecked(SettingValues.commentNav);
+            SwitchCompat single = (SwitchCompat) findViewById(R.id.volumenavcomments);
+            single.setChecked(SettingValues.commentVolumeNav);
             single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                    SettingValues.commentNav = isChecked;
+                    SettingValues.commentVolumeNav = isChecked;
                     SettingValues.prefs.edit().putBoolean(SettingValues.PREF_COMMENT_NAV, isChecked).apply();
                 }
             });
         }
         {
             SwitchCompat single = (SwitchCompat) findViewById(R.id.cropimage);
-
             single.setChecked(SettingValues.cropImage);
             single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
@@ -265,7 +265,7 @@ public class SettingsGeneral extends BaseActivityAnim implements FolderChooserDi
             });
         } else {
             findViewById(R.id.notifications).setEnabled(false);
-            findViewById(R.id.notifications).setAlpha((float) 0.25);
+            findViewById(R.id.notifications).setAlpha(0.25f);
         }
 
         ((TextView) findViewById(R.id.sorting_current)).setText(Reddit.getSortingStrings(getBaseContext())[Reddit.getSortingId("")]);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsReddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsReddit.java
@@ -89,10 +89,12 @@ public class SettingsReddit extends BaseActivityAnim {
 
                             if (isChecked) {
                                 (findViewById(R.id.nsfwrpev)).setEnabled(true);
-                                ((SwitchCompat) findViewById(R.id.nsfwrpev)).setChecked(Boolean.parseBoolean(prefs.data("no_profanity")));
+                                findViewById(R.id.nsfwrpev_text).setAlpha(1f);
+                                ((SwitchCompat) findViewById(R.id.nsfwrpev)).setChecked(true);
                             } else {
                                 ((SwitchCompat) findViewById(R.id.nsfwrpev)).setChecked(true);
                                 (findViewById(R.id.nsfwrpev)).setEnabled(false);
+                                findViewById(R.id.nsfwrpev_text).setAlpha(0.25f);
                             }
                         }
                     });
@@ -103,6 +105,7 @@ public class SettingsReddit extends BaseActivityAnim {
                     if (!((SwitchCompat) findViewById(R.id.nsfwcontent)).isChecked()) {
                         thumbnails.setChecked(true);
                         thumbnails.setEnabled(false);
+                        findViewById(R.id.nsfwrpev_text).setAlpha(0.25f);
                     } else {
                         thumbnails.setChecked(Boolean.parseBoolean(prefs.data("no_profanity")));
                     }
@@ -119,7 +122,6 @@ public class SettingsReddit extends BaseActivityAnim {
                 //Thumbnail type
                 String thumbType = String.valueOf(prefs.data("media"));
                 ((TextView) findViewById(R.id.thumbtext)).setText(thumbType.equals("on") ? getString(R.string.thumb_type_always) : thumbType.equals("off") ? getString(R.string.thumb_type_off) : getString(R.string.thumb_type_sub));
-
 
                 findViewById(R.id.thumbmode).setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsTheme.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsTheme.java
@@ -29,7 +29,7 @@ import uz.shift.colorpicker.OnColorChangedListener;
 /**
  * Created by ccrama on 3/5/2015.
  */
-public class SettingsTheme extends BaseActivity {
+public class SettingsTheme extends BaseActivityAnim {
     public static boolean changed;
 
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -298,7 +298,7 @@ public class CommentPage extends Fragment {
         }
         if (fab != null)
             fab.show();
-        toolbarScroll = new ToolbarScrollHideHandler(toolbar, v.findViewById(R.id.header), v.findViewById(R.id.progress), SettingValues.commentAutoHide?v.findViewById(R.id.fastscroll):null) {
+        toolbarScroll = new ToolbarScrollHideHandler(toolbar, v.findViewById(R.id.header), v.findViewById(R.id.progress), SettingValues.commentAutoHide?v.findViewById(R.id.commentnav):null) {
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);
@@ -321,7 +321,7 @@ public class CommentPage extends Fragment {
         };
 
         rv.addOnScrollListener(toolbarScroll);
-        fastScroll = v.findViewById(R.id.fastscroll);
+        fastScroll = v.findViewById(R.id.commentnav);
         if (!SettingValues.fastscroll) {
             fastScroll.setVisibility(View.GONE);
         } else {

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -72,7 +72,7 @@ public class SettingValues {
     public static final String SYNCCIT_NAME = "SYNCCIT_NAME";
     public static final String PREF_BLUR = "blur";
     public static final String PREF_ALBUM_SWIPE = "albumswipe";
-    public static final String PREF_COMMENT_NAV = "commentNav";
+    public static final String PREF_COMMENT_NAV = "commentVolumeNav";
     public static final String PREF_COLOR_COMMENT_DEPTH = "colorCommentDepth";
 
     public static CreateCardView.CardEnum defaultCardView;
@@ -116,7 +116,7 @@ public class SettingValues {
     public static boolean gif;
     public static boolean colorCommentDepth;
     public static boolean web;
-    public static boolean commentNav;
+    public static boolean commentVolumeNav;
     public static boolean postNav;
     public static boolean exit;
     public static boolean cropImage;
@@ -173,7 +173,7 @@ public class SettingValues {
         blurCheck = prefs.getBoolean(PREF_BLUR, false);
         overrideLanguage = prefs.getBoolean(PREF_OVERRIDE_LANGUAGE, false);
 
-        commentNav = prefs.getBoolean(PREF_COMMENT_NAV, false);
+        commentVolumeNav = prefs.getBoolean(PREF_COMMENT_NAV, false);
         postNav = false;
 
         fab = prefs.getBoolean(PREF_FAB, true);

--- a/app/src/main/res/layout/activity_settings_comments.xml
+++ b/app/src/main/res/layout/activity_settings_comments.xml
@@ -306,20 +306,64 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/settings_fastscroll"
+                        android:text="@string/settings_commentnav"
                         android:textColor="?attr/font"
                         android:textSize="16sp" />
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:alpha=".86"
-                        android:text="@string/settings_fastscroll_description"
+                        android:text="@string/settings_commentnav_description"
                         android:textColor="?attr/font"
                         android:textSize="13sp" />
                 </LinearLayout>
 
                 <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/fastscroll"
+                    android:id="@+id/commentnav"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?android:selectableItemBackground"
+                    android:backgroundTint="?attr/tint"
+                    android:button="@null"
+                    android:buttonTint="?attr/tint"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/font"
+                    android:textColorHint="?attr/font" />
+            </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:background="?attr/tint"
+                android:alpha=".25"
+                android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginEnd="42dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/auto_hide_the_comment_nav_bar_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/auto_hide_the_comment_nav_bar"
+                        android:textColor="?attr/font"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/autohidenav"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:background="?android:selectableItemBackground"
@@ -362,7 +406,7 @@
                 </LinearLayout>
 
                 <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/navcomments"
+                    android:id="@+id/volumenavcomments"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:background="?android:selectableItemBackground"
@@ -373,48 +417,7 @@
                     android:textColor="?attr/font"
                     android:textColorHint="?attr/font" />
             </RelativeLayout>
-            <View
-                android:layout_width="match_parent"
-                android:background="?attr/tint"
-                android:alpha=".25"
-                android:layout_height="0.25dp"/>
 
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:background="?android:selectableItemBackground"
-                android:paddingEnd="16dp"
-                android:paddingStart="16dp">
-
-                <LinearLayout
-                    android:layout_marginEnd="42dp"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/auto_hide_the_comment_nav_bar"
-                        android:textColor="?attr/font"
-                        android:textSize="16sp" />
-                </LinearLayout>
-
-                <android.support.v7.widget.SwitchCompat
-                    android:id="@+id/autohidenav"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:selectableItemBackground"
-                    android:backgroundTint="?attr/tint"
-                    android:button="@null"
-                    android:buttonTint="?attr/tint"
-                    android:hapticFeedbackEnabled="true"
-                    android:textColor="?attr/font"
-                    android:textColorHint="?attr/font" />
-            </RelativeLayout>
             <TextView
                 style="@style/TextAppearance.AppCompat.Body2"
                 android:id="@+id/collapseCommentsHeader"

--- a/app/src/main/res/layout/activity_settings_reddit.xml
+++ b/app/src/main/res/layout/activity_settings_reddit.xml
@@ -11,6 +11,7 @@
         android:orientation="vertical">
 
         <include layout="@layout/settings_toolbar" />
+
         <TextView
             android:layout_width="match_parent"
             android:padding="16dp"
@@ -18,6 +19,7 @@
             android:alpha=".5"
             android:text="@string/settings_reddit_description"
             android:layout_height="wrap_content" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -94,6 +96,7 @@
                     android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/nsfwrpev_text"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/settings_disable_nsfw_photo"

--- a/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
+++ b/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/activity_background">
-
 
     <me.ccrama.redditslide.Views.GeneralSwipeRefreshLayout
         android:id="@+id/activity_main_swipe_refresh_layout"
@@ -19,7 +17,6 @@
             android:fadeScrollbars="true"
             android:orientation="vertical"
             android:scrollbars="vertical" />
-
     </me.ccrama.redditslide.Views.GeneralSwipeRefreshLayout>
 
     <LinearLayout
@@ -92,11 +89,10 @@
             android:indeterminate="true"
             android:max="100"
             android:progress="0" />
-
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/fastscroll"
+        android:id="@+id/commentnav"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
@@ -116,8 +112,7 @@
             style="@style/Ripple.List"
             android:layout_width="48dp"
             android:layout_height="36dp"
-            android:padding="8dp
-            "
+            android:padding="8dp"
             app:srcCompat="@drawable/nav" />
 
         <ImageView
@@ -138,7 +133,6 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/activity_vertical_margin"
         app:elevation="4dp"
-
         app:fabSize="normal"
         app:layout_anchorGravity="bottom|right|end"
         app:layout_behavior="me.ccrama.redditslide.Views.AutoHideFAB"

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -367,7 +367,7 @@
   <string name="settings_store_history">Verlauf speichern</string>
   <string name="settings_store_nsfw_history">NSFW Verlauf speichern</string>
   <string name="settings_confirm_exit">Beenden von Slide bestätigen</string>
-  <string name="settings_fastscroll">Zwischen Kommentaren navigieren</string>
+  <string name="settings_commentnav">Zwischen Kommentaren navigieren</string>
   <string name="share_link">Link teilen</string>
   <string name="posts_hidden_forever">Beiträge für immer ausgeblendet</string>
   <string name="share_image">Bild teilen</string>
@@ -552,7 +552,7 @@
   <string name="fab_disabled">Deaktiviert</string>
   <string name="handling_internal_browser">In internem Browser öffnen</string>
   <string name="handling_external_browser">In externem Browser öffnen</string>
-  <string name="settings_fastscroll_description">Aktiviert eine Leiste mit Navigationspfeilen auf der Unterseite</string>
+  <string name="settings_commentnav_description">Aktiviert eine Leiste mit Navigationspfeilen auf der Unterseite</string>
   <string name="settings_comment_collapse">Kommentare komplett zusammenklappen</string>
   <string name="settings_comment_collapse_description">Deaktiviert Animationen in den Kommentaren</string>
   <string name="settings_comment_collapse_default">Untergeordnete Kommentare standardmäßig zusammenklappen</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -367,7 +367,7 @@
   <string name="settings_store_history">Save history</string>
   <string name="settings_store_nsfw_history">Save NSFW history</string>
   <string name="settings_confirm_exit">Confirm exit dialog</string>
-  <string name="settings_fastscroll">Navigate between parent comments</string>
+  <string name="settings_commentnav">Navigate between parent comments</string>
   <string name="share_link">Share link</string>
   <string name="posts_hidden_forever">Posts hidden forever</string>
   <string name="share_image">Share image</string>
@@ -553,7 +553,7 @@
   <string name="fab_disabled">Disabled</string>
   <string name="handling_internal_browser">Use internal browser</string>
   <string name="handling_external_browser">Use external browser</string>
-  <string name="settings_fastscroll_description">Enables a bottom bar with navigation arrows</string>
+  <string name="settings_commentnav_description">Enables a bottom bar with navigation arrows</string>
   <string name="settings_comment_collapse">Fully collapse comments</string>
   <string name="settings_comment_collapse_description">Also disables comment animations</string>
   <string name="settings_comment_collapse_default">Collapse child comments by default</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -362,7 +362,7 @@
   <string name="settings_store_history">Guardar historial</string>
   <string name="settings_store_nsfw_history">Guardar historial NSFW</string>
   <string name="settings_confirm_exit">Mensaje de confirmación de salida</string>
-  <string name="settings_fastscroll">Navegar entre comentarios parejos</string>
+  <string name="settings_commentnav">Navegar entre comentarios parejos</string>
   <string name="share_link">Compartir enlace</string>
   <string name="posts_hidden_forever">Ocultar posts para siempre</string>
   <string name="share_image">Compartir imagen</string>
@@ -522,7 +522,7 @@
   <string name="fab_disabled">Deshabilitado</string>
   <string name="handling_internal_browser">Usar navegador web interno</string>
   <string name="handling_external_browser">Usar navegador web externo</string>
-  <string name="settings_fastscroll_description">Activa una barra inferior con flechas de navegación</string>
+  <string name="settings_commentnav_description">Activa una barra inferior con flechas de navegación</string>
   <string name="settings_comment_collapse">Colapsar los comentarios completamente</string>
   <string name="settings_comment_collapse_description">También desactiva animaciones de comentarios</string>
   <string name="settings_comment_collapse_default">Ocultar comentarios hijos predeterminado</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -313,7 +313,7 @@
   <string name="settings_store_history">Sauvegarder l\'historique</string>
   <string name="settings_store_nsfw_history">Enregistrer l\'historique NSFW</string>
   <string name="settings_confirm_exit">Confirmation de fermeture</string>
-  <string name="settings_fastscroll">Naviguer entre les commentaires parents</string>
+  <string name="settings_commentnav">Naviguer entre les commentaires parents</string>
   <string name="share_link">Partager un Lien</string>
   <string name="posts_hidden_forever">Publications masquées pour toujours</string>
   <string name="share_image">Partager l\'image</string>

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -276,7 +276,7 @@
   <string name="settings_notification_short">Provjeri svakih %1$s</string>
   <string name="settings_disable_nsfw_photo">Sakrij sve NSFW fotografije</string>
   <string name="settings_confirm_exit">Dijaloški prozor za izlaz</string>
-  <string name="settings_fastscroll">Navigacija između nadređenih komentara</string>
+  <string name="settings_commentnav">Navigacija između nadređenih komentara</string>
   <string name="share_link">Podijeli link</string>
   <string name="posts_hidden_forever">Uvijek sakriveni postovi</string>
   <string name="share_image">Podijeli sliku</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -348,7 +348,7 @@
   <string name="settings_store_history">Salva cronologia</string>
   <string name="settings_store_nsfw_history">Salva cronologia NSFW</string>
   <string name="settings_confirm_exit">Dialogo di conferma all\'uscita</string>
-  <string name="settings_fastscroll">Navigazione rapida tra i commenti genitori</string>
+  <string name="settings_commentnav">Navigazione rapida tra i commenti genitori</string>
   <string name="share_link">Condividi link</string>
   <string name="posts_hidden_forever">Post nascosti per sempre</string>
   <string name="share_image">Condividi immagine</string>
@@ -509,7 +509,7 @@
   <string name="fab_disabled">Disabilitato</string>
   <string name="handling_internal_browser">Usa browser integrato</string>
   <string name="handling_external_browser">Usa browser esterno</string>
-  <string name="settings_fastscroll_description">Abilita una barra inferiore con frecce di navigazione</string>
+  <string name="settings_commentnav_description">Abilita una barra inferiore con frecce di navigazione</string>
   <string name="settings_comment_collapse">Nascondi interamente i commenti</string>
   <string name="settings_comment_collapse_description">Disattiva anche le animazioni dei commenti</string>
   <string name="settings_comment_collapse_default">Collassa commenti figli di default</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -346,7 +346,7 @@
   <string name="settings_store_history">履歴を保存</string>
   <string name="settings_store_nsfw_history">NSFW 履歴を保存</string>
   <string name="settings_confirm_exit">終了ダイアログを確認</string>
-  <string name="settings_fastscroll">親コメント間を移動</string>
+  <string name="settings_commentnav">親コメント間を移動</string>
   <string name="share_link">リンクを共有</string>
   <string name="posts_hidden_forever">投稿を永久に隠す</string>
   <string name="share_image">画像を共有</string>
@@ -524,7 +524,7 @@
   <string name="fab_disabled">無効</string>
   <string name="handling_internal_browser">内部ブラウザーを使用する</string>
   <string name="handling_external_browser">外部ブラウザーを使用する</string>
-  <string name="settings_fastscroll_description">最下段のナビ矢印付きバーを有効にする</string>
+  <string name="settings_commentnav_description">最下段のナビ矢印付きバーを有効にする</string>
   <string name="settings_comment_collapse">コメントを完全に折りたたむ</string>
   <string name="settings_comment_collapse_description">コメントのアニメーションも無効にします</string>
   <string name="settings_comment_collapse_default">デフォルトで子コメントを畳む</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -352,7 +352,7 @@
   <string name="settings_store_history">Geschiedenis bewaren</string>
   <string name="settings_store_nsfw_history">NSFW-geschiedenis geschiedenis bewaren</string>
   <string name="settings_confirm_exit">\"Sluiten bevestigen\"-melding</string>
-  <string name="settings_fastscroll">Navigeer tussen bovenliggende reacties</string>
+  <string name="settings_commentnav">Navigeer tussen bovenliggende reacties</string>
   <string name="share_link">Link delen</string>
   <string name="posts_hidden_forever">Berichten voor altijd verborgen</string>
   <string name="share_image">Afbeelding delen</string>
@@ -538,7 +538,7 @@
   <string name="fab_disabled">Uitgeschakeld</string>
   <string name="handling_internal_browser">Gebruik de geïntegreerde browser</string>
   <string name="handling_external_browser">Gebruik de externe browser</string>
-  <string name="settings_fastscroll_description">Toont onderaan een balk met navigatiepijlen</string>
+  <string name="settings_commentnav_description">Toont onderaan een balk met navigatiepijlen</string>
   <string name="settings_comment_collapse">Reacties volledig inklappen</string>
   <string name="settings_comment_collapse_description">Reactie-animaties ook uitschakelen</string>
   <string name="settings_comment_collapse_default">Onderliggende reacties standaard inklappen</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -352,7 +352,7 @@
   <string name="settings_store_history">Lagringshistorikk</string>
   <string name="settings_store_nsfw_history">Lagre NSFW-historikk</string>
   <string name="settings_confirm_exit">Bekreft lukking av appen</string>
-  <string name="settings_fastscroll">Hurtignavigering i kommentarer</string>
+  <string name="settings_commentnav">Hurtignavigering i kommentarer</string>
   <string name="share_link">Del lenke</string>
   <string name="posts_hidden_forever">Innlegg skjult for alltid</string>
   <string name="share_image">Del bilde</string>
@@ -538,7 +538,7 @@
   <string name="fab_disabled">Deaktivert</string>
   <string name="handling_internal_browser">Bruk intern nettleser</string>
   <string name="handling_external_browser">Bruk ekstern nettleser</string>
-  <string name="settings_fastscroll_description">Aktiverer en verktøyslinje på bunnen med navigasjonspiler</string>
+  <string name="settings_commentnav_description">Aktiverer en verktøyslinje på bunnen med navigasjonspiler</string>
   <string name="settings_comment_collapse">Kollaps kommentarer helt</string>
   <string name="settings_comment_collapse_description">Deaktiverer også kommentaranimasjoner</string>
   <string name="settings_comment_collapse_default">Kollaps barnekommentarer som standard</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -374,7 +374,7 @@
   <string name="settings_store_history">Zapisuj historię</string>
   <string name="settings_store_nsfw_history">Zapisuj historię NSFW</string>
   <string name="settings_confirm_exit">Potwierdzanie wyjścia</string>
-  <string name="settings_fastscroll">Nawigacja między nadrzędnymi komentarzami</string>
+  <string name="settings_commentnav">Nawigacja między nadrzędnymi komentarzami</string>
   <string name="share_link">Udostępnij link</string>
   <string name="posts_hidden_forever">Posty na zawsze ukryte</string>
   <string name="share_image">Udostępnij obraz</string>
@@ -568,7 +568,7 @@
   <string name="fab_disabled">Wyłączony</string>
   <string name="handling_internal_browser">Używaj wbudowanej przeglądarki</string>
   <string name="handling_external_browser">Używaj zewnętrznej przeglądarki</string>
-  <string name="settings_fastscroll_description">Włącza dolny pasek z przyciskami nawigacji</string>
+  <string name="settings_commentnav_description">Włącza dolny pasek z przyciskami nawigacji</string>
   <string name="settings_comment_collapse">Zwiń komentarze w pełni</string>
   <string name="settings_comment_collapse_description">Wyłącza również animacje komentarzy</string>
   <string name="settings_comment_collapse_default">Domyślnie zwijaj komentarze</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -367,7 +367,7 @@
   <string name="settings_store_history">Salvar histórico</string>
   <string name="settings_store_nsfw_history">Salvar NSFW no histórico</string>
   <string name="settings_confirm_exit">Confirmar saída</string>
-  <string name="settings_fastscroll">Navegar entre os comentários originais</string>
+  <string name="settings_commentnav">Navegar entre os comentários originais</string>
   <string name="share_link">Compartilhar link</string>
   <string name="posts_hidden_forever">Post oculto permanentemente</string>
   <string name="share_image">Compartilhar Imagem</string>
@@ -553,7 +553,7 @@
   <string name="fab_disabled">Desativado</string>
   <string name="handling_internal_browser">Usar navegador interno</string>
   <string name="handling_external_browser">Usar navegador externo</string>
-  <string name="settings_fastscroll_description">Permite uma barra inferior com setas de navegação</string>
+  <string name="settings_commentnav_description">Permite uma barra inferior com setas de navegação</string>
   <string name="settings_comment_collapse">Retrair comentários completamente</string>
   <string name="settings_comment_collapse_description">Também desativa animações de comentários</string>
   <string name="settings_comment_collapse_default">Retrair comentários subsequentes por padrão</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -367,7 +367,7 @@
   <string name="settings_store_history">Guardar histórico</string>
   <string name="settings_store_nsfw_history">Salvar o histórico NSFW</string>
   <string name="settings_confirm_exit">Confirmar saída</string>
-  <string name="settings_fastscroll">Navegar entre os comentários originais</string>
+  <string name="settings_commentnav">Navegar entre os comentários originais</string>
   <string name="share_link">Partilhar ligação</string>
   <string name="posts_hidden_forever">Postagens ocultas permanentemente</string>
   <string name="share_image">Partilhar imagem</string>
@@ -553,7 +553,7 @@
   <string name="fab_disabled">Desabilitado</string>
   <string name="handling_internal_browser">Usar navegador interno</string>
   <string name="handling_external_browser">Usar navegador externo</string>
-  <string name="settings_fastscroll_description">Permite uma barra inferior com setas de navegação</string>
+  <string name="settings_commentnav_description">Permite uma barra inferior com setas de navegação</string>
   <string name="settings_comment_collapse">Retrair comentários completamente</string>
   <string name="settings_comment_collapse_description">Também desativa animações de comentários</string>
   <string name="settings_comment_collapse_default">Retrair comentários subsequentes por padrão</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -282,7 +282,7 @@
   <string name="settings_notification_short">Verifică o dată la fiecare %1$s</string>
   <string name="settings_disable_nsfw_photo">Ascunde toate pozele NSFW</string>
   <string name="settings_confirm_exit">Mesajul de confirmare pentru a ieși</string>
-  <string name="settings_fastscroll">Navighează între comentariile părinte</string>
+  <string name="settings_commentnav">Navighează între comentariile părinte</string>
   <string name="share_link">Distribuie linkul</string>
   <string name="posts_hidden_forever">Post-uri ascunse pentru totdeauna</string>
   <string name="share_image">Distribuie imaginea</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -261,7 +261,7 @@
   <string name="settings_notification_short">Проверять каждые %1$s</string>
   <string name="settings_disable_nsfw_photo">Скрыть все NSFW фото</string>
   <string name="settings_confirm_exit">Подтверждать Выход</string>
-  <string name="settings_fastscroll">Перемещаться между родительскими комментариями</string>
+  <string name="settings_commentnav">Перемещаться между родительскими комментариями</string>
   <string name="share_link">Поделиться ссылкой</string>
   <string name="posts_hidden_forever">Пост скрыт навсегда</string>
   <string name="share_image">Поделиться изображением</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -275,7 +275,7 @@
   <string name="settings_notification_short">Kontrollera varje %1$s</string>
   <string name="settings_disable_nsfw_photo">Dölj alla NSFW bilder</string>
   <string name="settings_confirm_exit">Bekräfta avsluts dialog</string>
-  <string name="settings_fastscroll">Navigera mellan parent-kommentarer</string>
+  <string name="settings_commentnav">Navigera mellan parent-kommentarer</string>
   <string name="share_link">Dela länk</string>
   <string name="posts_hidden_forever">Göm dolda för alltid</string>
   <string name="share_image">Dela bild</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -301,7 +301,7 @@
   <string name="settings_disable_nsfw_photo">Tüm İİUD fotoğrafları gizle</string>
   <string name="settings_store_history">Geçmişi kaydet</string>
   <string name="settings_confirm_exit">Çıkış Onayı kutusu</string>
-  <string name="settings_fastscroll">Üst yorumlarda gezin</string>
+  <string name="settings_commentnav">Üst yorumlarda gezin</string>
   <string name="share_link">Bağlantıyı paylaş</string>
   <string name="share_image">Resmi paylaş</string>
   <string name="settings_libs">Açık kaynak kod kütüphaneleri</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -260,7 +260,7 @@
   <string name="settings_notification_short">每 %1$s 检查一次</string>
   <string name="settings_disable_nsfw_photo">隐藏所有 NSFW 图片</string>
   <string name="settings_confirm_exit">确认退出对话框</string>
-  <string name="settings_fastscroll">父评论间的导航</string>
+  <string name="settings_commentnav">父评论间的导航</string>
   <string name="share_link">分享链接</string>
   <string name="posts_hidden_forever">永久隐藏的帖子</string>
   <string name="share_image">分享图片</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -346,7 +346,7 @@
   <string name="settings_store_history">保存瀏覽歷史</string>
   <string name="settings_store_nsfw_history">保存 NSFW 瀏覽歷史</string>
   <string name="settings_confirm_exit">確認退出對話框</string>
-  <string name="settings_fastscroll">在上下層留言間移動</string>
+  <string name="settings_commentnav">在上下層留言間移動</string>
   <string name="share_link">分享連結</string>
   <string name="posts_hidden_forever">永久隱藏的貼文</string>
   <string name="share_image">分享圖片</string>
@@ -524,7 +524,7 @@
   <string name="fab_disabled">已停用</string>
   <string name="handling_internal_browser">使用內建瀏覽器</string>
   <string name="handling_external_browser">使用外部瀏覽器</string>
-  <string name="settings_fastscroll_description">啟用在畫面下方的瀏覽按鈕工具列</string>
+  <string name="settings_commentnav_description">啟用在畫面下方的瀏覽按鈕工具列</string>
   <string name="settings_comment_collapse">完全摺疊留言</string>
   <string name="settings_comment_collapse_description">同時會關閉留言動畫</string>
   <string name="settings_comment_collapse_default">預設摺疊下層留言</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -425,7 +425,7 @@
     <string name="settings_store_history">Save history</string>
     <string name="settings_store_nsfw_history">Save NSFW history</string>
     <string name="settings_confirm_exit">Confirm exit dialog</string>
-    <string name="settings_fastscroll">Navigate between parent comments</string>
+    <string name="settings_commentnav">Navigate between parent comments</string>
     <string name="share_link">Share link</string>
     <string name="posts_hidden_forever">Posts hidden forever</string>
     <string name="share_image">Share image</string>
@@ -637,7 +637,7 @@
     <string name="fab_disabled">Disabled</string>
     <string name="handling_internal_browser">Use internal browser</string>
     <string name="handling_external_browser">Use external browser</string>
-    <string name="settings_fastscroll_description">Enables a bottom bar with navigation arrows</string>
+    <string name="settings_commentnav_description">Enables a bottom bar with navigation arrows</string>
     <string name="settings_comment_collapse">Fully collapse comments</string>
     <string name="settings_comment_collapse_description">Also disables comment animations</string>
     <string name="settings_comment_collapse_default">Collapse child comments by default</string>


### PR DESCRIPTION
- Disable "auto hide nav comments bar" setting if "nav comments" setting is false
- Moved "auto hide nav comments bar" setting to be below "nav comments" setting (layout)
- Changed name of `fastscroll` id to `commentnav` id, in reference to the item in the layout (Did _NOT_ change SharedPref's name) (lots of String refactoring as well)
- Changed name of `navcomments` to `volumenavcomments`
- "Main Theme" and "Post layout" settings now animate sliding-in
- Cleanup and readability as usual