### PR TITLE
Gray out text if "Never Load LQ images" is checked

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
@@ -25,7 +25,6 @@ public class SettingsData extends BaseActivityAnim {
 
         final SwitchCompat single = (SwitchCompat) findViewById(R.id.imagelq);
 
-
         single.setChecked(SettingValues.loadImageLq);
         single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
@@ -68,10 +67,13 @@ public class SettingsData extends BaseActivityAnim {
                                 break;
                         }
                         ((TextView) findViewById(R.id.lowquality)).setText(SettingValues.lowResMobile ? (SettingValues.lowResAlways ? getString(R.string.datasave_always) : getString(R.string.datasave_mobile)) : getString(R.string.never));
-                        if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never)))
+                        if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never))) {
                             single.setEnabled(false);
-                        else
+                            findViewById(R.id.imagelq_text).setAlpha(0.25f);
+                        } else {
                             single.setEnabled(true);
+                            findViewById(R.id.imagelq_text).setAlpha(1f);
+                        }
                         single.setChecked(SettingValues.loadImageLq);
 
                         return true;
@@ -81,8 +83,10 @@ public class SettingsData extends BaseActivityAnim {
                 popup.show();
             }
         });
-        if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never)))
+        if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never))) {
             single.setEnabled(false);
+            findViewById(R.id.imagelq_text).setAlpha(0.25f);
+        }
 
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
@@ -70,9 +70,11 @@ public class SettingsData extends BaseActivityAnim {
                         if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never))) {
                             single.setEnabled(false);
                             findViewById(R.id.imagelq_text).setAlpha(0.25f);
+                            findViewById(R.id.imagelq_subtext).setAlpha(0.25f);
                         } else {
                             single.setEnabled(true);
                             findViewById(R.id.imagelq_text).setAlpha(1f);
+                            findViewById(R.id.imagelq_subtext).setAlpha(1f);
                         }
                         single.setChecked(SettingValues.loadImageLq);
 
@@ -86,6 +88,7 @@ public class SettingsData extends BaseActivityAnim {
         if (((TextView) findViewById(R.id.lowquality)).getText().equals(getString(R.string.never))) {
             single.setEnabled(false);
             findViewById(R.id.imagelq_text).setAlpha(0.25f);
+            findViewById(R.id.imagelq_subtext).setAlpha(0.25f);
         }
 
     }

--- a/app/src/main/res/layout/activity_settings_datasaving.xml
+++ b/app/src/main/res/layout/activity_settings_datasaving.xml
@@ -73,6 +73,7 @@
                     android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/imagelq_text"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/settings_data_lowqaul"

--- a/app/src/main/res/layout/activity_settings_datasaving.xml
+++ b/app/src/main/res/layout/activity_settings_datasaving.xml
@@ -81,6 +81,7 @@
                         android:textSize="16sp" />
 
                     <TextView
+                        android:id="@+id/imagelq_subtext"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:alpha=".86"


### PR DESCRIPTION
Grays out the "Load lower quality images if possible" text if that option is disabled.