### PR TITLE
Update Play/F-Droid badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Slide is available on the Google Play Store and F-Droid.
 <a href="https://play.google.com/store/apps/details?id=me.ccrama.redditslide">
     <img alt="Get it on Google Play"
         height="60"
-        src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+        src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" />
 </a>
 [![Get it on F-Droid](https://f-droid.org/wiki/images/0/06/F-Droid-button_get-it-on.png)](https://f-droid.org/app/me.ccrama.redditslide)
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ Slide is available on the Google Play Store and F-Droid.
 
 <a href="https://play.google.com/store/apps/details?id=me.ccrama.redditslide">
     <img alt="Get it on Google Play"
-        height="60"
+        height="80"
         src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" />
 </a>
-[![Get it on F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/app/me.ccrama.redditslide)
+<a href="https://f-droid.org/app/me.ccrama.redditslide">
+    <img alt="Get it on F-Droid"
+        height="80"
+        src="https://f-droid.org/badge/get-it-on.png" />
+</a>
 
 There is an active community for Slide on the
 [/r/slideforreddit](https://www.reddit.com/r/slideforreddit/) subreddit,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Slide is available on the Google Play Store and F-Droid.
         height="60"
         src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" />
 </a>
-[![Get it on F-Droid](https://f-droid.org/wiki/images/0/06/F-Droid-button_get-it-on.png)](https://f-droid.org/app/me.ccrama.redditslide)
+[![Get it on F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/app/me.ccrama.redditslide)
 
 There is an active community for Slide on the
 [/r/slideforreddit](https://www.reddit.com/r/slideforreddit/) subreddit,

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ width="200"
 Slide is an open source, ad free Reddit browser for Android. It is based around
 the [Java Reddit API Wrapper](https://github.com/thatJavaNerd/JRAW).
 
-Slide is available on the Google Play Store and F-Droid.
-
+Slide is available on the Google Play Store and F-Droid.  
 <a href="https://play.google.com/store/apps/details?id=me.ccrama.redditslide">
     <img alt="Get it on Google Play"
         height="80"
@@ -18,8 +17,7 @@ Slide is available on the Google Play Store and F-Droid.
     <img alt="Get it on F-Droid"
         height="80"
         src="https://f-droid.org/badge/get-it-on.png" />
-</a>
-
+</a>  
 There is an active community for Slide on the
 [/r/slideforreddit](https://www.reddit.com/r/slideforreddit/) subreddit,
 which anybody is welcome to join.


### PR DESCRIPTION
I updated the download badges to the latest versions, and made them the same size.

Previous:

![image](https://cloud.githubusercontent.com/assets/9433472/16006733/8aa75e5e-3166-11e6-9ba1-67511449fc26.png)

New:

![image](https://cloud.githubusercontent.com/assets/9433472/16006744/96945a0a-3166-11e6-8aec-6e39e1056f0e.png)

The large padding around the logos is mandated by [Google's badge policy](https://play.google.com/intl/en_gb/badges/):

> There must be clear space surrounding the badge equal to one-quarter the height of the badge.

The padding above and below can be mitigated somewhat by using line breaks instead of separate paragraphs:

![image](https://cloud.githubusercontent.com/assets/9433472/16006873/33366fc4-3167-11e6-84a5-2b872bb2d1c8.png)

so I can add that to this PR if people think it looks better.

Resolves #1818