### PR TITLE
Update Profile.java

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
@@ -532,7 +532,7 @@ public class Profile extends BaseActivityAnim {
                                 view.setOnClickListener(new View.OnClickListener() {
                                     @Override
                                     public void onClick(View v) {
-                                        CustomTabUtil.openUrl("https://reddit.com" + t.getAboutUrl(), Palette.getColorUser(account.getFullName()), Profile.this);
+                                        CustomTabUtil.openUrl(t.getAboutUrl(), Palette.getColorUser(account.getFullName()), Profile.this);
                                     }
                                 });
                             }


### PR DESCRIPTION
Before, 'https://reddit.com' was added in front of the url, causing the trophy URL to not open. This simple fix allows the links to properly open again.