### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
@@ -298,7 +298,7 @@ public class CommentsScreen extends BaseActivityAnim implements SubmissionDispla
         public void setPrimaryItem(ViewGroup container, int position, Object object) {
             super.setPrimaryItem(container, position, object);
             if (getCurrentFragment() != object && object != null && object instanceof CommentPage) {
-                mCurrentFragment = ((CommentPage) object);
+                mCurrentFragment = (CommentPage) object;
                 if (!mCurrentFragment.loaded) {
                     if (mCurrentFragment.isAdded()) {
                         mCurrentFragment.doAdapter(true);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreenSingle.java
@@ -251,7 +251,7 @@ public class CommentsScreenSingle extends BaseActivityAnim {
         @Override
         public void setPrimaryItem(ViewGroup container, int position, Object object) {
             if (getCurrentFragment() != object) {
-                mCurrentFragment = ((Fragment) object);
+                mCurrentFragment = (Fragment) object;
             }
             super.setPrimaryItem(container, position, object);
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ForceTouchLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ForceTouchLink.java
@@ -45,8 +45,8 @@ public class ForceTouchLink extends BaseActivityAnim {
 
         ContentType.Type t = ContentType.getContentType(url);
 
-        final ImageView mainImage = ((ImageView) findViewById(R.id.image));
-        MediaVideoView mainVideo = ((MediaVideoView) findViewById(R.id.gif));
+        final ImageView mainImage = (ImageView) findViewById(R.id.image);
+        MediaVideoView mainVideo = (MediaVideoView) findViewById(R.id.gif);
         mainVideo.setVisibility(View.GONE);
         switch(t){
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
@@ -402,7 +402,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             });
 
         } else if (firstHolder instanceof SpacerViewHolder) {
-            firstHolder.itemView.setLayoutParams(new LinearLayout.LayoutParams(firstHolder.itemView.getWidth(), (mContext).findViewById(R.id.header).getHeight()));
+            firstHolder.itemView.setLayoutParams(new LinearLayout.LayoutParams(firstHolder.itemView.getWidth(), mContext.findViewById(R.id.header).getHeight()));
         }
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
@@ -146,7 +146,7 @@ public class HistoryPosts extends GeneralPosts {
                 }
                 for (Thing c : paginator.next()) {
                     if (c instanceof Contribution) {
-                        newData.add(((Contribution)c));
+                        newData.add((Contribution)c);
                     }
                 }
 

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -264,7 +264,7 @@ public class CommentPage extends Fragment {
         LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
         v = localInflater.inflate(R.layout.fragment_verticalcontenttoolbar, container, false);
 
-        rv = ((RecyclerView) v.findViewById(R.id.vertical_content));
+        rv = (RecyclerView) v.findViewById(R.id.vertical_content);
         rv.setLayoutManager(mLayoutManager);
         rv.getLayoutManager().scrollToPosition(0);
         toolbar = (Toolbar) v.findViewById(R.id.toolbar);
@@ -281,7 +281,7 @@ public class CommentPage extends Fragment {
             fab.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    LayoutInflater inflater = (getActivity()).getLayoutInflater();
+                    LayoutInflater inflater = getActivity().getLayoutInflater();
 
                     final View dialoglayout = inflater.inflate(R.layout.edit_comment, null);
                     final AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
@@ -663,7 +663,7 @@ public class CommentPage extends Fragment {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             if (!(getActivity() instanceof MainActivity)) {
-                                (getActivity()).finish();
+                                getActivity().finish();
                             }
                         }
                     }).setPositiveButton(R.string.btn_offline, new DialogInterface.OnClickListener() {
@@ -886,7 +886,7 @@ public class CommentPage extends Fragment {
         //This is the filter
         if (event.getAction() != KeyEvent.ACTION_DOWN)
             return true;
-        if ((keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
             goDown();
             return true;
         } else if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/ContributionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/ContributionsView.java
@@ -81,7 +81,7 @@ public class ContributionsView extends Fragment {
                     }
                 }
         );
-        rv.addOnScrollListener(new ToolbarScrollHideHandler((Toolbar) (getActivity()).findViewById(R.id.toolbar), getActivity().findViewById(R.id.header)) {
+        rv.addOnScrollListener(new ToolbarScrollHideHandler((Toolbar) getActivity().findViewById(R.id.toolbar), getActivity().findViewById(R.id.header)) {
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/HistoryView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/HistoryView.java
@@ -78,7 +78,7 @@ public class HistoryView extends Fragment {
                     }
                 }
         );
-        rv.addOnScrollListener(new ToolbarScrollHideHandler((Toolbar) (getActivity()).findViewById(R.id.toolbar), getActivity().findViewById(R.id.header)) {
+        rv.addOnScrollListener(new ToolbarScrollHideHandler((Toolbar) getActivity().findViewById(R.id.toolbar), getActivity().findViewById(R.id.header)) {
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
@@ -158,7 +158,7 @@ public class MediaFragment extends Fragment {
                 Intent i2 = new Intent(getActivity(), CommentsScreen.class);
                 i2.putExtra(CommentsScreen.EXTRA_PAGE, i);
                 i2.putExtra(CommentsScreen.EXTRA_SUBREDDIT, sub);
-                (getActivity()).startActivity(i2);
+                getActivity().startActivity(i2);
 
             }
         });
@@ -192,7 +192,7 @@ public class MediaFragment extends Fragment {
                             Intent i2 = new Intent(getActivity(), CommentsScreen.class);
                             i2.putExtra(CommentsScreen.EXTRA_PAGE, i);
                             i2.putExtra(CommentsScreen.EXTRA_SUBREDDIT, sub);
-                            (getActivity()).startActivity(i2);
+                            getActivity().startActivity(i2);
                         }
                     });
                 } else {
@@ -306,7 +306,7 @@ public class MediaFragment extends Fragment {
 
                                                         if (obj != null && !obj.isJsonNull() && obj.has("error")) {
                                                             LogUtil.v("Error loading content");
-                                                            (getActivity()).finish();
+                                                            getActivity().finish();
                                                         } else {
                                                             try {
                                                                 if (!obj.isJsonNull() && obj.has("image")) {

--- a/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
@@ -248,7 +248,7 @@ public class DoEditorActions {
             @Override
             public void onClick(View v) {
                 String html = Processor.process(editText.getText().toString());
-                LayoutInflater inflater = (a).getLayoutInflater();
+                LayoutInflater inflater = a.getLayoutInflater();
                 final View dialoglayout = inflater.inflate(R.layout.parent_comment_dialog, null);
                 final AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(a);
                 setViews(html, "NO sub", (SpoilerRobotoTextView) dialoglayout.findViewById(R.id.firstTextView), (CommentOverflow) dialoglayout.findViewById(R.id.commentOverflow));

--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -595,11 +595,11 @@ public class GifUtils {
 
                                                                                          if(result != null && result.has("error") && result.get("error").getAsString().contains("not animated")){
                                                                                               if(c instanceof MediaView && c.getIntent() != null && c.getIntent().hasExtra(MediaView.EXTRA_DISPLAY_URL)){
-                                                                                                  (c).runOnUiThread(new Runnable() {
+                                                                                                  c.runOnUiThread(new Runnable() {
                                                                                                       @Override
                                                                                                       public void run() {
                                                                                                           ((MediaView)c).imageShown = false;
-                                                                                                          ((MediaView)c).displayImage((c).getIntent().getStringExtra(MediaView.EXTRA_DISPLAY_URL));
+                                                                                                          ((MediaView)c).displayImage(c.getIntent().getStringExtra(MediaView.EXTRA_DISPLAY_URL));
                                                                                                       }
                                                                                                   });
                                                                                               } else if(c instanceof Shadowbox){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.