### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -553,11 +553,11 @@ public class MainActivity extends BaseActivity {
                 protected Void doInBackground(Void... params) {
                     KVManger m = KVStore.getInstance();
                     Map<String, ?> values = seen.getAll();
-                    for (String value : values.keySet()) {
-                        if (value.length() == 6 && values.get(value) instanceof Boolean) {
-                            m.insert(value, "true");
-                        } else if (values.get(value) instanceof Long) {
-                            m.insert(value, String.valueOf(seen.getLong(value, 0)));
+                    for (Map.Entry<String, ?> entry : values.entrySet()) {
+                        if (entry.getKey().length() == 6 && entry.getValue() instanceof Boolean) {
+                            m.insert(entry.getKey(), "true");
+                        } else if (entry.getValue() instanceof Long) {
+                            m.insert(entry.getKey(), String.valueOf(seen.getLong(entry.getKey(), 0)));
                         }
                     }
                     seen.edit().clear().putBoolean("isCleared", true).apply();
@@ -568,9 +568,9 @@ public class MainActivity extends BaseActivity {
                     if (!Reddit.appRestart.contains("hasCleared")) {
                         SharedPreferences.Editor e = Reddit.appRestart.edit();
                         Map<String, ?> toClear = Reddit.appRestart.getAll();
-                        for (String s : toClear.keySet()) {
-                            if (toClear.get(s) instanceof String && ((String) toClear.get(s)).length() > 300) {
-                                e.remove(s);
+                        for (Map.Entry<String, ?> entry : toClear.entrySet()) {
+                            if (entry.getValue() instanceof String && ((String) entry.getValue()).length() > 300) {
+                                e.remove(entry.getKey());
                             }
                         }
                         e.putBoolean("hasCleared", true);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -230,11 +230,11 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                     protected ArrayList<String> doInBackground(Void... params) {
 
                                         ArrayList<String> finalReports = new ArrayList<>();
-                                        for (String s : reports.keySet()) {
-                                            finalReports.add("x" + reports.get(s) + " " + s);
+                                        for (Map.Entry<String, Integer> entry : reports.entrySet()) {
+                                            finalReports.add("x" + entry.getValue() + " " + entry.getKey());
                                         }
-                                        for (String s : reports2.keySet()) {
-                                            finalReports.add(s + ": " + reports2.get(s));
+                                        for (Map.Entry<String, String> entry : reports2.entrySet()) {
+                                            finalReports.add(entry.getKey() + ": " + entry.getValue());
                                         }
                                         if (finalReports.isEmpty()) {
                                             finalReports.add(mContext.getString(R.string.mod_no_reports));

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
@@ -113,20 +113,20 @@ public class HistoryPosts extends GeneralPosts {
                     ArrayList<String> ids = new ArrayList<>();
                     HashMap<Long, String> idsSorted = new HashMap<>();
                     Map<String,String> values = KVStore.getInstance().getByContains("");
-                    for (String value : values.keySet()) {
+                    for (Map.Entry<String, String> entry : values.entrySet()) {
                         Object done;
-                        if(values.get(value).equals("true") || values.get(value).equals("false")){
-                            done = Boolean.valueOf(values.get(value));
+                        if(entry.getValue().equals("true") || entry.getValue().equals("false")){
+                            done = Boolean.valueOf(entry.getValue());
                         } else {
-                            done = Long.valueOf(values.get(value));
+                            done = Long.valueOf(entry.getValue());
                         }
-                        if (value.length() == 6 && done instanceof Boolean){
-                            ids.add("t3_" + value);
+                        if (entry.getKey().length() == 6 && done instanceof Boolean){
+                            ids.add("t3_" + entry.getKey());
                         } else if(done instanceof Long){
-                            if(value.contains("_")){
-                                idsSorted.put((Long)done, value);
+                            if(entry.getKey().contains("_")){
+                                idsSorted.put((Long)done, entry.getKey());
                             } else {
-                                idsSorted.put((Long) done, "t3_" + value);
+                                idsSorted.put((Long) done, "t3_" + entry.getKey());
                             }
                         }
                     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -693,11 +693,11 @@ public class PopulateSubmissionViewHolder {
                                     protected ArrayList<String> doInBackground(Void... params) {
 
                                         ArrayList<String> finalReports = new ArrayList<>();
-                                        for (String s : reports.keySet()) {
-                                            finalReports.add(reports.get(s) + "× " + s);
+                                        for (Map.Entry<String, Integer> entry : reports.entrySet()) {
+                                            finalReports.add(entry.getValue() + "× " + entry.getKey());
                                         }
-                                        for (String s : reports2.keySet()) {
-                                            finalReports.add(s + ": " + reports2.get(s));
+                                        for (Map.Entry<String, String> entry : reports2.entrySet()) {
+                                            finalReports.add(entry.getKey() + ": " + entry.getValue());
                                         }
                                         if (finalReports.isEmpty()) {
                                             finalReports.add(mContext.getString(R.string.mod_no_reports));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.