### PR TITLE
Update patch versions of dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.gladed.androidgitversion' version '0.2.7'
+    id 'com.gladed.androidgitversion' version '0.2.13'
 }
 
 apply plugin: 'com.android.application'
@@ -98,15 +98,15 @@ dependencies {
     compile 'com.android.support:customtabs:23.3.0'
     compile 'com.android.support:recyclerview-v7:23.3.0'
     compile 'com.android.support:appcompat-v7:23.3.0'
-    compile 'com.github.rey5137:material:1.2.1'
+    compile 'com.github.rey5137:material:1.2.4'
     withGPlayCompile 'com.google.android.gms:play-services-drive:8.4.0'
-    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
-    compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.4.1'
+    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+    compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.4.1' // ↑ minor
     compile 'com.android.support:cardview-v7:23.3.0'
     compile 'com.cocosw:bottomsheet:1.3.0@aar'
     compile 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
     compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.github.johnkil.android-robototextview:robototextview:2.4.3'
+    compile 'com.github.johnkil.android-robototextview:robototextview:2.4.3' // ↑ minor
     compile 'com.makeramen:roundedimageview:2.2.1'
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.getbase:floatingactionbutton:1.10.1'
@@ -121,13 +121,13 @@ dependencies {
     testCompile 'org.robolectric:shadows-multidex:3.0'
     testCompile 'commons-io:commons-io:2.4'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
-    compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') {
+    compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') { // ↑ major
         transitive = true;
     }
     compile 'com.github.ccrama:commonmark-java:07b304b575'
     compile 'org.jetbrains:annotations-java5:15.0'
     compile 'com.mikepenz:itemanimators:0.2.4@aar'
-    compile 'com.neovisionaries:nv-websocket-client:1.28'
+    compile 'com.neovisionaries:nv-websocket-client:1.28' // ↑ minor
     compile 'com.github.ccrama:PeekAndPop:09adee29f1'
-    compile 'com.theartofdev.edmodo:android-image-cropper:2.2.+'
+    compile 'com.theartofdev.edmodo:android-image-cropper:2.2.5'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,56 +77,57 @@ android {
         exclude 'META-INF/LGPL2.1'
     }
 
-    repositories {
-        maven { url "https://jitpack.io" }
-        mavenCentral()
-        flatDir {
-            dirs 'src/main/assets'
-        }
-    }
+}
 
-    dependencies {
-        compile 'com.github.ccrama:JRAW:206c8156d3'
-        compile('com.github.afollestad.material-dialogs:commons:0.8.5.8@aar') {
-            transitive = true
-        }
-        compile 'com.jakewharton:process-phoenix:1.0.2'
-        compile 'org.ligi:snackengage:0.5'
-        compile 'com.android.support:design:23.3.0'
-        compile 'com.android.support:customtabs:23.3.0'
-        compile 'com.android.support:recyclerview-v7:23.3.0'
-        compile 'com.android.support:appcompat-v7:23.3.0'
-        compile 'com.github.rey5137:material:1.2.1'
-        withGPlayCompile 'com.google.android.gms:play-services-drive:8.4.0'
-        compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
-        compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.4.1'
-        compile 'com.android.support:cardview-v7:23.3.0'
-        compile 'com.cocosw:bottomsheet:1.3.0@aar'
-        compile 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
-        compile 'org.apache.commons:commons-lang3:3.4'
-        compile 'com.github.johnkil.android-robototextview:robototextview:2.4.3'
-        compile 'com.makeramen:roundedimageview:2.2.1'
-        compile 'com.android.support:multidex:1.0.1'
-        compile 'com.getbase:floatingactionbutton:1.10.1'
-        compile 'com.sothree.slidinguppanel:library:3.3.0'
-        compile 'com.github.suckgamony.RapidDecoder:library:7cdfca47fa'
-        compile 'com.github.dasar:shiftcolorpicker:v0.5'
-        compile 'com.squareup.okhttp3:okhttp:3.4.1'
-        compile 'com.google.code.gson:gson:2.7'
-        testCompile 'junit:junit:4.12'
-        testCompile 'org.mockito:mockito-core:1.10.19'
-        testCompile 'org.robolectric:robolectric:3.0'
-        testCompile 'org.robolectric:shadows-multidex:3.0'
-        testCompile 'commons-io:commons-io:2.4'
-        testCompile 'org.hamcrest:hamcrest-all:1.3'
-        compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') {
-            transitive = true;
-        }
-        compile 'com.github.ccrama:commonmark-java:07b304b575'
-        compile 'org.jetbrains:annotations-java5:15.0'
-        compile 'com.mikepenz:itemanimators:0.2.4@aar'
-        compile 'com.neovisionaries:nv-websocket-client:1.28'
-        compile 'com.github.ccrama:PeekAndPop:09adee29f1'
-        compile 'com.theartofdev.edmodo:android-image-cropper:2.2.+'
+repositories {
+    maven { url "https://jitpack.io" }
+    mavenCentral()
+    flatDir {
+        dirs 'src/main/assets'
     }
+}
+
+dependencies {
+    compile 'com.github.ccrama:JRAW:206c8156d3'
+    compile('com.github.afollestad.material-dialogs:commons:0.8.5.8@aar') {
+        transitive = true
+    }
+    compile 'com.jakewharton:process-phoenix:1.0.2'
+    compile 'org.ligi:snackengage:0.5'
+    compile 'com.android.support:design:23.3.0'
+    compile 'com.android.support:customtabs:23.3.0'
+    compile 'com.android.support:recyclerview-v7:23.3.0'
+    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.github.rey5137:material:1.2.1'
+    withGPlayCompile 'com.google.android.gms:play-services-drive:8.4.0'
+    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
+    compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.4.1'
+    compile 'com.android.support:cardview-v7:23.3.0'
+    compile 'com.cocosw:bottomsheet:1.3.0@aar'
+    compile 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
+    compile 'org.apache.commons:commons-lang3:3.4'
+    compile 'com.github.johnkil.android-robototextview:robototextview:2.4.3'
+    compile 'com.makeramen:roundedimageview:2.2.1'
+    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.getbase:floatingactionbutton:1.10.1'
+    compile 'com.sothree.slidinguppanel:library:3.3.0'
+    compile 'com.github.suckgamony.RapidDecoder:library:7cdfca47fa'
+    compile 'com.github.dasar:shiftcolorpicker:v0.5'
+    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.google.code.gson:gson:2.7'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.robolectric:shadows-multidex:3.0'
+    testCompile 'commons-io:commons-io:2.4'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') {
+        transitive = true;
+    }
+    compile 'com.github.ccrama:commonmark-java:07b304b575'
+    compile 'org.jetbrains:annotations-java5:15.0'
+    compile 'com.mikepenz:itemanimators:0.2.4@aar'
+    compile 'com.neovisionaries:nv-websocket-client:1.28'
+    compile 'com.github.ccrama:PeekAndPop:09adee29f1'
+    compile 'com.theartofdev.edmodo:android-image-cropper:2.2.+'
 }


### PR DESCRIPTION
0.2.7 → 0.2.13 https://github.com/gladed/gradle-android-git-version/commits/master
1.2.1 → 1.2.4 https://github.com/rey5137/material/releases
1.9.4 → 1.9.5 https://github.com/nostra13/Android-Universal-Image-Loader/blob/master/CHANGELOG.md

Also uses a fixed version for android-image-cropper, and flattens the build.gradle to stop android-studio complaining