### PR TITLE
Check domain boundaries in host comparisons

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -16,13 +16,36 @@ import java.util.HashMap;
  * Created by ccrama on 5/26/2015.
  */
 public class ContentType {
+    /**
+     * Checks if {@code host} is contains by any of the provided {@code bases}
+     *
+     * For example "www.youtube.com" contains "youtube.com" but not "notyoutube.com" or
+     * "youtube.co.uk"
+     *
+     * @param host A hostname from e.g. {@link URI#getHost()}
+     * @param bases Any number of hostnames to compare against {@code host}
+     * @return If {@code host} contains any of {@code bases}
+     */
+    public static boolean hostContains(String host, String... bases) {
+        if (host == null || host.isEmpty()) return false;
+
+        for (String base : bases) {
+            if (base == null || base.isEmpty()) continue;
+
+            final int index = host.indexOf(base);
+            if (index < 0 || index + base.length() != host.length()) continue;
+            if (base.length() == host.length() || host.charAt(index - 1) == '.') return true;
+        }
+
+        return false;
+    }
 
     public static boolean isGif(URI uri) {
         try {
             final String host = uri.getHost().toLowerCase();
             final String path = uri.getPath().toLowerCase();
 
-            return host.endsWith("gfycat.com")
+            return hostContains(host, "gfycat.com")
                     || path.endsWith(".gif")
                     || path.endsWith(".gifv")
                     || path.endsWith(".webm")
@@ -53,7 +76,7 @@ public class ContentType {
             final String host = uri.getHost().toLowerCase();
             final String path = uri.getPath().toLowerCase();
 
-            return (host.endsWith("imgur.com") || host.endsWith("bildgur.de"))
+            return hostContains(host, "imgur.com", "bildgur.de")
                     && (path.startsWith("/a/")
                     || path.startsWith("/gallery/")
                     || path.startsWith("/g/")
@@ -64,12 +87,14 @@ public class ContentType {
         }
     }
 
-    public static boolean isRedditLink(URI uri) {
+    public static boolean isVideo(URI uri) {
         try {
             final String host = uri.getHost().toLowerCase();
+            final String path = uri.getPath().toLowerCase();
 
-            return host.endsWith("reddit.com")
-                    || host.endsWith("redd.it");
+            return Reddit.videoPlugin
+                    && hostContains(host, "youtu.be", "youtube.com", "youtube.co.uk")
+                    && !path.contains("/user/");
 
         } catch (NullPointerException e) {
             return false;
@@ -81,7 +106,7 @@ public class ContentType {
             final URI uri = new URI(url);
             final String host = uri.getHost().toLowerCase();
 
-            return (host.endsWith("imgur.com") || host.endsWith("bildgur.de"))
+            return hostContains(host, "imgur.com", "bildgur.de")
                     && !isAlbum(uri)
                     && !isGif(uri)
                     && !isImage(uri);
@@ -121,9 +146,10 @@ public class ContentType {
             if (!scheme.equals("http") && !scheme.equals("https")) {
                 return Type.EXTERNAL;
             }
-            if (Reddit.videoPlugin && ((host.equals("youtu.be") || host.startsWith("youtube.co") || host.contains(".youtube.co"))) && !url.contains("/user/")) {
+            if (isVideo(uri)) {
                 return Type.VIDEO;
-            } else if (PostMatch.openExternal(url)) {
+            }
+            if (PostMatch.openExternal(url)) {
                 return Type.EXTERNAL;
             }
             if (isGif(uri)) {
@@ -135,22 +161,19 @@ public class ContentType {
             if (isAlbum(uri)) {
                 return Type.ALBUM;
             }
-            if (host.endsWith("imgur.com")) {
+            if (hostContains(host, "imgur.com", "bildgur.de")) {
                 return Type.IMGUR;
             }
-            if (host.endsWith("bildgur.de")) {
-                return Type.IMGUR;
-            }
-            if (isRedditLink(uri)) {
+            if (hostContains(host, "reddit.com", "redd.it")) {
                 return Type.REDDIT;
             }
-            if (host.endsWith("vid.me")) {
+            if (hostContains(host, "vid.me")) {
                 return Type.VID_ME;
             }
-            if (host.endsWith("deviantart.com")) {
+            if (hostContains(host, "deviantart.com")) {
                 return Type.DEVIANTART;
             }
-            if (host.endsWith("streamable.com")) {
+            if (hostContains(host, "streamable.com")) {
                 return Type.STREAMABLE;
             }
 

--- a/app/src/main/java/me/ccrama/redditslide/PostMatch.java
+++ b/app/src/main/java/me/ccrama/redditslide/PostMatch.java
@@ -34,7 +34,7 @@ public class PostMatch {
         URL domain = new URL(target);
         for (String s : strings) {
             if (!s.contains("/")) {
-                if (domain.getHost().endsWith(s)) {
+                if (ContentType.hostContains(domain.getHost(), s)) {
                     return true;
                 } else {
                     continue;
@@ -48,7 +48,7 @@ public class PostMatch {
             try {
                 URL comparison = new URL(s.toLowerCase());
 
-                if (domain.getHost().endsWith(comparison.getHost())
+                if (ContentType.hostContains(domain.getHost(), comparison.getHost())
                         && domain.getPath().startsWith(comparison.getPath())) {
                     return true;
                 }

--- a/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/ContentTypeTest.java
@@ -10,7 +10,9 @@ import me.ccrama.redditslide.SettingValues;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
 public class ContentTypeTest {
@@ -18,6 +20,20 @@ public class ContentTypeTest {
     @BeforeClass
     public static void setUp() {
         SettingValues.alwaysExternal = "twitter.com,github.com,t.co,example.com/path";
+    }
+
+    @Test
+    public void comparesHosts() {
+        assertTrue(ContentType.hostContains("www.example.com", "example.com"));
+        assertTrue(ContentType.hostContains("www.example.com", "www.example.com"));
+        assertTrue(ContentType.hostContains("www.example.com", "no-match", "example.com"));
+        assertTrue(ContentType.hostContains("www.example.com", "", null, "example.com"));
+        assertTrue(ContentType.hostContains("www.example.com", "example.com", "no-match"));
+
+        assertFalse(ContentType.hostContains("www.example.com", "www.example.com.au"));
+        assertFalse(ContentType.hostContains("www.example.com", "www.example"));
+        assertFalse(ContentType.hostContains("www.example.com", "notexample.com"));
+        assertFalse(ContentType.hostContains("www.example.com", ""));
     }
 
     @Test
@@ -103,6 +119,8 @@ public class ContentTypeTest {
         Reddit.videoPlugin = true;
         assertThat(ContentType.getContentType("https://www.youtube.com/watch?v=lX_pF03vCSU"), is(Type.VIDEO));
         assertThat(ContentType.getContentType("https://youtu.be/lX_pF03vCSU"), is(Type.VIDEO));
+
+        assertThat(ContentType.getContentType("https://www.gifyoutube.com/"), is(not(Type.VIDEO)));
 
         Reddit.videoPlugin = false;
         assertThat(ContentType.getContentType("https://www.youtube.com/watch?v=lX_pF03vCSU"), is(not(Type.VIDEO)));


### PR DESCRIPTION
e.g. `youtube.com` will no longer match `gifyoutube.com`, it's used in both content type tests and postmatch so a user could now add `t.co` without blocking any domains ending with a t on the co TLD. 

It is a stricter match but I can't think of a domain that has multiple non subdomain prefixes where it would cause confusion. It may impact users if they hadn't decided to type out the full domain, but I would imagine that's rare if it happens at all

edit: also this build will fail, because it's already failing, I tested it on non failing version then applied to latest 