### PR TITLE
Use String.format for Strings that deal with numbers

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -2798,7 +2798,6 @@ public class MainActivity extends BaseActivity {
     }
 
     public class AsyncNotificationBadge extends AsyncTask<Void, Void, Void> {
-
         int count;
         int modCount;
 
@@ -2850,8 +2849,6 @@ public class MainActivity extends BaseActivity {
 
         @Override
         protected void onPostExecute(Void aVoid) {
-
-
             if (Authentication.mod) {
                 headerMain.findViewById(R.id.mod).setVisibility(View.VISIBLE);
                 headerMain.findViewById(R.id.mod).setOnClickListener(new View.OnClickListener() {
@@ -2866,7 +2863,6 @@ public class MainActivity extends BaseActivity {
             }
 
             if (count != -1) {
-
                 int oldCount = Reddit.appRestart.getInt("inbox", 0);
                 if (count > oldCount) {
                     final Snackbar s = Snackbar.make(mToolbar, getResources().getQuantityString(R.plurals.new_messages, count - oldCount, count - oldCount), Snackbar.LENGTH_LONG).setAction(R.string.btn_view, new View.OnClickListener() {
@@ -2887,12 +2883,16 @@ public class MainActivity extends BaseActivity {
             }
             View badge = headerMain.findViewById(R.id.count);
             if (count == 0) {
-                if (badge != null) badge.setVisibility(View.GONE);
+                if (badge != null) {
+                    badge.setVisibility(View.GONE);
+                }
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
                 notificationManager.cancelAll();
             } else if (count != -1) {
-                if (badge != null) badge.setVisibility(View.VISIBLE);
-                ((TextView) headerMain.findViewById(R.id.count)).setText(count + "");
+                if (badge != null) {
+                    badge.setVisibility(View.VISIBLE);
+                }
+                ((TextView) headerMain.findViewById(R.id.count)).setText(String.format(Locale.getDefault(), "%d", count));
             }
 
             /* Todo possibly
@@ -2902,9 +2902,8 @@ public class MainActivity extends BaseActivity {
                 if (modBadge != null) modBadge.setVisibility(View.GONE);
             } else if (modCount != -1) {
                 if (modBadge != null) modBadge.setVisibility(View.VISIBLE);
-                ((TextView) headerMain.findViewById(R.id.count)).setText(count + "");
+                ((TextView) headerMain.findViewById(R.id.count)).setText(String.format(Locale.getDefault(), "%d", count));
             }*/
         }
-
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
@@ -39,6 +39,7 @@ import net.dean.jraw.paginators.Sorting;
 import net.dean.jraw.paginators.TimePeriod;
 
 import java.util.List;
+import java.util.Locale;
 
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.ColorPreferences;
@@ -683,8 +684,8 @@ public class Profile extends BaseActivityAnim {
 
 
                     }
-                    ((TextView) dialoglayout.findViewById(R.id.commentkarma)).setText(account.getCommentKarma() + "");
-                    ((TextView) dialoglayout.findViewById(R.id.linkkarma)).setText(account.getLinkKarma() + "");
+                    ((TextView) dialoglayout.findViewById(R.id.commentkarma)).setText(String.format(Locale.getDefault(), "%d", account.getCommentKarma()));
+                    ((TextView) dialoglayout.findViewById(R.id.linkkarma)).setText(String.format(Locale.getDefault(), "%d", account.getLinkKarma()));
 
                     builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
                         @Override

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -731,7 +732,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (comment.isScoreHidden()) {
             scoreText = "[" + mContext.getString(R.string.misc_score_hidden).toUpperCase() + "]";
         } else {
-            scoreText = Integer.toString(sc + offset);
+            scoreText = String.format(Locale.getDefault(), "%d", sc + offset);
         }
         SpannableStringBuilder score = new SpannableStringBuilder(scoreText);
         int scoreColor;
@@ -2426,7 +2427,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             hiddenPersons.add(comment.getFullName());
                         if (childNumber > 0) {
                             showChildrenObject(holder.childrenNumber);
-                            ((TextView) holder.childrenNumber).setText("+" + childNumber);
+                            holder.childrenNumber.setText("+" + childNumber);
                         }
                     }
                     toCollapse.add(comment.getFullName());

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -1583,7 +1583,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         final int heightSpec2 = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
         l2.measure(widthSpec2, heightSpec2);
 
-
         mAnimator = slideAnimator((l.getMeasuredHeight() - l2.getMeasuredHeight()), l.getMeasuredHeight() - (l.getMeasuredHeight() - l2.getMeasuredHeight()), l);
 
         mAnimator.addListener(new Animator.AnimatorListener() {
@@ -2057,19 +2056,16 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         doShowMenu(baseView);
                     }
                 });
-
             } else {
-
-                if (reply.getVisibility() == View.VISIBLE)
-
+                if (reply.getVisibility() == View.VISIBLE) {
                     reply.setVisibility(View.GONE);
-                if (upvote.getVisibility() == View.VISIBLE)
-
+                }
+                if (upvote.getVisibility() == View.VISIBLE) {
                     upvote.setVisibility(View.GONE);
-                if (downvote.getVisibility() == View.VISIBLE)
-
+                }
+                if (downvote.getVisibility() == View.VISIBLE) {
                     downvote.setVisibility(View.GONE);
-
+                }
             }
 
             more.setOnClickListener(new View.OnClickListener() {
@@ -2157,7 +2153,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         } else {
             doHighlightedStuff(holder, n, baseNode, finalPos, finalPos1, false, animate);
         }
-
     }
 
     public EditText currentlyEditing;
@@ -2198,7 +2193,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         holder.itemView.setLayoutParams(params);
 
         holder.itemView.findViewById(R.id.background).setBackgroundColor(color);
-
     }
 
     public void doUnHighlighted(final CommentViewHolder holder, final Comment comment, final CommentNode baseNode, boolean animate) {
@@ -2314,14 +2308,12 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         animator.setInterpolator(new FastOutSlowInInterpolator());
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
 
-
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {
                 float value = ((Float) (animation.getAnimatedValue())).floatValue();
                 v.setAlpha(value);
                 v.setScaleX(value);
                 v.setScaleY(value);
-
             }
         });
 
@@ -2463,10 +2455,11 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         } else {
             position -= 1;
         }
-        if (position == 0)
+        if (position == 0) {
             return HEADER;
-        return (users.get(getRealPosition(position - 1)) instanceof CommentItem ? 2 : 3);
+        }
 
+        return (users.get(getRealPosition(position - 1)) instanceof CommentItem ? 2 : 3);
     }
 
     @Override
@@ -2534,7 +2527,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (!ignored.getComment().getFullName().equals(n.getComment().getFullName())) {
                 boolean parentHidden = parentHidden(ignored);
 
-                if (parentHidden) continue;
+                if (parentHidden) {
+                    continue;
+                }
 
                 String name = ignored.getComment().getFullName();
 
@@ -2551,7 +2546,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         }
                     }
                 }
-
                 i += unhideNumber(ignored, 0);
             }
         }
@@ -2561,9 +2555,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (hidden.contains(fullname)) {
                 i++;
                 hidden.remove(fullname);
-
             }
-
         }
         return i;
     }
@@ -2571,13 +2563,11 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     public int hideNumber(CommentNode n, int i) {
         for (CommentNode ignored : n.getChildren()) {
             if (!ignored.getComment().getFullName().equals(n.getComment().getFullName())) {
-
                 String fullname = ignored.getComment().getFullName();
 
                 if (!hidden.contains(fullname)) {
                     i++;
                     hidden.add(fullname);
-
                 }
                 if (ignored.hasMoreComments()) {
                     fullname = fullname + "more";
@@ -2585,7 +2575,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     if (!hidden.contains(fullname)) {
                         i++;
                         hidden.add(fullname);
-
                     }
                 }
                 i += hideNumber(ignored, 0);
@@ -2597,7 +2586,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (!hidden.contains(fullname)) {
                 i++;
                 hidden.add(fullname);
-
             }
         }
         return i;
@@ -2618,8 +2606,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     private int getHiddenCountUpTo(int location) {
         int count = 0;
         for (int i = 0; i <= location; i++) {
-            if (users.size() > i && hidden.contains(users.get(i).getName()))
+            if (users.size() > i && hidden.contains(users.get(i).getName())) {
                 count++;
+            }
         }
         return count;
     }
@@ -2647,7 +2636,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
         @Override
         protected Integer doInBackground(MoreChildItem... params) {
-
             ArrayList<CommentObject> finalData = new ArrayList<>();
             int i = 0;
 
@@ -2751,7 +2739,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     }
                 }, 2000);
             }
-
         }
 
         @Override
@@ -2855,7 +2842,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 return null;
             }
         }
-
     }
 
     public String reportReason;
@@ -2932,13 +2918,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                                } catch (ApiException e) {
                                                    e.printStackTrace();
                                                }
-
                                                return null;
                                            }
-
                                        }.execute();
-
-
                                    } else {
                                        new AsyncTask<Void, Void, Void>() {
                                            @Override
@@ -2949,14 +2931,10 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                                } catch (ApiException e) {
                                                    e.printStackTrace();
                                                }
-
                                                return null;
                                            }
-
                                        }.execute();
-
                                    }
-
                                    break;
                                case 23: {
                                    String s = "https://reddit.com" + submission.getPermalink() +
@@ -3032,9 +3010,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                            }
                                        }
                                    }
-
                                    break;
-
                                case 7:
                                    ClipboardManager clipboard = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
                                    ClipData clip = ClipData.newPlainText("Comment text", n.getBody());
@@ -3047,15 +3023,10 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                                    n.getFullName().substring(3, n.getFullName().length()) + "?context=3"
                                            , mContext);
                                    break;
-
                            }
                        }
                    }
-
         );
-
-
         b.show();
     }
-
 }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
@@ -33,6 +33,7 @@ import net.dean.jraw.models.DistinguishedStatus;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.R;
@@ -106,15 +107,16 @@ public class CommentAdapterSearch extends RecyclerView.Adapter<RecyclerView.View
         if (comment.isScoreHidden()) {
             scoreText = "[" + mContext.getString(R.string.misc_score_hidden).toUpperCase() + "]";
         } else {
-            scoreText = Integer.toString(comment.getScore() + offset);
+            scoreText = String.format(Locale.getDefault(), "%d", comment.getScore() + offset);
         }
         SpannableStringBuilder score = new SpannableStringBuilder(scoreText);
         int scoreColor;
 
 
         titleString.append(score);
-        if (!scoreText.contains("["))
+        if (!scoreText.contains("[")) {
             titleString.append(mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
+        }
         titleString.append((comment.isControversial() ? " †" : ""));
 
         titleString.append(spacer);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
@@ -185,7 +185,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
-                    LayoutInflater inflater = ((Activity) mContext).getLayoutInflater();
+                    LayoutInflater inflater = mContext.getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.postmenu, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(mContext);
                     final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
@@ -362,7 +362,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             if (comment.getTimesGilded() > 0) {
                 holder.gild.setVisibility(View.VISIBLE);
-                ((TextView) holder.gild).setText("" + comment.getTimesGilded());
+                ((TextView) holder.gild).setText(Integer.toString(comment.getTimesGilded()));
             } else if (holder.gild.getVisibility() == View.VISIBLE)
                 holder.gild.setVisibility(View.GONE);
 

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -421,7 +421,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
     private void openGif(String url) {
         if (SettingValues.gif) {
             Intent myIntent = new Intent(getContext(), MediaView.class);
-            myIntent.putExtra(MediaView.EXTRA_URL, "" + url);
+            myIntent.putExtra(MediaView.EXTRA_URL, url);
             getContext().startActivity(myIntent);
         } else {
             Reddit.defaultShare(url, getContext());

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
@@ -36,6 +36,8 @@ import net.dean.jraw.models.DistinguishedStatus;
 import net.dean.jraw.models.Submission;
 import net.dean.jraw.models.VoteDirection;
 
+import java.util.Locale;
+
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.Profile;
 import me.ccrama.redditslide.Activities.SubredditView;
@@ -82,8 +84,8 @@ public class PopulateShadowboxInfo {
         titleString.append(TimeUtils.getTimeAgo(s.getCreated().getTime(), c));
 
         desc.setText(titleString);
-        ((TextView) rootView.findViewById(R.id.comments)).setText("" + s.getCommentCount());
-        ((TextView) rootView.findViewById(R.id.score)).setText("" + s.getScore());
+        ((TextView) rootView.findViewById(R.id.comments)).setText(String.format(Locale.getDefault(), "%d", s.getCommentCount()));
+        ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
 
         if (extras) {
             final ImageView downvotebutton = (ImageView) rootView.findViewById(R.id.downvote);
@@ -102,7 +104,7 @@ public class PopulateShadowboxInfo {
                         ((TextView) rootView.findViewById(R.id.score)).setTextColor(ContextCompat.getColor(c, R.color.md_orange_500));
                         upvotebutton.setColorFilter(ContextCompat.getColor(c, R.color.md_orange_500), PorterDuff.Mode.SRC_ATOP);
                         ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.BOLD);
-                        ((TextView) rootView.findViewById(R.id.score)).setText("" + (s.getScore() + (s.getAuthor().equals(Authentication.name) ? 0 : 1)));
+                        ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", (s.getScore() + ((s.getAuthor().equals(Authentication.name)) ? 0 : 1))));
                         downvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
                         break;
                     }
@@ -110,13 +112,13 @@ public class PopulateShadowboxInfo {
                         ((TextView) rootView.findViewById(R.id.score)).setTextColor(ContextCompat.getColor(c, R.color.md_blue_500));
                         downvotebutton.setColorFilter(ContextCompat.getColor(c, R.color.md_blue_500), PorterDuff.Mode.SRC_ATOP);
                         ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.BOLD);
-                        ((TextView) rootView.findViewById(R.id.score)).setText("" + (s.getScore() + (s.getAuthor().equals(Authentication.name) ? 0 : -1)));
+                        ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", (s.getScore() + ((s.getAuthor().equals(Authentication.name)) ? 0 : -1))));
                         upvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
                         break;
                     }
                     case NO_VOTE: {
                         ((TextView) rootView.findViewById(R.id.score)).setTextColor(((TextView) rootView.findViewById(R.id.comments)).getCurrentTextColor());
-                        ((TextView) rootView.findViewById(R.id.score)).setText("" + (s.getScore()));
+                        ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
                         ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.NORMAL);
                         downvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
                         upvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
@@ -198,14 +200,14 @@ public class PopulateShadowboxInfo {
                                     AnimateHelper.setFlashAnimation(rootView, downvotebutton, ContextCompat.getColor(c, R.color.md_blue_500));
                                     ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.BOLD);
                                     final int downvoteScore = (s.getScore() == 0) ? 0 : s.getScore() - 1; //if a post is at 0 votes, keep it at 0 when downvoting
-                                    ((TextView) rootView.findViewById(R.id.score)).setText(Integer.toString(downvoteScore));
+                                    ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", downvoteScore));
                                     new Vote(false, points, c).execute(s);
                                     ActionStates.setVoteDirection(s, VoteDirection.DOWNVOTE);
                                 } else {
                                     points.setTextColor(comments.getCurrentTextColor());
                                     new Vote(points, c).execute(s);
                                     ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.NORMAL);
-                                    ((TextView) rootView.findViewById(R.id.score)).setText(Integer.toString(s.getScore()));
+                                    ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
                                     ActionStates.setVoteDirection(s, VoteDirection.NO_VOTE);
                                     downvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
                                 }
@@ -231,14 +233,14 @@ public class PopulateShadowboxInfo {
 
                                     AnimateHelper.setFlashAnimation(rootView, upvotebutton, ContextCompat.getColor(c, R.color.md_orange_500));
                                     ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.BOLD);
-                                    ((TextView) rootView.findViewById(R.id.score)).setText(Integer.toString(s.getScore() + 1));
+                                    ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore() + 1));
                                     new Vote(true, points, c).execute(s);
                                     ActionStates.setVoteDirection(s, VoteDirection.UPVOTE);
                                 } else {
                                     points.setTextColor(comments.getCurrentTextColor());
                                     new Vote(points, c).execute(s);
                                     ((TextView) rootView.findViewById(R.id.score)).setTypeface(null, Typeface.NORMAL);
-                                    ((TextView) rootView.findViewById(R.id.score)).setText(Integer.toString(s.getScore()));
+                                    ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
                                     ActionStates.setVoteDirection(s, VoteDirection.NO_VOTE);
                                     upvotebutton.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
                                 }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -49,6 +49,7 @@ import net.dean.jraw.models.VoteDirection;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import me.ccrama.redditslide.ActionStates;
@@ -251,7 +252,7 @@ public class PopulateSubmissionViewHolder {
 
             Intent myIntent = new Intent(contextActivity, MediaView.class);
 
-            myIntent.putExtra(MediaView.EXTRA_URL, "" + submission.getUrl());
+            myIntent.putExtra(MediaView.EXTRA_URL, submission.getUrl());
 
             if (submission.getDataNode().has("preview") && submission.getDataNode().get("preview").get("images").get(0).get("source").has("height")) { //Load the preview image which has probably already been cached in memory instead of the direct link
                 String previewUrl = submission.getDataNode().get("preview").get("images").get(0).get("source").get("url").asText();
@@ -1336,16 +1337,16 @@ public class PopulateSubmissionViewHolder {
             }
         });
 
-        int commentCount = submission.getCommentCount();
-        int more = LastComments.commentsSince(submission);
-        holder.comments.setText("" + commentCount + ((more != 0 && SettingValues.commentLastVisit) ? " (" + (more > 0 ? "+" : "") + more + ")" : ""));
-        String scoreRatio = SettingValues.upvotePercentage && full && submission.getUpvoteRatio() != null ? " (" + (int) (submission.getUpvoteRatio() * 100) + "%)" : "";
-        holder.score.setText("" + submission.getScore());
+        final int commentCount = submission.getCommentCount();
+        final int more = LastComments.commentsSince(submission);
+        holder.comments.setText(String.format(Locale.getDefault(), "%d %s", commentCount, ((more != 0 && SettingValues.commentLastVisit) ? "(" + ((more > 0) ? "+" : "") + more + ")" : "")));
+        String scoreRatio = (SettingValues.upvotePercentage && full && submission.getUpvoteRatio() != null) ? "(" + (int)(submission.getUpvoteRatio() * 100) + "%)" : "";
+        holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
         if (!scoreRatio.isEmpty()) {
             TextView percent = ((TextView) holder.itemView.findViewById(R.id.percent));
             percent.setVisibility(View.VISIBLE);
             percent.setText(scoreRatio);
-            double numb = (submission.getUpvoteRatio());
+            final double numb = (submission.getUpvoteRatio());
             if (numb <= .5) {
                 if (numb <= .1)
                     percent.setTextColor(ContextCompat.getColor(mContext, R.color.md_blue_500));
@@ -1378,7 +1379,7 @@ public class PopulateSubmissionViewHolder {
                 holder.score.setTextColor(ContextCompat.getColor(mContext, R.color.md_orange_500));
                 upvotebutton.setColorFilter(ContextCompat.getColor(mContext, R.color.md_orange_500), PorterDuff.Mode.SRC_ATOP);
                 holder.score.setTypeface(null, Typeface.BOLD);
-                holder.score.setText("" + (submission.getScore()));
+                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                 downvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                 break;
             }
@@ -1386,13 +1387,13 @@ public class PopulateSubmissionViewHolder {
                 holder.score.setTextColor(ContextCompat.getColor(mContext, R.color.md_blue_500));
                 downvotebutton.setColorFilter(ContextCompat.getColor(mContext, R.color.md_blue_500), PorterDuff.Mode.SRC_ATOP);
                 holder.score.setTypeface(null, Typeface.BOLD);
-                holder.score.setText("" + (submission.getScore() + (submission.getAuthor().equals(Authentication.name) || submission.getScore() == 0 ? 0 : -1)));
+                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore() + (submission.getAuthor().equals(Authentication.name) || (submission.getScore() == 0) ? 0 : -1)));
                 upvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                 break;
             }
             case NO_VOTE: {
                 holder.score.setTextColor(holder.comments.getCurrentTextColor());
-                holder.score.setText("" + (submission.getScore()));
+                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                 holder.score.setTypeface(null, Typeface.NORMAL);
                 downvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                 upvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
@@ -1595,14 +1596,14 @@ public class PopulateSubmissionViewHolder {
                                 AnimateHelper.setFlashAnimation(holder.itemView, downvotebutton, ContextCompat.getColor(mContext, R.color.md_blue_500));
                                 holder.score.setTypeface(null, Typeface.BOLD);
                                 final int downvoteScore = (submission.getScore() == 0) ? 0 : submission.getScore() - 1; //if a post is at 0 votes, keep it at 0 when downvoting
-                                holder.score.setText(Integer.toString(downvoteScore));
+                                holder.score.setText(String.format(Locale.getDefault(), "%d", downvoteScore));
                                 new Vote(false, points, mContext).execute(submission);
                                 ActionStates.setVoteDirection(submission, VoteDirection.DOWNVOTE);
                             } else {
                                 points.setTextColor(comments.getCurrentTextColor());
                                 new Vote(points, mContext).execute(submission);
                                 holder.score.setTypeface(null, Typeface.NORMAL);
-                                holder.score.setText(Integer.toString(submission.getScore()));
+                                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                                 ActionStates.setVoteDirection(submission, VoteDirection.NO_VOTE);
                                 downvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                             }
@@ -1632,26 +1633,26 @@ public class PopulateSubmissionViewHolder {
 
                                 AnimateHelper.setFlashAnimation(holder.itemView, upvotebutton, ContextCompat.getColor(mContext, R.color.md_orange_500));
                                 holder.score.setTypeface(null, Typeface.BOLD);
-                                holder.score.setText(Integer.toString(submission.getScore() + 1));
+                                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore() + 1));
                                 new Vote(true, points, mContext).execute(submission);
                                 ActionStates.setVoteDirection(submission, VoteDirection.UPVOTE);
                             } else {
                                 points.setTextColor(comments.getCurrentTextColor());
                                 new Vote(points, mContext).execute(submission);
                                 holder.score.setTypeface(null, Typeface.NORMAL);
-                                holder.score.setText(Integer.toString(submission.getScore()));
+                                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                                 ActionStates.setVoteDirection(submission, VoteDirection.NO_VOTE);
                                 upvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                             }
-                            if (!full && !SettingValues.actionbarVisible)
+                            if (!full && !SettingValues.actionbarVisible) {
                                 CreateCardView.toggleActionbar(holder.itemView);
+                            }
                         }
                     });
                 }
             } else {
                 upvotebutton.setVisibility(View.GONE);
                 downvotebutton.setVisibility(View.GONE);
-
             }
         } catch (Exception ignored) {
             ignored.printStackTrace();
@@ -1662,8 +1663,9 @@ public class PopulateSubmissionViewHolder {
             holder.body.setAlpha(0.54f);
         } else {
             holder.title.setAlpha(1f);
-            if (!full)
+            if (!full) {
                 holder.body.setAlpha(1f);
+            }
         }
     }
 


### PR DESCRIPTION
- Will now format numbers to their Locale (For example: 123,456.789 in US locale; 123'456.789 in German locale); this is also _slightly_ more efficient than performing an empty String concat (i.e `"" + intValue`)
- General code cleanup and readability improvements


Only place I didn't do this formatting was in regards to gilding. That will still always show `★ {US locale int}`