### PR TITLE
Use Java collection interfaces rather than specific implementation

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentSearch.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentSearch.java
@@ -9,6 +9,7 @@ import android.widget.EditText;
 import net.dean.jraw.models.CommentNode;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.ccrama.redditslide.Adapters.CommentAdapterSearch;
 import me.ccrama.redditslide.Adapters.CommentItem;
@@ -40,7 +41,7 @@ public class CommentSearch extends BaseActivityAnim {
         mLayoutManager = new PreCachingLayoutManager(this);
         rv.setLayoutManager(mLayoutManager);
         ArrayList<CommentNode> comments = new ArrayList<>();
-        ArrayList<CommentObject> commentsOld = DataShare.sharedComments;
+        List<CommentObject> commentsOld = DataShare.sharedComments;
         for (CommentObject o : commentsOld) {
             if(o instanceof CommentItem)
             comments.add(o.comment);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ManageHistory.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ManageHistory.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.List;
 
 import me.ccrama.redditslide.Autocache.AutoCacheScheduler;
 import me.ccrama.redditslide.ColorPreferences;
@@ -75,12 +76,12 @@ public class ManageHistory extends BaseActivityAnim {
             @Override
             public void onClick(View v) {
 
-                ArrayList<String> sorted = UserSubscriptions.sort(UserSubscriptions.getSubscriptions(ManageHistory.this));
+                List<String> sorted = UserSubscriptions.sort(UserSubscriptions.getSubscriptions(ManageHistory.this));
                 final String[] all = new String[sorted.size()];
                 boolean[] checked = new boolean[all.length];
 
                 int i = 0;
-                ArrayList<String> s2 = new ArrayList<>();
+                List<String> s2 = new ArrayList<>();
                 Collections.addAll(s2, Reddit.cachedData.getString("toCache", "").split(","));
 
                 for (String s : sorted) {
@@ -184,7 +185,7 @@ public class ManageHistory extends BaseActivityAnim {
     }
 
     public ArrayList<String> domains = new ArrayList<>();
-    ArrayList<String> subsToBack;
+    List<String> subsToBack;
 
     public void updateFilters() {
         domains = new ArrayList<>();

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSubreddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSubreddit.java
@@ -19,6 +19,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import net.dean.jraw.models.Subreddit;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.ccrama.redditslide.Adapters.SettingsSubAdapter;
 import me.ccrama.redditslide.Authentication;
@@ -184,7 +185,7 @@ public class SettingsSubreddit extends BaseActivityAnim {
 
     public void reloadSubList() {
         changedSubs.clear();
-        ArrayList<String> allSubs = UserSubscriptions.sort(UserSubscriptions.getAllUserSubreddits(this));
+        List<String> allSubs = UserSubscriptions.sort(UserSubscriptions.getAllUserSubreddits(this));
 
         // Check which subreddits are different
         ColorPreferences colorPrefs = new ColorPreferences(SettingsSubreddit.this);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Wiki.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Wiki.java
@@ -74,7 +74,7 @@ public class Wiki extends BaseActivityAnim {
             try {
                 pages = wiki.getPages(subreddit);
 
-                ArrayList<String> toRemove = new ArrayList<>();
+                List<String> toRemove = new ArrayList<>();
                 for (String s : pages) {
                     if (s.startsWith("config")) {
                         toRemove.add(s);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditAdapter.java
@@ -22,6 +22,7 @@ import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.models.Submission;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.CommentsScreen;
@@ -39,7 +40,7 @@ public class MultiredditAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     private final RecyclerView listView;
     public Activity context;
     public MultiredditPosts dataSet;
-    public ArrayList<Submission> seen;
+    public List<Submission> seen;
     private final int LOADING_SPINNER = 5;
     private final int NO_MORE = 3;
     private final int SPACER = 6;

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -24,6 +24,7 @@ import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.models.Submission;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.CommentsScreen;
@@ -48,7 +49,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public Activity context;
     private final boolean custom;
     public SubredditPosts dataSet;
-    public ArrayList<Submission> seen;
+    public List<Submission> seen;
     private final int LOADING_SPINNER = 5;
     private final int NO_MORE = 3;
     private final int SPACER = 6;

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionComments.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionComments.java
@@ -20,6 +20,7 @@ import net.dean.jraw.util.JrawUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -53,12 +54,12 @@ public class SubmissionComments {
             CommentNode baseComment = s.getComments();
             boolean online = NetworkUtil.isConnected(page.getActivity());
             comments = new ArrayList<>();
-            HashMap<Integer, MoreChildItem> waiting = new HashMap<>();
+            Map<Integer, MoreChildItem> waiting = new HashMap<>();
 
             for (CommentNode n : baseComment.walkTree()) {
 
                 CommentObject obj = new CommentItem(n);
-                ArrayList<Integer> removed = new ArrayList<>();
+                List<Integer> removed = new ArrayList<>();
                 Map<Integer, MoreChildItem> map = new TreeMap<>(Collections.reverseOrder());
                 map.putAll(waiting);
 
@@ -227,12 +228,12 @@ public class SubmissionComments {
                     page.o.setCommentAndWrite(submission.getFullName(), node, submission).writeToMemory();*/
 
                 comments = new ArrayList<>();
-                HashMap<Integer, MoreChildItem> waiting = new HashMap<>();
+                Map<Integer, MoreChildItem> waiting = new HashMap<>();
 
                 for (CommentNode n : baseComment.walkTree()) {
 
                     CommentObject obj = new CommentItem(n);
-                    ArrayList<Integer> removed = new ArrayList<>();
+                    List<Integer> removed = new ArrayList<>();
                     Map<Integer, MoreChildItem> map = new TreeMap<>(Collections.reverseOrder());
                     map.putAll(waiting);
 

--- a/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
+++ b/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
@@ -197,7 +197,7 @@ public class CommentCacheAsync extends AsyncTask<String, Void, Void> {
                     mBuilder.setContentTitle("Caching " + (sub.equalsIgnoreCase("frontpage") ? "" : "/r/") + sub)
                             .setSmallIcon(R.drawable.save);
                 }
-                ArrayList<Submission> submissions = new ArrayList<>();
+                List<Submission> submissions = new ArrayList<>();
                 ArrayList<String> newFullnames = new ArrayList<>();
                 int count = 0;
                 if (alreadyReceived != null) {

--- a/app/src/main/java/me/ccrama/redditslide/DragSort/ReorderSubreddits.java
+++ b/app/src/main/java/me/ccrama/redditslide/DragSort/ReorderSubreddits.java
@@ -47,6 +47,7 @@ import net.dean.jraw.models.MultiSubreddit;
 import net.dean.jraw.models.Subreddit;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.ccrama.redditslide.Activities.BaseActivityAnim;
 import me.ccrama.redditslide.Activities.SettingsTheme;
@@ -364,7 +365,7 @@ public class ReorderSubreddits extends BaseActivityAnim {
         @Override
         public void onPostExecute(Subreddit subreddit) {
             if (subreddit != null || input.equalsIgnoreCase("friends") || input.equalsIgnoreCase("all") || input.equalsIgnoreCase("frontpage") || input.equalsIgnoreCase("mod")) {
-                ArrayList<String> sortedSubs = UserSubscriptions.sortNoExtras(subs);
+                List<String> sortedSubs = UserSubscriptions.sortNoExtras(subs);
 
                 if (sortedSubs.equals(subs)) {
                     subs.add(input);

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
@@ -148,7 +148,7 @@ public class CheckForMail extends BroadcastReceiver {
                 if (Authentication.isLoggedIn && Authentication.didOnline) {
                     InboxPaginator unread = new InboxPaginator(Authentication.reddit, "unread");
 
-                    ArrayList<Message> messages = new ArrayList<>();
+                    List<Message> messages = new ArrayList<>();
                     if (unread.hasNext()) {
                         messages.addAll(unread.next());
                     }
@@ -230,7 +230,7 @@ public class CheckForMail extends BroadcastReceiver {
                 if (Authentication.isLoggedIn && Authentication.didOnline) {
                     InboxPaginator unread = new InboxPaginator(Authentication.reddit, "moderator/unread");
 
-                    ArrayList<Message> messages = new ArrayList<>();
+                    List<Message> messages = new ArrayList<>();
                     if (unread.hasNext()) {
                         messages.addAll(unread.next());
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -38,6 +38,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import me.ccrama.redditslide.Activities.Internet;
 import me.ccrama.redditslide.Activities.MainActivity;
@@ -569,7 +570,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         sorting.put(s, sort);
     }
 
-    public static HashMap<String, Sorting> sorting = new HashMap<>();
+    public static Map<String, Sorting> sorting = new HashMap<>();
 
     public static Sorting getSorting(String subreddit) {
         if (sorting.containsKey(subreddit)) {
@@ -583,7 +584,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         times.put(s, sort);
     }
 
-    public static HashMap<String, TimePeriod> times = new HashMap<>();
+    public static Map<String, TimePeriod> times = new HashMap<>();
 
     public static TimePeriod getTime(String subreddit) {
         if (times.containsKey(subreddit)) {

--- a/app/src/main/java/me/ccrama/redditslide/UserSubscriptions.java
+++ b/app/src/main/java/me/ccrama/redditslide/UserSubscriptions.java
@@ -67,14 +67,14 @@ public class UserSubscriptions {
 
         } else {
             String s = subscriptions.getString(Authentication.name, "");
-            ArrayList<String> subredditsForHome = new ArrayList<>();
+            List<String> subredditsForHome = new ArrayList<>();
             if (!s.isEmpty()) {
                 for (String s2 : s.split(",")) {
                     subredditsForHome.add(s2.toLowerCase());
                 }
             }
             ArrayList<String> finals = new ArrayList<>();
-            ArrayList<String> offline = OfflineSubreddit.getAllFormatted();
+            List<String> offline = OfflineSubreddit.getAllFormatted();
             for(String subs : subredditsForHome){
                 if(offline.contains(subs)){
                     finals.add(subs);
@@ -303,8 +303,8 @@ public class UserSubscriptions {
     //Gets user subscriptions + top 500 subs + subs in history
     public static ArrayList<String> getAllSubreddits(Context c) {
         ArrayList<String> finalReturn = new ArrayList<>();
-        ArrayList<String> history = getHistory();
-        ArrayList<String> defaults = getDefaults(c);
+        List<String> history = getHistory();
+        List<String> defaults = getDefaults(c);
         finalReturn.addAll(getSubscriptions(c));
         for(String s : finalReturn){
             if(history.contains(s)){
@@ -479,7 +479,7 @@ public class UserSubscriptions {
      * @see #sort(ArrayList)
      */
     public static ArrayList<String> sortNoExtras(ArrayList<String> unsorted) {
-        ArrayList<String> subs = new ArrayList<>(unsorted);
+        List<String> subs = new ArrayList<>(unsorted);
         ArrayList<String> finals = new ArrayList<>();
         final List<String> specialSubreddits = Arrays.asList(
                 "frontpage", "all", "random", "randnsfw", "myrandom", "friends", "mod"

--- a/app/src/main/java/me/ccrama/redditslide/util/IabHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/IabHelper.java
@@ -734,11 +734,11 @@ public class IabHelper {
                 return IABHELPER_BAD_RESPONSE;
             }
 
-            ArrayList<String> ownedSkus = ownedItems.getStringArrayList(
+            List<String> ownedSkus = ownedItems.getStringArrayList(
                     RESPONSE_INAPP_ITEM_LIST);
-            ArrayList<String> purchaseDataList = ownedItems.getStringArrayList(
+            List<String> purchaseDataList = ownedItems.getStringArrayList(
                     RESPONSE_INAPP_PURCHASE_DATA_LIST);
-            ArrayList<String> signatureList = ownedItems.getStringArrayList(
+            List<String> signatureList = ownedItems.getStringArrayList(
                     RESPONSE_INAPP_SIGNATURE_LIST);
 
             for (int i = 0; i < purchaseDataList.size(); ++i) {
@@ -805,7 +805,7 @@ public class IabHelper {
             }
         }
 
-        ArrayList<String> responseList = skuDetails.getStringArrayList(
+        List<String> responseList = skuDetails.getStringArrayList(
                 RESPONSE_GET_SKU_DETAILS_LIST);
 
         for (String thisResponse : responseList) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.