### PR TITLE
"Share Image" action now stores images to app cache

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,18 @@
         android:installLocation="auto"
         android:label="@string/app_name"
         android:theme="@style/yellow_dark">
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="me.ccrama.redditslide.Activities.MediaView"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
         <activity
             android:name=".Activities.Slide"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode"
@@ -43,7 +55,8 @@
                 <data android:scheme="package" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".Activities.MakeExternal"/>
+        <receiver android:name=".Activities.MakeExternal" />
+
         <activity
             android:name=".Activities.SettingsSynccit"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode"
@@ -156,6 +169,7 @@
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <action android:name="android.nfc.action.TECH_DISCOVERED" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -318,11 +332,11 @@
              <meta-data android:name="android.appwidget.provider"
                  android:resource="@xml/subreddit_widget" />
          </receiver> !-->
-        <service
-        android:name=".Notifications.ImageDownloadNotificationService" />
+        <service android:name=".Notifications.ImageDownloadNotificationService" />
         <service
             android:name=".Adapters.MarkAsReadService"
             android:exported="false" />
+
         <receiver android:name=".Widget.SubredditWidgetProvider">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Slide.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Slide.java
@@ -10,10 +10,11 @@ import android.os.Bundle;
 public class Slide extends Activity {
 
     public static boolean hasStarted;
+
     @Override
     public void onCreate(Bundle savedInstance) {
         super.onCreate(savedInstance);
-        if(!hasStarted){
+        if (!hasStarted) {
             hasStarted = true;
             Intent i = new Intent(this, MainActivity.class);
             startActivity(i);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -825,6 +825,7 @@
     <string name="include_personal_info_msg">This includes authentication tokens, usernames, tags, and history</string>
     <string name="err_something_wrong">Uh oh, something went wrong</string>
     <string name="err_couldnt_save_choose_new">Slide couldn\'t save to the selected directory. Would you like to choose a new save location?</string>
+    <string name="err_share_image">Error sharing image</string>
     <string name="set_save_location">Set image save location</string>
     <string name="set_save_location_msg">Slide\'s image save location has not been set yet. Would you like to set this now?</string>
     <string name="really_remove_subreddit_title">Really remove this subreddit?</string>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="shared_images"
+        path="/shared_image" />
+</paths>


### PR DESCRIPTION
I found it annoying that when I selected "Share Image", it downloaded the image without any indication; if I wanted the image stored for later use, I'd download the image; if I'm sharing an image, I expect it to be temporarily stored on the device.

So, save the image to the cache (_/data/user/0/me.ccrama.redditslide/cache/shared_image_) instead!

- Creates a uniquely named file suffixed with `.png`
- If the `shared_image` dir doesn't exist, create it
- If the `shared_image` dir **does** exist, delete all images in the directory (this avoids unnecessarily bloating the cache size, as only the most recently shared image will exist in the cache at any given time)
- Display a Toast message if there was an error

PS: sorry for all the white space stuff. I ran IntelliJ's Code Formatter. The changes start on line 998 in `MediaView` and also in `AndroidManifest.xml` on line 22.