### PR TITLE
add missing break statement

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
@@ -325,6 +325,7 @@ public class PopulateShadowboxInfo {
                             break;
                             case 7:
                                 LinkUtil.openExternally(submission.getUrl(), mContext, true);
+                                break;
                             case 4:
                                 Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);
                                 break;


### PR DESCRIPTION
avoids opening the share window when trying to open externally