### PR TITLE
Fix the in menu copy text icon to match function of command.

### DIFF
--- a/app/src/main/res/layout/postmenu.xml
+++ b/app/src/main/res/layout/postmenu.xml
@@ -234,7 +234,7 @@
                             android:layout_height="match_parent"
                             android:alpha=".86"
                             android:padding="12dp"
-                            app:srcCompat="@drawable/infonew"
+                            app:srcCompat="@drawable/ic_content_copy"
                             android:tint="?attr/tint" />
 
                         <TextView


### PR DESCRIPTION
@Nxt3 This fixes the icon in the drop down menu, such that the copy text icon matches the function of the menu command. See after and before screenshots, respectively, for clarity.
 
![newicon](https://cloud.githubusercontent.com/assets/3961523/16317058/f07af548-394e-11e6-9a0a-ceda8b629a93.JPG)
![odlicon](https://cloud.githubusercontent.com/assets/3961523/16317057/f079b07a-394e-11e6-8f55-7cfc74aa44f7.JPG)

