### PR TITLE
Fixed intents firing twice if item is clicked rapidly

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -126,6 +126,7 @@ import me.ccrama.redditslide.Views.ToggleSwipeViewPager;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
+import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 
@@ -394,9 +395,9 @@ public class MainActivity extends BaseActivity {
                                     } else {
                                         title = getString(R.string.btn_view);
                                     }
-                                    Snackbar snack = Snackbar.make(pager, s.getTitle(), Snackbar.LENGTH_INDEFINITE).setAction(title, new View.OnClickListener() {
+                                    Snackbar snack = Snackbar.make(pager, s.getTitle(), Snackbar.LENGTH_INDEFINITE).setAction(title, new OnSingleClickListener() {
                                         @Override
-                                        public void onClick(View v) {
+                                        public void onSingleClick(View v) {
                                             Intent i = new Intent(MainActivity.this, Announcement.class);
                                             startActivity(i);
                                         }
@@ -737,9 +738,9 @@ public class MainActivity extends BaseActivity {
 
                 pinned.setVisibility(View.GONE);
 
-                submit.setOnClickListener(new View.OnClickListener() {
+                submit.setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View view) {
+                    public void onSingleClick(View view) {
                         Intent inte = new Intent(MainActivity.this, Submit.class);
                         inte.putExtra(Submit.EXTRA_SUBREDDIT, subreddit);
                         MainActivity.this.startActivity(inte);
@@ -1399,9 +1400,9 @@ public class MainActivity extends BaseActivity {
 
             drawerSubList.addHeaderView(header, null, false);
             ((TextView) header.findViewById(R.id.name)).setText(Authentication.name);
-            header.findViewById(R.id.multi).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.multi).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     if (runAfterLoad == null) {
                         Intent inte = new Intent(MainActivity.this, MultiredditOverview.class);
                         MainActivity.this.startActivity(inte);
@@ -1409,61 +1410,61 @@ public class MainActivity extends BaseActivity {
                 }
             });
 
-            header.findViewById(R.id.discover).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.discover).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Discover.class);
                     MainActivity.this.startActivity(inte);
                 }
             });
 
-            header.findViewById(R.id.prof_click).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.prof_click).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.saved).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.saved).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     inte.putExtra(Profile.EXTRA_SAVED, true);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.history).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.history).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     inte.putExtra(Profile.EXTRA_HISTORY, true);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.commented).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.commented).setOnClickListener(new OnSingleClickListener(){
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     inte.putExtra(Profile.EXTRA_COMMENT, true);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.submitted).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.submitted).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     inte.putExtra(Profile.EXTRA_SUBMIT, true);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.upvoted).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.upvoted).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Profile.class);
                     inte.putExtra(Profile.EXTRA_PROFILE, Authentication.name);
                     inte.putExtra(Profile.EXTRA_UPVOTE, true);
@@ -1471,9 +1472,9 @@ public class MainActivity extends BaseActivity {
                 }
             });
 
-            header.findViewById(R.id.submit).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.submit).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Submit.class);
                     inte.putExtra(Submit.EXTRA_SUBREDDIT, selectedSub);
                     MainActivity.this.startActivity(inte);
@@ -1584,16 +1585,16 @@ public class MainActivity extends BaseActivity {
                             LogUtil.v("Switching to " + accName);
                             if (!accName.equals(guest)) {
                                 if (!accounts.get(accName).isEmpty()) {
-                                    Authentication.authentication.edit().putString("lasttoken", accounts.get(accName)).remove("backedCreds").commit();
+                                    Authentication.authentication.edit().putString("lasttoken", accounts.get(accName)).remove("backedCreds").apply();
                                 } else {
                                     ArrayList<String> tokens = new ArrayList<>(Authentication.authentication.getStringSet("tokens", new HashSet<String>()));
-                                    Authentication.authentication.edit().putString("lasttoken", tokens.get(keys.indexOf(accName))).remove("backedCreds").commit();
+                                    Authentication.authentication.edit().putString("lasttoken", tokens.get(keys.indexOf(accName))).remove("backedCreds").apply();
                                 }
                                 Authentication.name = accName;
                             } else {
                                 Authentication.name = "LOGGEDOUT";
                                 Authentication.isLoggedIn = false;
-                                Authentication.authentication.edit().remove("lasttoken").remove("backedCreds").commit();
+                                Authentication.authentication.edit().remove("lasttoken").remove("backedCreds").apply();
                             }
 
                             UserSubscriptions.switchAccounts();
@@ -1632,23 +1633,23 @@ public class MainActivity extends BaseActivity {
                     }
                 }
             });
-            header.findViewById(R.id.add).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.add).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Login.class);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.offline).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.offline).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Reddit.appRestart.edit().putBoolean("forceoffline", true).commit();
                     Reddit.forceRestart(MainActivity.this);
                 }
             });
-            header.findViewById(R.id.inbox).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.inbox).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Inbox.class);
                     MainActivity.this.startActivityForResult(inte, INBOX_RESULT);
                 }
@@ -1739,7 +1740,6 @@ public class MainActivity extends BaseActivity {
                                                         UserSubscriptions.switchAccounts();
                                                         Reddit.forceRestart(MainActivity.this, true);
                                                     }
-
                                                 }
                                                 if (!d) {
                                                     Authentication.name = "LOGGEDOUT";
@@ -1748,7 +1748,6 @@ public class MainActivity extends BaseActivity {
                                                     UserSubscriptions.switchAccounts();
                                                     Reddit.forceRestart(MainActivity.this, true);
                                                 }
-
                                             } else {
                                                 accounts.remove(accName);
                                                 keys.remove(accName);
@@ -1756,16 +1755,14 @@ public class MainActivity extends BaseActivity {
                                         }
                                     })
                                     .setPositiveButton(R.string.btn_cancel, null).show();
-
-
                         }
                     });
                 } else {
                     t.findViewById(R.id.remove).setVisibility(View.GONE);
                 }
-                t.setOnClickListener(new View.OnClickListener() {
+                t.setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onSingleClick(View v) {
                         if (!accName.equalsIgnoreCase(Authentication.name)) {
                             if (!accName.equals(guest)) {
                                 if (!accounts.get(accName).isEmpty()) {
@@ -1786,16 +1783,16 @@ public class MainActivity extends BaseActivity {
             }
 
 
-            header.findViewById(R.id.add).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.add).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Login.class);
                     MainActivity.this.startActivity(inte);
                 }
             });
-            header.findViewById(R.id.offline).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.offline).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Reddit.appRestart.edit().putBoolean("forceoffline", true).commit();
                     Reddit.forceRestart(MainActivity.this);
                 }
@@ -1808,18 +1805,18 @@ public class MainActivity extends BaseActivity {
             drawerSubList.addHeaderView(header, null, false);
             hea = header.findViewById(R.id.back);
 
-            header.findViewById(R.id.online).setOnClickListener(new View.OnClickListener() {
+            header.findViewById(R.id.online).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Reddit.appRestart.edit().remove("forceoffline").apply();
                     ((Reddit) getApplication()).forceRestart(MainActivity.this);
                 }
             });
 
         }
-        header.findViewById(R.id.manage).setOnClickListener(new View.OnClickListener() {
+        header.findViewById(R.id.manage).setOnClickListener(new OnSingleClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onSingleClick(View view) {
                 Intent i = new Intent(MainActivity.this, ManageHistory.class);
                 startActivity(i);
             }
@@ -1831,9 +1828,9 @@ public class MainActivity extends BaseActivity {
                 support.setVisibility(View.GONE);
             }
             else {
-                header.findViewById(R.id.support).setOnClickListener(new View.OnClickListener() {
+                header.findViewById(R.id.support).setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View view) {
+                    public void onSingleClick(View view) {
                         try {
                             startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=me.ccrama.slideforreddittabletuiunlock")));
                         } catch (android.content.ActivityNotFoundException anfe) {
@@ -1878,9 +1875,9 @@ public class MainActivity extends BaseActivity {
             });
         }
 
-        header.findViewById(R.id.settings).setOnClickListener(new View.OnClickListener() {
+        header.findViewById(R.id.settings).setOnClickListener(new OnSingleClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onSingleClick(View v) {
                 Intent i = new Intent(MainActivity.this, Settings.class);
                 startActivity(i);
                 // Cancel sub loading because exiting the settings will reload it anyway
@@ -2914,9 +2911,9 @@ public class MainActivity extends BaseActivity {
         protected void onPostExecute(Void aVoid) {
             if (Authentication.mod) {
                 headerMain.findViewById(R.id.mod).setVisibility(View.VISIBLE);
-                headerMain.findViewById(R.id.mod).setOnClickListener(new View.OnClickListener() {
+                headerMain.findViewById(R.id.mod).setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View view) {
+                    public void onSingleClick(View view) {
                         if (UserSubscriptions.modOf != null && !UserSubscriptions.modOf.isEmpty()) {
                             Intent inte = new Intent(MainActivity.this, ModQueue.class);
                             MainActivity.this.startActivity(inte);
@@ -2928,9 +2925,9 @@ public class MainActivity extends BaseActivity {
             if (count != -1) {
                 int oldCount = Reddit.appRestart.getInt("inbox", 0);
                 if (count > oldCount) {
-                    final Snackbar s = Snackbar.make(mToolbar, getResources().getQuantityString(R.plurals.new_messages, count - oldCount, count - oldCount), Snackbar.LENGTH_LONG).setAction(R.string.btn_view, new View.OnClickListener() {
+                    final Snackbar s = Snackbar.make(mToolbar, getResources().getQuantityString(R.plurals.new_messages, count - oldCount, count - oldCount), Snackbar.LENGTH_LONG).setAction(R.string.btn_view, new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
                             Intent i = new Intent(MainActivity.this, Inbox.class);
                             i.putExtra(Inbox.EXTRA_UNREAD, true);
                             startActivity(i);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -105,6 +105,7 @@ import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.Vote;
 import me.ccrama.redditslide.util.LogUtil;
+import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 
@@ -916,9 +917,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 holder.commentOverflow.setVisibility(View.VISIBLE);
             }
 
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
+            holder.itemView.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
                     if (!currentlyEditingId.equals(comment.getFullName()))
 
                         if (SettingValues.swap) {
@@ -928,9 +929,10 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         }
                 }
             });
-            holder.firstTextView.setOnClickListener(new View.OnClickListener() {
+
+            holder.firstTextView.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
                     SpoilerRobotoTextView SpoilerRobotoTextView = (SpoilerRobotoTextView) v;
                     if (SettingValues.swap) {
                         doLongClick(holder, comment, baseNode, finalPos, finalPos1);
@@ -997,9 +999,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 if (submission.isArchived() || submission.isLocked())
                     firstHolder.itemView.findViewById(R.id.reply).setVisibility(View.GONE);
                 else {
-                    firstHolder.itemView.findViewById(R.id.reply).setOnClickListener(new View.OnClickListener() {
+                    firstHolder.itemView.findViewById(R.id.reply).setOnClickListener(new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
                             final View replyArea = firstHolder.itemView.findViewById(R.id.innerSend);
                             if (replyArea.getVisibility() == View.GONE) {
                                 expand(replyArea, true, true);
@@ -1025,9 +1027,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                 });
                                 editingPosition = firstHolder.getAdapterPosition();
 
-                                firstHolder.itemView.findViewById(R.id.send).setOnClickListener(new View.OnClickListener() {
+                                firstHolder.itemView.findViewById(R.id.send).setOnClickListener(new OnSingleClickListener() {
                                     @Override
-                                    public void onClick(View v) {
+                                    public void onSingleClick(View v) {
                                         dataSet.refreshLayout.setRefreshing(true);
 
                                         if (SettingValues.fastscroll) {
@@ -1054,9 +1056,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             }
                         }
                     });
-                    firstHolder.itemView.findViewById(R.id.discard).setOnClickListener(new View.OnClickListener() {
+                    firstHolder.itemView.findViewById(R.id.discard).setOnClickListener(new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
                             firstHolder.itemView.findViewById(R.id.innerSend).setVisibility(View.GONE);
                             currentlyEditing = null;
                             editingPosition = -1;
@@ -1079,12 +1081,11 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             } else {
                 firstHolder.itemView.findViewById(R.id.innerSend).setVisibility(View.GONE);
                 firstHolder.itemView.findViewById(R.id.reply).setVisibility(View.GONE);
-
             }
 
-            firstHolder.itemView.findViewById(R.id.more).setOnClickListener(new View.OnClickListener() {
+            firstHolder.itemView.findViewById(R.id.more).setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
                     firstHolder.itemView.findViewById(R.id.menu).callOnClick();
                 }
             });
@@ -1108,7 +1109,6 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         } catch (Exception e) {
                             e.printStackTrace();
                             //sub probably has no flairs?
-
                         }
 
 
@@ -1119,9 +1119,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     public void onPostExecute(final ArrayList<String> data) {
                         final boolean flair = (data != null && !data.isEmpty());
 
-                        edit.setOnClickListener(new View.OnClickListener() {
+                        edit.setOnClickListener(new OnSingleClickListener() {
                             @Override
-                            public void onClick(View v) {
+                            public void onSingleClick(View v) {
 
 
                                 int[] attrs = new int[]{R.attr.tint};
@@ -1375,10 +1375,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
             final View progress = holder.loading;
             progress.setVisibility(View.GONE);
-            holder.content.setOnClickListener(new View.OnClickListener() {
+            holder.content.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View v) {
-
+                public void onSingleClick(View v) {
                     if (baseNode.children.getChildrenIds().isEmpty()) {
                         String toGoTo = "https://reddit.com" + submission.getPermalink() + baseNode.comment.getComment().getId();
                         new OpenRedditLink(mContext, toGoTo, true);
@@ -1754,11 +1753,10 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
                     }
 
-                    baseView.findViewById(R.id.mod).setOnClickListener(new View.OnClickListener() {
+                    baseView.findViewById(R.id.mod).setOnClickListener(new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
                             showModBottomSheet(mContext, baseNode, baseNode.getComment(), holder, reports, reports2);
-
                         }
                     });
                 } else {
@@ -1768,9 +1766,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             {
                 final ImageView edit = (ImageView) baseView.findViewById(R.id.edit);
                 if (Authentication.name != null && Authentication.name.toLowerCase().equals(baseNode.getComment().getAuthor().toLowerCase()) && Authentication.didOnline) {
-                    edit.setOnClickListener(new View.OnClickListener() {
+                    edit.setOnClickListener(new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
                             LayoutInflater inflater = ((Activity) mContext).getLayoutInflater();
 
                             final View dialoglayout = inflater.inflate(R.layout.edit_comment, null);
@@ -1841,9 +1839,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             {
                 final ImageView delete = (ImageView) baseView.findViewById(R.id.delete);
                 if (Authentication.name != null && Authentication.name.toLowerCase().equals(baseNode.getComment().getAuthor().toLowerCase()) && Authentication.didOnline) {
-                    delete.setOnClickListener(new View.OnClickListener() {
+                    delete.setOnClickListener(new OnSingleClickListener() {
                         @Override
-                        public void onClick(View v) {
+                        public void onSingleClick(View v) {
 
                             new AlertDialogWrapper.Builder(mContext)
                                     .setTitle(R.string.comment_delete)
@@ -1968,9 +1966,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     });
                     editingPosition = holder.getAdapterPosition();
                 }
-                reply.setOnClickListener(new View.OnClickListener() {
+                reply.setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onSingleClick(View v) {
                         expand(baseView, true);
                         replyArea.setVisibility(View.VISIBLE);
                         menu.setVisibility(View.GONE);
@@ -2013,9 +2011,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
                     }
                 });
-                send.setOnClickListener(new View.OnClickListener() {
+                send.setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onSingleClick(View v) {
                         currentlyEditingId = "";
                         backedText = "";
 
@@ -2041,9 +2039,9 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
                     }
                 });
-                discard.setOnClickListener(new View.OnClickListener() {
+                discard.setOnClickListener(new OnSingleClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onSingleClick(View v) {
                         currentlyEditing = null;
                         editingPosition = -1;
                         currentlyEditingId = "";
@@ -2069,16 +2067,16 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 }
             }
 
-            more.setOnClickListener(new View.OnClickListener() {
+            more.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
                     showBottomSheet(mContext, holder, baseNode);
                 }
             });
-            upvote.setOnClickListener(new View.OnClickListener() {
+            upvote.setOnClickListener(new OnSingleClickListener() {
 
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
                     doUnHighlighted(holder, baseNode.getComment(), baseNode, true);
                     if (up.contains(n.getFullName())) {
                         new Vote(v, mContext).execute(n);
@@ -2101,10 +2099,10 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                     }
                 }
             });
-            downvote.setOnClickListener(new View.OnClickListener() {
+            downvote.setOnClickListener(new OnSingleClickListener() {
 
                 @Override
-                public void onClick(View v) {
+                public void onSingleClick(View v) {
 
                     doUnHighlighted(holder, baseNode.getComment(), baseNode, true);
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -41,6 +41,7 @@ import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionViews.PopulateSubmissionViewHolder;
 import me.ccrama.redditslide.Views.CatchStaggeredGridLayoutManager;
 import me.ccrama.redditslide.Views.CreateCardView;
+import me.ccrama.redditslide.util.OnSingleClickListener;
 
 
 public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements BaseAdapter {
@@ -160,16 +161,14 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         int i = pos != 0 ? pos - 1 : pos;
 
-
         if (holder2 instanceof SubmissionViewHolder) {
             final SubmissionViewHolder holder = (SubmissionViewHolder) holder2;
 
             final Submission submission = dataSet.posts.get(i);
             CreateCardView.colorCard(submission.getSubredditName().toLowerCase(), holder.itemView, subreddit, (subreddit.equals("frontpage") || subreddit.equals("mod") || subreddit.equals("friends") || (subreddit.equals("all")) || subreddit.contains(".") || subreddit.contains("+")));
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
-
+            holder.itemView.setOnClickListener(new OnSingleClickListener() {
                                                    @Override
-                                                   public void onClick(View arg0) {
+                                                   public void onSingleClick(View v) {
 
                                                        if (Authentication.didOnline || submission.getComments() != null) {
                                                            holder.title.setAlpha(0.54f);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditAdapter.java
@@ -28,6 +28,7 @@ import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Views.CatchStaggeredGridLayoutManager;
 import me.ccrama.redditslide.Views.CommentOverflow;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 
@@ -109,25 +110,25 @@ public class SubredditAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             holder.color.setBackgroundResource(R.drawable.circle);
             holder.color.getBackground().setColorFilter(Palette.getColor(sub.getDisplayName().toLowerCase()), PorterDuff.Mode.MULTIPLY);
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
+            holder.itemView.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(context, SubredditView.class);
                     inte.putExtra(SubredditView.EXTRA_SUBREDDIT, sub.getDisplayName());
                     context.startActivityForResult(inte, 4);
                 }
             });
-            holder.overflow.setOnClickListener(new View.OnClickListener() {
+            holder.overflow.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(context, SubredditView.class);
                     inte.putExtra(SubredditView.EXTRA_SUBREDDIT, sub.getDisplayName());
                     context.startActivityForResult(inte, 4);
                 }
             });
-            holder.body.setOnClickListener(new View.OnClickListener() {
+            holder.body.setOnClickListener(new OnSingleClickListener() {
                 @Override
-                public void onClick(View view) {
+                public void onSingleClick(View view) {
                     Intent inte = new Intent(context, SubredditView.class);
                     inte.putExtra(SubredditView.EXTRA_SUBREDDIT, sub.getDisplayName());
                     context.startActivityForResult(inte, 4);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -86,6 +86,7 @@ import me.ccrama.redditslide.Vote;
 import me.ccrama.redditslide.util.CustomTabUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
+import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 /**
@@ -100,9 +101,9 @@ public class PopulateSubmissionViewHolder {
     }
 
     private static void addClickFunctions(final View base, final ContentType.Type type, final Activity contextActivity, final Submission submission, final SubmissionViewHolder holder, final boolean full) {
-        base.setOnClickListener(new View.OnClickListener() {
+        base.setOnClickListener(new OnSingleClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onSingleClick(View v) {
                 if (NetworkUtil.isConnected(contextActivity) || (!NetworkUtil.isConnected(contextActivity) && ContentType.fullImage(type))) {
                     if (SettingValues.storeHistory && !full) {
                         if (!submission.isNsfw() || SettingValues.storeNSFWHistory) {
@@ -115,7 +116,6 @@ public class PopulateSubmissionViewHolder {
                     }
 
                     if (!PostMatch.openExternal(submission.getUrl()) || type == ContentType.Type.VIDEO) {
-
                         switch (type) {
                             case VID_ME:
                             case STREAMABLE:

--- a/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
@@ -1,0 +1,57 @@
+package me.ccrama.redditslide.util;
+
+import android.os.SystemClock;
+import android.util.Config;
+import android.util.Log;
+import android.view.View;
+
+/**
+ * Implementation of {@link View.OnClickListener} that ignores subsequent clicks that happen too quickly after the first one.<br/>
+ * To use this class, implement {@link #onSingleClick(View)} instead of {@link View.OnClickListener#onClick(View)}.
+ */
+public abstract class OnSingleClickListener implements View.OnClickListener {
+
+    private long mLastClickTime;
+    private static final long MIN_DELAY_MS = 300;
+    private static final String TAG = OnSingleClickListener.class.getSimpleName();
+
+    /**
+     * Called when a view has been clicked.
+     *
+     * @param v The view that was clicked.
+     */
+    public abstract void onSingleClick(View v);
+
+    @Override
+    public final void onClick(View v) {
+        final long lastClickTime = mLastClickTime;
+        final long now = SystemClock.uptimeMillis(); //guaranteed 100% monotonic
+        mLastClickTime = now;
+
+        if (now - lastClickTime < MIN_DELAY_MS) {
+            // Too fast: ignore
+            if (Config.LOGD) {
+                Log.d(TAG, "onClick Clicked too quickly: ignored");
+            }
+        } else {
+            // Register the click
+            onSingleClick(v);
+        }
+    }
+
+//    /**
+//     * Wraps an {@link View.OnClickListener} into an {@link OnSingleClickListener}.
+//     * The argument's {@link View.OnClickListener#onClick(View)} method will be called when a single click is registered.
+//     *
+//     * @param onClickListener The listener to wrap.
+//     * @return the wrapped listener.
+//     */
+//    public static View.OnClickListener wrap(final View.OnClickListener onClickListener) {
+//        return new OnSingleClickListener() {
+//            @Override
+//            public void onSingleClick(View v) {
+//                onClickListener.onClick(v);
+//            }
+//        };
+//    }
+}


### PR DESCRIPTION
- Also fixes click quickly on a comment before the comment menu has collapse getting funky

Added the class `OnSingleClickListener()`. If multiple clicks happen within the specified amount (`300ms` in this case), they will be ignored.

There is even a `wrap()` function that would allow us to wrap an `OnClickListener()` to become a `OnSingleClickListener()`. I commented it out though, simply because it's easier to change two words in the code for a click listener, than move it out into it's own object. :P 

Fixes #1621 