### PR TITLE
Improvements to Sending Inbox messages

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Inbox.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Inbox.java
@@ -180,8 +180,9 @@ public class Inbox extends BaseActivityAnim {
             @Override
             protected Void doInBackground(Void... params) {
                 if (Authentication.me == null) {
-                    if (Authentication.reddit == null)
+                    if (Authentication.reddit == null) {
                         new Authentication(getApplicationContext());
+                    }
                     Authentication.me = Authentication.reddit.me();
                     Authentication.mod = Authentication.me.isMod();
                     Reddit.over18 = Authentication.me.isOver18();

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Sendmessage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Sendmessage.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 
@@ -21,8 +22,6 @@ import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Views.DoEditorActions;
 import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.LogUtil;
-
 
 /**
  * Created by ccrama on 3/5/2015.
@@ -40,6 +39,9 @@ public class Sendmessage extends BaseActivity {
     private String subjecttext;
     private String totext;
     private EditText body;
+
+    private String messageSentStatus; //the String to show in the Toast for when the message is sent
+    private boolean messageSent = true; //whether or not the message was sent successfully
 
 
     public void onCreate(Bundle savedInstanceState) {
@@ -60,14 +62,19 @@ public class Sendmessage extends BaseActivity {
             name = getIntent().getExtras().getString(EXTRA_NAME, "");
             to.setText(name);
             to.setInputType(InputType.TYPE_NULL);
+
             if (reply) {
                 b.setTitle(getString(R.string.mail_reply_to, name));
                 previousMessage = DataShare.sharedMessage;
                 subject.setText(getString(R.string.mail_re, previousMessage.getSubject()));
-
                 subject.setInputType(InputType.TYPE_NULL);
 
+                //Disable if replying to another user, as they are already set
+                to.setEnabled(false);
+                subject.setEnabled(false);
+
                 body.requestFocus();
+
                 oldMSG.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -75,20 +82,16 @@ public class Sendmessage extends BaseActivity {
                         b.setTitle(getString(R.string.mail_author_wrote, name));
                         b.setMessage(previousMessage.getBody());
                         b.create().show();
-
                     }
                 });
-
             } else {
                 b.setTitle(getString(R.string.mail_send_to, name));
                 oldMSG.setVisibility(View.GONE);
             }
-
         } else {
             name = "";
             oldMSG.setVisibility(View.GONE);
             b.setTitle(R.string.mail_send);
-
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -99,7 +102,6 @@ public class Sendmessage extends BaseActivity {
         setupUserAppBar(R.id.toolbar, null, true, name);
         setRecentBar(b.getTitle().toString(), Palette.getDefaultColor());
 
-
         findViewById(R.id.send).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -108,41 +110,57 @@ public class Sendmessage extends BaseActivity {
                 subjecttext = subject.getText().toString();
 
                 new AsyncDo().execute();
-                findViewById(R.id.send).setVisibility(View.GONE);
             }
         });
         DoEditorActions.doActions(((EditText) findViewById(R.id.body)), findViewById(R.id.area), getSupportFragmentManager(), Sendmessage.this);
-
-
     }
 
     private class AsyncDo extends AsyncTask<Void, Void, Void> {
-
-        @Override
-        public void onPostExecute(Void voids) {
-            finish();
-        }
-
         @Override
         protected Void doInBackground(Void... voids) {
             if (reply) {
                 try {
-                    LogUtil.v("XXX");
                     new net.dean.jraw.managers.AccountManager(Authentication.reddit).reply(previousMessage, bodytext);
                 } catch (ApiException e) {
+                    messageSent = false;
                     e.printStackTrace();
                 }
             } else {
                 try {
-                    LogUtil.v("YYY");
                     new InboxManager(Authentication.reddit).compose(totext, subjecttext, bodytext);
                 } catch (ApiException e) {
+                    messageSent = false;
                     e.printStackTrace();
+
+                    //Display a Toast with an error if the user doesn't exist
+                    if (e.getReason().equals("USER_DOESNT_EXIST")) {
+                        messageSentStatus = getString(R.string.msg_send_user_dne);
+                    }
+
                     //todo show captcha
                 }
             }
             return null;
         }
-    }
 
+        @Override
+        public void onPostExecute(Void voids) {
+            //If the error wasn't that the user doesn't exist, show a generic failure message
+            if (messageSentStatus == null) {
+                messageSentStatus = getString(R.string.msg_sent_failure);
+            }
+
+            final String MESSAGE_SENT = (messageSent)
+                    ? getString(R.string.msg_sent_success) : messageSentStatus;
+
+            Toast.makeText(Sendmessage.this, MESSAGE_SENT, Toast.LENGTH_SHORT).show();
+
+            //Only finish() this Activity if the message sent successfully
+            if (messageSent) {
+                finish();
+            } else {
+                messageSent = true;
+            }
+        }
+    }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/DoEditorActions.java
@@ -54,6 +54,7 @@ import me.ccrama.redditslide.ColorPreferences;
 import me.ccrama.redditslide.Drafts;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.SecretConstants;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.SubmissionParser;

--- a/app/src/main/res/layout/activity_sendmessage.xml
+++ b/app/src/main/res/layout/activity_sendmessage.xml
@@ -34,10 +34,11 @@
 
             <TextView
                 android:id="@+id/oldMSG"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingBottom="16dp"
-                android:paddingTop="16dp"
+                android:background="?android:selectableItemBackground"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:text="@string/mail_theirs"
                 android:textAllCaps="true"
                 android:textColor="?attr/font"
@@ -47,6 +48,7 @@
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:textColorHint="?attr/font">
 
                 <EditText
@@ -59,6 +61,7 @@
                     android:maxLength="21"
                     android:maxLines="1"
                     android:textColor="?attr/font" />
+                <requestFocus />
             </android.support.design.widget.TextInputLayout>
 
             <android.support.design.widget.TextInputLayout
@@ -75,7 +78,6 @@
                     android:maxLength="300"
                     android:maxLines="1"
                     android:textColor="?attr/font">
-                    <requestFocus />
                 </EditText>
             </android.support.design.widget.TextInputLayout>
 
@@ -108,9 +110,9 @@
                 android:id="@+id/preview"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
+                android:layout_gravity="end"
                 android:background="?android:selectableItemBackground"
-                android:padding="6dp"
+                android:padding="8dp"
                 android:text="@string/btn_preview"
                 android:textAllCaps="true"
                 android:textColor="?attr/font"
@@ -124,9 +126,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_gravity="bottom|end"
-        android:layout_margin="16dp"
+        android:layout_margin="@dimen/activity_vertical_margin"
         android:tint="@color/white"
         app:fabSize="normal"
         app:layout_behavior="me.ccrama.slideforreddit.AutoHideFAB"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -746,6 +746,9 @@
     <string name="dialog_no_drafts">No drafts yet</string>
     <string name="dialog_no_drafts_msg">You can add a draft by clicking the \'save\' icon in the editor bar!</string>
     <string name="msg_save_draft">Message saved as a draft</string>
+    <string name="msg_sent_success">Message sent</string>
+    <string name="msg_sent_failure">Message failed to send</string>
+    <string name="msg_send_user_dne">That user doesn\'t exist</string>
     <string name="content_removed">[removed]</string>
     <string name="guest">Guest</string>
     <string name="err_comment_post_nosave_message">\nPlease try again in a minute</string>


### PR DESCRIPTION
- Doesn't hide the FAB anymore
- Displays a Toast with a message of success or failure
    - if the failure was because an incorrect username was the recipient, the Toast will show a "This user doesn't exist" message
- If sending the message failed for whatever reason, stay on this screen so the user will get another opportunity to possibly correct their error
- When composing a message, `requestFocus()` on the `to` field
- When replying to a message, disable editing in the `to` and `subject` fields
- Layout improvements
- General cleanup to the code