### PR TITLE
Avoid recreating the layout on every configuration change

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -59,9 +59,12 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
     private int pastVisiblesItems;
 
     @NonNull
-    private RecyclerView.LayoutManager createLayoutManager(int orientation) {
-        final int numColumns;
+    private RecyclerView.LayoutManager createLayoutManager(final int numColumns) {
+        return new CatchStaggeredGridLayoutManager(numColumns, CatchStaggeredGridLayoutManager.VERTICAL);
+    }
 
+    private int getNumColumns(final int orientation) {
+        final int numColumns;
         if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT && SettingValues.dualPortrait) {
@@ -69,9 +72,7 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
         } else {
             numColumns = 1;
         }
-
-        return new CatchStaggeredGridLayoutManager(numColumns, CatchStaggeredGridLayoutManager.VERTICAL);
-
+        return numColumns;
     }
 
     @Override
@@ -81,7 +82,7 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
 
         rv = ((RecyclerView) v.findViewById(R.id.vertical_content));
         final RecyclerView.LayoutManager mLayoutManager =
-                createLayoutManager(getResources().getConfiguration().orientation);
+                createLayoutManager(getNumColumns(getResources().getConfiguration().orientation));
 
         rv.setLayoutManager(mLayoutManager);
         if (SettingValues.fab) {
@@ -306,25 +307,14 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
-
         super.onConfigurationChanged(newConfig);
-        int currentOrientation = newConfig.orientation;
 
-        int i = 0;
+        final int currentOrientation = newConfig.orientation;
 
+        final CatchStaggeredGridLayoutManager mLayoutManager =
+                (CatchStaggeredGridLayoutManager) rv.getLayoutManager();
 
-        if (rv.getAdapter() != null) {
-            int[] firstVisibleItems;
-            firstVisibleItems = ((CatchStaggeredGridLayoutManager) rv.getLayoutManager()).findFirstVisibleItemPositions(null);
-            if (firstVisibleItems != null && firstVisibleItems.length > 0) {
-                i = firstVisibleItems[0];
-            }
-        }
-        final RecyclerView.LayoutManager mLayoutManager = createLayoutManager(currentOrientation);
-        rv.setLayoutManager(mLayoutManager);
-
-        rv.getLayoutManager().scrollToPosition(i);
-
+        mLayoutManager.setSpanCount(getNumColumns(currentOrientation));
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -63,23 +63,14 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
-
         super.onConfigurationChanged(newConfig);
 
-        int i = 0;
-        if (rv.getAdapter() != null) {
-            int[] firstVisibleItems;
+        final int currentOrientation = newConfig.orientation;
 
-            firstVisibleItems = ((CatchStaggeredGridLayoutManager) rv.getLayoutManager()).findFirstVisibleItemPositions(null);
-            if (firstVisibleItems != null && firstVisibleItems.length > 0) {
-                i = firstVisibleItems[0];
-            }
-        }
+        final CatchStaggeredGridLayoutManager mLayoutManager =
+                (CatchStaggeredGridLayoutManager) rv.getLayoutManager();
 
-        final RecyclerView.LayoutManager mLayoutManager = createLayoutManager(newConfig.orientation);
-        rv.setLayoutManager(mLayoutManager);
-        rv.getLayoutManager().scrollToPosition(i);
-
+        mLayoutManager.setSpanCount(getNumColumns(currentOrientation));
     }
 
     @Override
@@ -97,7 +88,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         rv.setHasFixedSize(true);
 
         final RecyclerView.LayoutManager mLayoutManager;
-        mLayoutManager = createLayoutManager(getResources().getConfiguration().orientation);
+        mLayoutManager = createLayoutManager(getNumColumns(getResources().getConfiguration().orientation));
 
         if (!(getActivity() instanceof SubredditView)) {
             v.findViewById(R.id.back).setBackground(null);
@@ -289,9 +280,12 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
     }
 
     @NonNull
-    private RecyclerView.LayoutManager createLayoutManager(int orientation) {
-        final int numColumns;
+    private RecyclerView.LayoutManager createLayoutManager(final int numColumns) {
+        return new CatchStaggeredGridLayoutManager(numColumns, CatchStaggeredGridLayoutManager.VERTICAL);
+    }
 
+    private int getNumColumns(final int orientation) {
+        final int numColumns;
         if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT && SettingValues.dualPortrait) {
@@ -299,10 +293,9 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         } else {
             numColumns = 1;
         }
-
-        return new CatchStaggeredGridLayoutManager(numColumns, CatchStaggeredGridLayoutManager.VERTICAL);
-
+        return numColumns;
     }
+
 
     public void doAdapter() {
         mSwipeRefreshLayout.post(new Runnable() {


### PR DESCRIPTION
Doing this we don't need to keep track of the scroll position manually (StaggeredGridLayoutManager seems to take care of it). This also reduces the GPU/CPU use when doing rotations and avoids creating objects that have to be deleted by the garbage collector at some point.