### PR TITLE
Fixed voting states for Comments and Submissions

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -698,16 +698,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     public void doScoreText(CommentViewHolder holder, Comment comment, int offset) {
         String spacer = " " + mContext.getString(R.string.submission_properties_seperator_comments) + " ";
         SpannableStringBuilder titleString = new SpannableStringBuilder();
-        int sc = comment.getScore();
-
-        switch (comment.getVote()) {
-            case UPVOTE:
-                sc -= 1;
-                break;
-            case DOWNVOTE:
-                sc += 1;
-                break;
-        }
 
         SpannableStringBuilder author = new SpannableStringBuilder(" " + comment.getAuthor() + " ");
         int authorcolor = Palette.getFontColorUser(comment.getAuthor());
@@ -725,17 +715,28 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
 
         titleString.append(author);
-
         titleString.append(spacer);
 
         String scoreText;
         if (comment.isScoreHidden()) {
             scoreText = "[" + mContext.getString(R.string.misc_score_hidden).toUpperCase() + "]";
         } else {
-            scoreText = String.format(Locale.getDefault(), "%d", sc + offset);
+            scoreText = String.format(Locale.getDefault(), "%d", comment.getScore() + offset);
         }
         SpannableStringBuilder score = new SpannableStringBuilder(scoreText);
+
         int scoreColor;
+        switch (ActionStates.getVoteDirection(comment)) {
+            case UPVOTE:
+                scoreColor = (holder.textColorUp);
+                break;
+            case DOWNVOTE:
+                scoreColor = (holder.textColorDown);
+                break;
+            case NO_VOTE:
+                scoreColor = (holder.textColorRegular);
+                break;
+        }
 
         if (up.contains(comment.getFullName())) {
             scoreColor = (holder.textColorUp);
@@ -749,7 +750,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             score = new SpannableStringBuilder("0");
         }
         if (!scoreText.contains("[")) {
-            score.append(" " + mContext.getResources().getQuantityString(R.plurals.points, comment.getScore()));
+            score.append(String.format(Locale.getDefault(), " %s", mContext.getResources().getQuantityString(R.plurals.points, comment.getScore() + offset)));
         }
         score.setSpan(new ForegroundColorSpan(scoreColor), 0, score.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -1374,32 +1374,39 @@ public class PopulateSubmissionViewHolder {
                 upvotebutton.setVisibility(View.VISIBLE);
             }
         }
+
+        int offset = 0;
+        final int submissionScore = submission.getScore();
+
         switch (ActionStates.getVoteDirection(submission)) {
             case UPVOTE: {
                 holder.score.setTextColor(ContextCompat.getColor(mContext, R.color.md_orange_500));
                 upvotebutton.setColorFilter(ContextCompat.getColor(mContext, R.color.md_orange_500), PorterDuff.Mode.SRC_ATOP);
                 holder.score.setTypeface(null, Typeface.BOLD);
-                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                 downvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
+                offset = 1;
                 break;
             }
             case DOWNVOTE: {
                 holder.score.setTextColor(ContextCompat.getColor(mContext, R.color.md_blue_500));
                 downvotebutton.setColorFilter(ContextCompat.getColor(mContext, R.color.md_blue_500), PorterDuff.Mode.SRC_ATOP);
                 holder.score.setTypeface(null, Typeface.BOLD);
-                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore() + (submission.getAuthor().equals(Authentication.name) || (submission.getScore() == 0) ? 0 : -1)));
                 upvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
+                offset = -1;
                 break;
             }
             case NO_VOTE: {
                 holder.score.setTextColor(holder.comments.getCurrentTextColor());
-                holder.score.setText(String.format(Locale.getDefault(), "%d", submission.getScore()));
                 holder.score.setTypeface(null, Typeface.NORMAL);
                 downvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                 upvotebutton.setColorFilter((((holder.itemView.getTag(holder.itemView.getId())) != null && holder.itemView.getTag(holder.itemView.getId()).equals("none") || full)) ? getCurrentTintColor(mContext) : getWhiteTintColor(), PorterDuff.Mode.SRC_ATOP);
                 break;
             }
         }
+
+        //if the submission is already at 0pts, keep it at 0pts
+        final int scoreAmount = (((offset + submissionScore) < 0) ? 0 : submissionScore + offset);
+        holder.score.setText(String.format(Locale.getDefault(), "%d", scoreAmount));
 
         final ImageView hideButton = (ImageView) holder.hide;
 


### PR DESCRIPTION
Trying to fix #1595 

**Edit 1:** So, the Submission voting states seem to be fixed. The _only_ issue that exists with them is that if you open a submission (in comments) on Slide--then go to another device (not Slide) and upvote/downvote that submission from the other device--and then refresh the comments of that submission--the vote count will be correct along with the correct coloring. However, when you leave the submission's comments, the post won't have any indication it was voted on in the submission view until you refresh the submission view.
Not sure if this is worth fixing given the likeliness of that situation happening--I mean, who has two devices open to the same post simultaneously?

**Edit 2:** It feels hacky [given the `ActionStates` AND checking for values in `up`](https://github.com/Nxt3/Slide/blob/voting-state-fix/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java#L728), but this works.