### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ImageLoaderUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/ImageLoaderUtils.java
@@ -27,6 +27,9 @@ public class ImageLoaderUtils {
 
     public static ImageLoader imageLoader;
 
+    private ImageLoaderUtils() {
+    }
+
     public static File getCacheDirectory(Context context) {
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED) && context.getExternalCacheDir() != null) {
             return context.getExternalCacheDir();

--- a/app/src/main/java/me/ccrama/redditslide/TimeUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/TimeUtils.java
@@ -15,6 +15,9 @@ public class TimeUtils {
     private static final long YEAR_MILLIS = 365 * DAY_MILLIS;
     private static final long MONTH_MILLIS = 30 * DAY_MILLIS;
 
+    private TimeUtils() {
+    }
+
 
     public static String getTimeAgo(long time, Context c) {
         if (time < 1000000000000L) {

--- a/app/src/main/java/me/ccrama/redditslide/Views/AnimateHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/AnimateHelper.java
@@ -16,6 +16,9 @@ import me.ccrama.redditslide.R;
 public class AnimateHelper {
 
 
+    private AnimateHelper() {
+    }
+
     public static void setFlashAnimation(final View vBig, final View from, final int color) {
         // get the center for the clipping circle
         final View v = vBig.findViewById(R.id.vote);

--- a/app/src/main/java/me/ccrama/redditslide/Views/ToolbarColorizeHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/ToolbarColorizeHelper.java
@@ -38,6 +38,9 @@ import me.ccrama.redditslide.R;
  */
 public class ToolbarColorizeHelper {
 
+    private ToolbarColorizeHelper() {
+    }
+
     /**
      * Use this method to colorize toolbar icons to the desired target color
      *

--- a/app/src/main/java/me/ccrama/redditslide/util/CacheUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/CacheUtil.java
@@ -15,6 +15,9 @@ public class CacheUtil {
 
     private static final long MAX_SIZE = 75000000L; // 75MB
 
+    private CacheUtil() {
+    }
+
     public static void makeRoom(Activity context, int length) {
 
         File cacheDir = ImageLoaderUtils.getCacheDirectoryGif(context);

--- a/app/src/main/java/me/ccrama/redditslide/util/CustomTabUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/CustomTabUtil.java
@@ -29,6 +29,9 @@ public class CustomTabUtil {
     private static CustomTabsClient mClient;
     private static CustomTabsServiceConnection mConnection;
 
+    private CustomTabUtil() {
+    }
+
     public static Bitmap drawableToBitmap(Drawable drawable) {
 
         if (drawable instanceof BitmapDrawable) {

--- a/app/src/main/java/me/ccrama/redditslide/util/EditTextValidator.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/EditTextValidator.java
@@ -12,6 +12,9 @@ import android.widget.EditText;
  */
 public class EditTextValidator {
 
+    private EditTextValidator() {
+    }
+
     /**
      * Validates EditTexts intended for reddit username input. Valid characters include:
      * A-Z, a-z

--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -48,6 +48,9 @@ import me.ccrama.redditslide.Views.MediaVideoView;
  */
 public class GifUtils {
 
+    private GifUtils() {
+    }
+
     public static String getSmallerGfy(String gfyUrl) {
         gfyUrl = gfyUrl.replaceAll("fat|zippy|giant", "thumbs");
         if (!gfyUrl.endsWith("-mobile.mp4"))

--- a/app/src/main/java/me/ccrama/redditslide/util/NetworkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/NetworkUtil.java
@@ -16,6 +16,9 @@ public class NetworkUtil {
     // Assigned a random value that is not a value of ConnectivityManager.TYPE_*
     private static final int CONST_NO_NETWORK = 525138;
 
+    private NetworkUtil() {
+    }
+
     /**
      * Uses the provided context to determine the current connectivity status.
      *

--- a/app/src/main/java/me/ccrama/redditslide/util/StreamableUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/StreamableUtil.java
@@ -46,6 +46,9 @@ import me.ccrama.redditslide.Views.MediaVideoView;
 public class StreamableUtil {
 
 
+    private StreamableUtil() {
+    }
+
     public static class AsyncLoadStreamable extends AsyncTask<String, Void, Void> {
 
         public Activity c;

--- a/app/src/main/java/me/ccrama/redditslide/util/SubmissionParser.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/SubmissionParser.java
@@ -19,6 +19,9 @@ public class SubmissionParser {
     private static final String TABLE_START_TAG = "<table>";
     private static final String TABLE_END_TAG = "</table>";
 
+    private SubmissionParser() {
+    }
+
     /**
      * Parses html and returns a list corresponding to blocks of text to be
      * formatted.

--- a/app/src/main/java/me/ccrama/redditslide/util/TitleExtractor.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/TitleExtractor.java
@@ -20,6 +20,9 @@ public class TitleExtractor {
     private static final Pattern TITLE_TAG =
             Pattern.compile("<title[^>]*>(.*?)</title>", Pattern.CASE_INSENSITIVE|Pattern.DOTALL);
 
+    private TitleExtractor() {
+    }
+
     /**
      * @param url the HTML page
      * @return title text (null if document isn't HTML or lacks a title tag)

--- a/app/src/main/java/me/ccrama/redditslide/util/UpgradeUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/UpgradeUtil.java
@@ -26,6 +26,9 @@ public class UpgradeUtil {
     // Increment for each needed change
     private static final int VERSION = 1;
 
+    private UpgradeUtil() {
+    }
+
     /**
      * Runs any upgrade actions required between versions in an organised way
      */

--- a/app/src/main/java/me/ccrama/redditslide/util/VidMeUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/VidMeUtil.java
@@ -48,6 +48,9 @@ import me.ccrama.redditslide.Views.MediaVideoView;
 public class VidMeUtil {
 
 
+    private VidMeUtil() {
+    }
+
     public static class AsyncLoadVidMe extends AsyncTask<String, Void, Void> {
 
         public Activity c;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.