### PR TITLE
Added option for small thumbnails and large thumbnails

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
@@ -141,8 +141,18 @@ public class EditCardsLayout extends BaseActivityAnim {
             });
         }
         //Pic modes//
+        final TextView CURRENT_PICTURE = (TextView) findViewById(R.id.picture_current);
+        assert CURRENT_PICTURE != null; //it won't be
 
-        ((TextView) findViewById(R.id.picture_current)).setText(SettingValues.bigPicEnabled ? (SettingValues.bigPicCropped ? getString(R.string.mode_cropped) : getString(R.string.mode_bigpic)) : getString(R.string.mode_thumbnail));
+        if (SettingValues.bigPicEnabled) {
+            CURRENT_PICTURE.setText(R.string.mode_bigpic);
+        } else if (SettingValues.bigPicCropped) {
+            CURRENT_PICTURE.setText(R.string.mode_cropped);
+        } else if (SettingValues.bigThumbnails) {
+            CURRENT_PICTURE.setText(R.string.mode_big_thumbnails);
+        } else {
+            CURRENT_PICTURE.setText(R.string.mode_small_thumbnails);
+        }
 
         findViewById(R.id.picture).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -155,6 +165,7 @@ public class EditCardsLayout extends BaseActivityAnim {
                         switch (item.getItemId()) {
                             case R.id.bigpic:
                                 layout.removeAllViews();
+                                SettingValues.bigThumbnails = true;
                                 layout.addView(CreateCardView.setBigPicEnabled(true, layout));
                             {
                                 SharedPreferences.Editor e = SettingValues.prefs.edit();
@@ -168,10 +179,12 @@ public class EditCardsLayout extends BaseActivityAnim {
                             break;
                             case R.id.cropped:
                                 layout.removeAllViews();
+                                SettingValues.bigThumbnails = true;
                                 layout.addView(CreateCardView.setBigPicCropped(true, layout));
                                 break;
-                            case R.id.thumbnail:
+                            case R.id.small_thumbnails:
                                 layout.removeAllViews();
+                                SettingValues.bigThumbnails = false;
                                 layout.addView(CreateCardView.setBigPicEnabled(false, layout));
                             {
                                 SharedPreferences.Editor e = SettingValues.prefs.edit();
@@ -180,15 +193,39 @@ public class EditCardsLayout extends BaseActivityAnim {
                                         e.remove(map.getKey()); //reset all overridden values
                                     }
                                 }
+                                SettingsTheme.changed = true;
+                                e.apply();
+                            }
+                            break;
+                            case R.id.big_thumbnails:
+                                layout.removeAllViews();
+                                SettingValues.bigThumbnails = true;
+                                layout.addView(CreateCardView.setBigPicEnabled(false, layout));
+                            {
+                                SharedPreferences.Editor e = SettingValues.prefs.edit();
+                                for (Map.Entry<String, ?> map : SettingValues.prefs.getAll().entrySet()) {
+                                    if (map.getKey().startsWith("picsenabled")) {
+                                        e.remove(map.getKey()); //reset all overridden values
+                                    }
+                                }
+                                SettingsTheme.changed = true;
                                 e.apply();
                             }
                             break;
                         }
-                        ((TextView) findViewById(R.id.picture_current)).setText(SettingValues.bigPicEnabled ? (SettingValues.bigPicCropped ? getString(R.string.mode_cropped) : getString(R.string.mode_bigpic)) : getString(R.string.mode_thumbnail));
+
+                        if (SettingValues.bigPicEnabled) {
+                            CURRENT_PICTURE.setText(R.string.mode_bigpic);
+                        } else if (SettingValues.bigPicCropped) {
+                            CURRENT_PICTURE.setText(R.string.mode_cropped);
+                        } else if (SettingValues.bigThumbnails) {
+                            CURRENT_PICTURE.setText(R.string.mode_big_thumbnails);
+                        } else {
+                            CURRENT_PICTURE.setText(R.string.mode_small_thumbnails);
+                        }
                         return true;
                     }
                 });
-
                 popup.show();
             }
         });

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -2821,8 +2821,9 @@ public class MainActivity extends BaseActivity {
         }
         Reddit.setDefaultErrorHandler(this);
 
-        if (sideArrayAdapter != null)
+        if (sideArrayAdapter != null) {
             sideArrayAdapter.updateHistory(UserSubscriptions.getHistory());
+        }
 
         if (datasetChanged && UserSubscriptions.hasSubs() && !usedArray.isEmpty()) {
             usedArray = new ArrayList<>(UserSubscriptions.getSubscriptions(this));
@@ -2836,7 +2837,8 @@ public class MainActivity extends BaseActivity {
             setToolbarClick();
         }
         //Only refresh the view if a Setting was altered
-        if (Settings.changed || SettingsTheme.changed || (NetworkUtil.isConnected(this) && usedArray != null && usedArray.size() != UserSubscriptions.getSubscriptions(this).size())) {
+        if (Settings.changed || SettingsTheme.changed || (NetworkUtil.isConnected(this) && usedArray != null
+                && usedArray.size() != UserSubscriptions.getSubscriptions(this).size())) {
 
             int current = pager.getCurrentItem();
             if (commentPager && current == currentComment) {
@@ -2875,7 +2877,6 @@ public class MainActivity extends BaseActivity {
                 }
                 SettingsGeneral.searchChanged = false;
             }
-
             SettingsTheme.changed = false;
             Settings.changed = false;
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -1179,7 +1179,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             //Make a space the size of the toolbar minus 1 so there isn't a gap
             firstHolder.itemView.findViewById(R.id.height)
                     .setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
-                            (Constants.SINGLE_HEADER_VIEW_OFFSET - Reddit.dpToPx(1) + mPage.shownHeaders)));
+                            (Constants.SINGLE_HEADER_VIEW_OFFSET - Reddit.dpToPxVertical(1) + mPage.shownHeaders)));
         }
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionViewHolder.java
@@ -2,6 +2,7 @@ package me.ccrama.redditslide.Adapters;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import me.ccrama.redditslide.R;
@@ -33,6 +34,7 @@ public class SubmissionViewHolder extends RecyclerView.ViewHolder {
     public final View save;
     public final TextView flairText;
     public final SpoilerRobotoTextView body;
+    public final RelativeLayout innerRelative;
 
     public SubmissionViewHolder(View v) {
         super(v);
@@ -56,6 +58,6 @@ public class SubmissionViewHolder extends RecyclerView.ViewHolder {
         comments = (TextView) v.findViewById(R.id.comments);
         firstTextView = (SpoilerRobotoTextView) v.findViewById(R.id.firstTextView);
         commentOverflow = (CommentOverflow) v.findViewById(R.id.commentOverflow);
-
+        innerRelative = (RelativeLayout) v.findViewById(R.id.innerrelative);
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Constants.java
+++ b/app/src/main/java/me/ccrama/redditslide/Constants.java
@@ -12,14 +12,14 @@ public class Constants {
      * Use this for calculating the SwipeToRefresh (PTR) progresses indicator offset when using
      * "Tabs" view mode.
      */
-    public static final int TAB_HEADER_VIEW_OFFSET = Reddit.dpToPx(108);
+    public static final int TAB_HEADER_VIEW_OFFSET = Reddit.dpToPxVertical(108);
 
     /**
      * This is the estimated height of the toolbar height in dp.
      * Use this for calculating the SwipeToRefresh (PTR) progresses indicator offset when using
      * "Single" view mode.
      */
-    public static final int SINGLE_HEADER_VIEW_OFFSET = Reddit.dpToPx(56);
+    public static final int SINGLE_HEADER_VIEW_OFFSET = Reddit.dpToPxVertical(56);
 
     /**
      * These offsets are used for the SwipeToRefresh (PTR) progress indicator.
@@ -27,6 +27,6 @@ public class Constants {
      * The BOTTOM offset is used for the end point of the indicator (below the toolbar).
      * This is used whenever we call mSwipeRefreshLayout.setProgressViewOffset().
      */
-    public static final int PTR_OFFSET_TOP = Reddit.dpToPx(40);
-    public static final int PTR_OFFSET_BOTTOM = Reddit.dpToPx(18);
+    public static final int PTR_OFFSET_TOP = Reddit.dpToPxVertical(40);
+    public static final int PTR_OFFSET_BOTTOM = Reddit.dpToPxVertical(18);
 }

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -130,16 +130,24 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     }
 
     /**
-     * Converts dp to px
-     *
+     * Converts dp to px, uses vertical density
      * @param dp to convert to px
      * @return px
      */
-    public static int dpToPx(int dp) {
+    public static int dpToPxVertical(int dp) {
         final DisplayMetrics displayMetrics = Resources.getSystem().getDisplayMetrics();
         return Math.round(dp * (displayMetrics.ydpi / DisplayMetrics.DENSITY_DEFAULT));
     }
 
+    /**
+     * Converts dp to px, uses general density
+     * @param dp to convert to px
+     * @return px
+     */
+    public static int dpToPxGeneral(int dp) {
+        final DisplayMetrics displayMetrics = Resources.getSystem().getDisplayMetrics();
+        return Math.round(dp * (displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT));
+    }
 
     public static void defaultShareText(String title, String url, Context c) {
         Intent sharingIntent = new Intent(Intent.ACTION_SEND);

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -53,6 +53,7 @@ public class SettingValues {
     public static final String PREF_CROP_IMAGE = "cropImage";
     public static final String PREF_COMMENT_FAB = "commentFab";
     public static final String PREF_SWITCH_THUMB = "switchThumb";
+    public static final String PREF_BIG_THUMBS = "bigThumbnails";
     public static final String PREF_LOW_RES_ALWAYS = "lowResAlways";
     public static final String PREF_LOW_RES_MOBILE = "lowRes";
     public static final String PREF_IMAGE_LQ = "imageLq";
@@ -159,6 +160,7 @@ public class SettingValues {
     public static boolean autoTime;
     public static boolean albumSwipe;
     public static boolean switchThumb;
+    public static boolean bigThumbnails;
     public static boolean commentPager;
     public static boolean colorSubName;
     public static boolean hideSelftextLeadImage;
@@ -249,6 +251,7 @@ public class SettingValues {
 
         cropImage = prefs.getBoolean(PREF_CROP_IMAGE, true);
         switchThumb = prefs.getBoolean(PREF_SWITCH_THUMB, true);
+        bigThumbnails = prefs.getBoolean(PREF_BIG_THUMBS, true);
 
         swipeAnywhere = true; //override this always now
         album = prefs.getBoolean(PREF_ALBUM, true);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -33,6 +33,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -63,6 +64,7 @@ import java.util.Map;
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.Album;
 import me.ccrama.redditslide.Activities.AlbumPager;
+import me.ccrama.redditslide.Activities.CommentsScreen;
 import me.ccrama.redditslide.Activities.FullscreenVideo;
 import me.ccrama.redditslide.Activities.MainActivity;
 import me.ccrama.redditslide.Activities.MediaView;
@@ -1629,6 +1631,22 @@ public class PopulateSubmissionViewHolder {
         }
 
         ImageView thumbImage2 = ((ImageView) holder.thumbimage);
+
+        /**
+         * If the user wants small thumbnails, revert the list style to the "old" list view.
+         * The "old" thumbnails were (65dp x 65dp).
+         * Adjusts the paddingTop of the innerrelative, and adjusts the margins on the thumbnail.
+         * Don't do it on the CommentsScreen though, because then we get Force Closes. :(
+         */
+        if (!SettingValues.bigThumbnails && !(mContext instanceof CommentsScreen)) {
+            thumbImage2.getLayoutParams().height = Reddit.dpToPxGeneral(65);
+            thumbImage2.getLayoutParams().width = Reddit.dpToPxGeneral(65);
+
+            final int EIGHT_DP = Reddit.dpToPxGeneral(8);
+            ((RelativeLayout.LayoutParams) thumbImage2.getLayoutParams())
+                    .setMargins(EIGHT_DP, 0, EIGHT_DP, EIGHT_DP);
+            holder.innerRelative.setPadding(0, EIGHT_DP, 0, 0);
+        }
 
         if (holder.leadImage.thumbImage2 == null) {
             holder.leadImage.setThumbnail(thumbImage2);

--- a/app/src/main/java/me/ccrama/redditslide/Views/CommentOverflow.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/CommentOverflow.java
@@ -6,7 +6,6 @@ import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.util.TypedValue;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.HorizontalScrollView;
@@ -23,7 +22,6 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Visuals.FontPreferences;
-import me.ccrama.redditslide.util.LogUtil;
 
 /**
  * Class that provides methods to help bind submissions with
@@ -100,7 +98,7 @@ public class CommentOverflow extends LinearLayout {
                 scrollView.setScrollbarFadingEnabled(false);
                 TableLayout table = formatTable(block, subreddit);
                 scrollView.setLayoutParams(MARGIN_PARAMS);
-                table.setPaddingRelative(0, 0, 0, Reddit.dpToPx(10));
+                table.setPaddingRelative(0, 0, 0, Reddit.dpToPxVertical(10));
                 scrollView.addView(table);
                 addView(scrollView);
 
@@ -111,7 +109,7 @@ public class CommentOverflow extends LinearLayout {
                 newTextView.setTextHtml(block, subreddit);
                 setStyle(newTextView, subreddit);
                 scrollView.setLayoutParams(MARGIN_PARAMS);
-                newTextView.setPaddingRelative(0, 0, 0, Reddit.dpToPx(10));
+                newTextView.setPaddingRelative(0, 0, 0, Reddit.dpToPxVertical(10));
                 scrollView.addView(newTextView);
                 addView(scrollView);
 

--- a/app/src/main/java/me/ccrama/redditslide/Views/CreateCardView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/CreateCardView.java
@@ -40,7 +40,6 @@ public class CreateCardView {
             case LIST:
                 v = LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.submission_list, viewGroup, false);
                 break;
-
         }
 
         doHideObjects(v);
@@ -177,45 +176,40 @@ public class CreateCardView {
     public static View setCardViewType(CardEnum cardEnum, ViewGroup parent) {
         SettingValues.prefs.edit().putBoolean("middleCard", false).apply();
         SettingValues.middleImage = false;
+
         SettingValues.prefs.edit().putString("defaultCardViewNew", cardEnum.name()).apply();
         SettingValues.defaultCardView = cardEnum;
+
         return CreateView(parent);
     }
 
-
     public static View setBigPicEnabled(Boolean b, ViewGroup parent) {
-
-
         SettingValues.prefs.edit().putBoolean("bigPicEnabled", b).apply();
-
         SettingValues.bigPicEnabled = b;
+
         SettingValues.prefs.edit().putBoolean("bigPicCropped", false).apply();
-
         SettingValues.bigPicCropped = false;
+
         return CreateView(parent);
-
-
     }
 
     public static View setBigPicCropped(Boolean b, ViewGroup parent) {
-
         SettingValues.prefs.edit().putBoolean("bigPicEnabled", b).apply();
-
         SettingValues.bigPicEnabled = b;
 
         SettingValues.prefs.edit().putBoolean("bigPicCropped", b).apply();
-
         SettingValues.bigPicCropped = b;
+
         return CreateView(parent);
-
-
     }
 
     public static View setMiddleCard(boolean b, ViewGroup parent) {
         SettingValues.prefs.edit().putString("defaultCardViewNew", CardEnum.LARGE.name()).apply();
         SettingValues.defaultCardView = CardEnum.LARGE;
+
         SettingValues.prefs.edit().putBoolean("middleCard", b).apply();
         SettingValues.middleImage = b;
+
         return CreateView(parent);
     }
 
@@ -267,14 +261,14 @@ public class CreateCardView {
     public static void animateIn(View l) {
         l.setVisibility(View.VISIBLE);
 
-        ValueAnimator mAnimator = slideAnimator(0, Reddit.dpToPx(36), l);
+        ValueAnimator mAnimator = slideAnimator(0, Reddit.dpToPxVertical(36), l);
 
         mAnimator.start();
     }
 
     public static void animateOut(final View l) {
 
-        ValueAnimator mAnimator = slideAnimator(Reddit.dpToPx(36), 0, l);
+        ValueAnimator mAnimator = slideAnimator(Reddit.dpToPxVertical(36), 0, l);
         mAnimator.addListener(new Animator.AnimatorListener() {
             @Override
             public void onAnimationStart(Animator animation) {
@@ -438,7 +432,6 @@ public class CreateCardView {
 
     }
 
-
     public enum CardEnum {
         LARGE("Big Card"),
         LIST("List");
@@ -452,6 +445,4 @@ public class CreateCardView {
             return displayName;
         }
     }
-
-
 }

--- a/app/src/main/res/layout/submission_largecard.xml
+++ b/app/src/main/res/layout/submission_largecard.xml
@@ -31,8 +31,8 @@
 
             <com.makeramen.roundedimageview.RoundedImageView
                 android:id="@+id/thumbimage2"
-                android:layout_width="@dimen/thumbnail_width"
-                android:layout_height="@dimen/thumbnail_height"
+                android:layout_width="@dimen/big_thumbnail_width"
+                android:layout_height="@dimen/big_thumbnail_height"
                 android:layout_alignParentTop="true"
                 android:layout_marginBottom="8dp"
                 android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/submission_largecard_middle.xml
+++ b/app/src/main/res/layout/submission_largecard_middle.xml
@@ -25,8 +25,8 @@
 
             <com.makeramen.roundedimageview.RoundedImageView
                 android:id="@+id/thumbimage2"
-                android:layout_width="@dimen/thumbnail_width"
-                android:layout_height="@dimen/thumbnail_height"
+                android:layout_width="@dimen/big_thumbnail_width"
+                android:layout_height="@dimen/big_thumbnail_height"
                 android:layout_alignParentTop="true"
                 android:layout_marginBottom="8dp"
                 android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/submission_list.xml
+++ b/app/src/main/res/layout/submission_list.xml
@@ -11,7 +11,7 @@
     android:layerType="hardware"
     android:orientation="vertical"
     cardview:cardBackgroundColor="?attr/card_background"
-    cardview:cardCornerRadius=".25dp"
+    cardview:cardCornerRadius="0.25dp"
     cardview:cardElevation="0dp"
     cardview:cardMaxElevation="0dp">
 
@@ -35,8 +35,8 @@
 
             <com.makeramen.roundedimageview.RoundedImageView
                 android:id="@+id/thumbimage2"
-                android:layout_width="@dimen/thumbnail_width"
-                android:layout_height="@dimen/thumbnail_height"
+                android:layout_width="@dimen/big_thumbnail_width"
+                android:layout_height="@dimen/big_thumbnail_height"
                 android:layout_alignParentTop="true"
                 android:layout_marginTop="6dp"
                 android:layout_marginBottom="8dp"

--- a/app/src/main/res/menu/pic_mode_settings.xml
+++ b/app/src/main/res/menu/pic_mode_settings.xml
@@ -9,7 +9,11 @@
         android:title="@string/mode_cropped"/>
 
     <item
-        android:id="@+id/thumbnail"
-        android:title="@string/mode_thumbnail"/>
+        android:id="@+id/small_thumbnails"
+        android:title="@string/mode_small_thumbnails"/>
+
+    <item
+        android:id="@+id/big_thumbnails"
+        android:title="@string/mode_big_thumbnails"/>
 
 </menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,6 +15,11 @@
     <!-- Material Design's dimension for a standard toolbar -->
     <dimen name="standard_toolbar_height">56dp</dimen>
 
-    <dimen name="thumbnail_width">100dp</dimen>
-    <dimen name="thumbnail_height">70dp</dimen>
+    <!-- Big thumbnails -->
+    <dimen name="big_thumbnail_width">100dp</dimen>
+    <dimen name="big_thumbnail_height">70dp</dimen>
+
+    <!-- Small thumbnails -->
+    <dimen name="small_thumbnail_width">65dp</dimen>
+    <dimen name="small_thumbnail_height">65dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -659,7 +659,8 @@
     <string name="mode_list">List</string>
     <string name="mode_centered">Card with centered image</string>
     <string name="mode_card">Card</string>
-    <string name="mode_thumbnail">Thumbnail only</string>
+    <string name="mode_big_thumbnails">Big Thumbnails</string>
+    <string name="mode_small_thumbnails">Small Thumbnails</string>
     <string name="mode_cropped">Big picture cropped</string>
     <string name="mode_bigpic">Big picture</string>
     <string name="settings_general_swipeanywhere_description">Swipe anywhere in view to exit</string>


### PR DESCRIPTION
Two things I couldn't fix
- When changing the thumbnail size--the card in Layout Settings doesn't update to reflect the changes between the thumbnail size.
- When changing the thumbnail size, upon returning to the `MainActivity`, the view wouldn't refresh--so you'd still have the old setting. I think this happened when switching between the two sizes only. (i.e. Big -> Small == no refresh; Big/Small -> Big picture cropped == refresh). To mitigate this, I just used the `SettingsTheme.changed = true;` workaround to force a refresh. This was a workaround, and not a fix--but I couldn't figure it out. :|