### PR TITLE
Fix fast clicks

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
@@ -10,10 +10,10 @@ import android.view.View;
  * To use this class, implement {@link #onSingleClick(View)} instead of {@link View.OnClickListener#onClick(View)}.
  */
 public abstract class OnSingleClickListener implements View.OnClickListener {
-
-    private static final long MIN_DELAY_MS = 300;
+    
+    private static final long MIN_DELAY_MS = 750;
     private static final String TAG = OnSingleClickListener.class.getSimpleName();
-    private long mLastClickTime;
+    private static long mLastClickTime;
 
     /**
      * Called when a view has been clicked.
@@ -33,8 +33,8 @@ public abstract class OnSingleClickListener implements View.OnClickListener {
                 Log.d(TAG, "onClick Clicked too quickly: ignored");
             }
         } else {
+            // Update mLastClickTime and register the click
             mLastClickTime = now;
-            // Register the click
             onSingleClick(v);
         }
     }

--- a/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/OnSingleClickListener.java
@@ -11,9 +11,9 @@ import android.view.View;
  */
 public abstract class OnSingleClickListener implements View.OnClickListener {
 
-    private long mLastClickTime;
     private static final long MIN_DELAY_MS = 300;
     private static final String TAG = OnSingleClickListener.class.getSimpleName();
+    private long mLastClickTime;
 
     /**
      * Called when a view has been clicked.
@@ -26,7 +26,6 @@ public abstract class OnSingleClickListener implements View.OnClickListener {
     public final void onClick(View v) {
         final long lastClickTime = mLastClickTime;
         final long now = SystemClock.uptimeMillis(); //guaranteed 100% monotonic
-        mLastClickTime = now;
 
         if (now - lastClickTime < MIN_DELAY_MS) {
             // Too fast: ignore
@@ -34,6 +33,7 @@ public abstract class OnSingleClickListener implements View.OnClickListener {
                 Log.d(TAG, "onClick Clicked too quickly: ignored");
             }
         } else {
+            mLastClickTime = now;
             // Register the click
             onSingleClick(v);
         }


### PR DESCRIPTION
Unfortunately #1623 didn't completely fix the issue #1621.
The different posts have different OnSingleClickListener objects and the mLastClickTime wasn't being shared between them, so the original commit only prevented the same view from having multiples clicks registered.
I was able to open different posts by clicking 717ms after the first click, so 300ms didn't seem enough. I've increased it to 750ms, but as this is shared between the views this may be too high therefore the issue may need a different fix.
I've also changed so mLastClickTime is updated only when a click is registered. That way we can at least make sure the user can have at least a single click registered once every 750ms instead of always having his clicks ignored when clicking too fast.