### PR TITLE
Hide sidebar and submit menu items in various views

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -823,8 +823,9 @@ public class MainActivity extends BaseActivity {
                 @Override
                 public void onClick(View v) {
                     Intent i = new Intent(MainActivity.this, Submit.class);
-                    if (!subreddit.contains("/m/"))
+                    if (!subreddit.contains("/m/") || !subreddit.contains(".")) {
                         i.putExtra(Submit.EXTRA_SUBREDDIT, subreddit);
+                    }
                     startActivity(i);
                 }
             });
@@ -1590,8 +1591,9 @@ public class MainActivity extends BaseActivity {
                 @Override
                 public void onSingleClick(View view) {
                     Intent inte = new Intent(MainActivity.this, Submit.class);
-                    if (!selectedSub.contains("/m/"))
+                    if (!selectedSub.contains("/m/") || !selectedSub.contains(".")) {
                         inte.putExtra(Submit.EXTRA_SUBREDDIT, selectedSub);
+                    }
                     MainActivity.this.startActivity(inte);
                 }
             });
@@ -2274,10 +2276,25 @@ public class MainActivity extends BaseActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
+        final String subreddit = usedArray.get(pager.getCurrentItem());
+
+        /**
+         * Hide the "Submit" and "Sidebar" menu items if the currently viewed sub is a multi,
+         * domain, the frontpage, or /r/all. If the subreddit has a "." in it, we know it's a domain because
+         * subreddits aren't allowed to have hard-stops in the name.
+         */
+        if (subreddit.contains("/m/") || subreddit.contains(".")
+                || subreddit.equals("frontpage") || subreddit.equals("all")) {
+            menu.findItem(R.id.submit).setVisible(false);
+            menu.findItem(R.id.sidebar).setVisible(false);
+        } else {
+            menu.findItem(R.id.submit).setVisible(true);
+            menu.findItem(R.id.sidebar).setVisible(true);
+        }
+
         mToolbar.getMenu().findItem(R.id.theme).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                final String subreddit = usedArray.get(pager.getCurrentItem());
                 int style = new ColorPreferences(MainActivity.this).getThemeSubreddit(subreddit);
                 final Context contextThemeWrapper = new ContextThemeWrapper(MainActivity.this, style);
                 LayoutInflater localInflater = getLayoutInflater().cloneInContext(contextThemeWrapper);
@@ -2299,7 +2316,6 @@ public class MainActivity extends BaseActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-
         MenuInflater inflater = getMenuInflater();
         if (NetworkUtil.isConnected(this)) {
             if (SettingValues.expandedToolbar) {
@@ -2499,8 +2515,9 @@ public class MainActivity extends BaseActivity {
                 return true;
             case R.id.submit: {
                 Intent i = new Intent(this, Submit.class);
-                if (!selectedSub.contains("/m/"))
+                if (!selectedSub.contains("/m/") || !selectedSub.contains(".")) {
                     i.putExtra(Submit.EXTRA_SUBREDDIT, selectedSub);
+                }
                 startActivity(i);
             }
             return true;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -219,7 +219,7 @@ public class SubredditView extends BaseActivityAnim {
                 }
                 builder.show();
                 return true;
-            case R.id.action_info:
+            case R.id.sidebar:
                 drawerLayout.openDrawer(Gravity.RIGHT);
                 return true;
             case R.id.action_shadowbox:
@@ -372,10 +372,16 @@ public class SubredditView extends BaseActivityAnim {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
+
+        //Hide the "Submit" menu item if the currently viewed sub is the frontpage or /r/all.
+        if (subreddit.equals("frontpage") || subreddit.equals("all")) {
+            menu.findItem(R.id.submit).setVisible(false);
+            menu.findItem(R.id.sidebar).setVisible(false);
+        }
+
         mToolbar.getMenu().findItem(R.id.theme).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-
                 int style = new ColorPreferences(SubredditView.this).getThemeSubreddit(subreddit);
                 final Context contextThemeWrapper = new ContextThemeWrapper(SubredditView.this, style);
                 LayoutInflater localInflater = getLayoutInflater().cloneInContext(contextThemeWrapper);

--- a/app/src/main/res/menu/menu_single_subreddit.xml
+++ b/app/src/main/res/menu/menu_single_subreddit.xml
@@ -14,26 +14,31 @@
         android:icon="@drawable/sort"
         android:title="@string/sorting_change_sorting"
         app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/action_refresh"
         android:icon="@drawable/ic_refresh"
         android:title="@string/btn_refresh"
         app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/search"
         android:icon="@drawable/search"
         android:title="@string/search_title"
         app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/gallery"
         android:icon="@drawable/image"
         android:title="Gallery mode"
         app:showAsAction="ifRoom" />
+
     <item
-        android:id="@+id/action_info"
+        android:id="@+id/sidebar"
         android:icon="@drawable/infonew"
         android:title="@string/general_open_settings"
         app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/submit"
         android:title="@string/btn_submit"
@@ -48,5 +53,4 @@
         android:id="@+id/filter"
         android:title="@string/sub_content_filter"
         app:showAsAction="never" />
-
 </menu>

--- a/app/src/main/res/menu/menu_single_subreddit_expanded.xml
+++ b/app/src/main/res/menu/menu_single_subreddit_expanded.xml
@@ -14,26 +14,31 @@
         android:icon="@drawable/sort"
         android:title="@string/sorting_change_sorting"
         app:showAsAction="always" />
+
     <item
         android:id="@+id/action_refresh"
         android:icon="@drawable/ic_refresh"
         android:title="@string/btn_refresh"
         app:showAsAction="always" />
+
     <item
         android:id="@+id/search"
         android:icon="@drawable/search"
         android:title="@string/search_title"
         app:showAsAction="always" />
+
     <item
         android:id="@+id/gallery"
         android:icon="@drawable/image"
         android:title="Gallery mode"
         app:showAsAction="ifRoom" />
+
     <item
-        android:id="@+id/action_info"
+        android:id="@+id/sidebar"
         android:icon="@drawable/infonew"
         android:title="@string/general_open_settings"
         app:showAsAction="always" />
+
     <item
         android:id="@+id/submit"
         android:title="@string/btn_submit"


### PR DESCRIPTION
Both of these suggestions are from #1658 

Hide the "Sidebar" and "Submit" overflow menu items if the currently viewed sub is one of the following:
- multi (i.e name contains `"/m/"`) [only while in the Main view, not the MultiReddits view]
- frontpage
- /r/all
- domain (i.e. name contains `"."`)