### PR TITLE
Offline mode improvements

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -113,6 +113,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import me.ccrama.redditslide.Adapters.SettingsSubAdapter;
 import me.ccrama.redditslide.Adapters.SideArrayAdapter;
@@ -3419,10 +3421,14 @@ public class MainActivity extends BaseActivity {
                         caching = new CommentCacheAsync(submissions, MainActivity.this, subreddit,
                                 chosen).execute();
                     }
-
+                }).setPositiveButton(R.string.btn_save, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ExecutorService service = Executors.newSingleThreadExecutor();
+                new CommentCacheAsync(submissions, MainActivity.this, subreddit, chosen).executeOnExecutor(service);
+            }
                 })
                 .show();
-
 
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ManageHistory.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ManageHistory.java
@@ -56,7 +56,7 @@ public class ManageHistory extends BaseActivityAnim {
             findViewById(R.id.sync_now).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    new CommentCacheAsync(ManageHistory.this, Reddit.cachedData.getString("toCache", "").split(","), true).execute();
+                    new CommentCacheAsync(ManageHistory.this, Reddit.cachedData.getString("toCache", "").split(",")).execute();
                 }
             });
         } else {
@@ -91,6 +91,28 @@ public class ManageHistory extends BaseActivityAnim {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 SettingValues.prefs.edit().putString(SettingValues.COMMENT_DEPTH, commentDepths.get(which)).apply();
+                            }
+                        });
+                builder.show();
+
+            }
+        });
+
+        final List<String> commentCounts = ImmutableList.of("20", "40", "60", "80", "100");
+        final String[] commentCountArray = new String[commentCounts.size()];
+
+
+        findViewById(R.id.comments_count).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                final String commentCount = SettingValues.prefs.getString(SettingValues.COMMENT_COUNT, "2");
+                AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(ManageHistory.this);
+                builder.setTitle(R.string.comments_count);
+                builder.setSingleChoiceItems(
+                        commentCounts.toArray(commentCountArray), commentCounts.indexOf(commentCount), new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SettingValues.prefs.edit().putString(SettingValues.COMMENT_COUNT, commentCounts.get(which)).apply();
                             }
                         });
                 builder.show();

--- a/app/src/main/java/me/ccrama/redditslide/Autocache/CacheAll.java
+++ b/app/src/main/java/me/ccrama/redditslide/Autocache/CacheAll.java
@@ -20,7 +20,7 @@ public class CacheAll extends BroadcastReceiver {
         if (NetworkUtil.isConnectedNoOverride(c)) {
             if (Reddit.cachedData.getBoolean("wifiOnly", false) && !NetworkUtil.isConnectedWifi(context))
                 return;
-            new CommentCacheAsync(c, Reddit.cachedData.getString("toCache", "").split(","), false).execute();
+            new CommentCacheAsync(c, Reddit.cachedData.getString("toCache", "").split(",")).execute();
 
         }
     }

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -87,6 +87,7 @@ public class SettingValues {
     public static final String PREF_COMMENT_NAV = "commentVolumeNav";
     public static final String PREF_COLOR_COMMENT_DEPTH = "colorCommentDepth";
     public static final String COMMENT_DEPTH = "commentDepth";
+    public static final String COMMENT_COUNT = "commentcount";
     public static final String PREF_USER_FILTERS = "userFilters";
 
     public static CreateCardView.CardEnum defaultCardView;

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -57,6 +57,7 @@ import net.dean.jraw.models.VoteDirection;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,6 +77,7 @@ import me.ccrama.redditslide.Activities.SubredditView;
 import me.ccrama.redditslide.Adapters.CommentAdapter;
 import me.ccrama.redditslide.Adapters.SubmissionViewHolder;
 import me.ccrama.redditslide.Authentication;
+import me.ccrama.redditslide.CommentCacheAsync;
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
@@ -321,6 +323,7 @@ public class PopulateSubmissionViewHolder {
         Drawable hide = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.hide, null);
         final Drawable report = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.report, null);
         Drawable copy = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.ic_content_copy, null);
+        Drawable saveOffline = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.save, null);
         Drawable open = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.openexternal, null);
         Drawable share = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.share, null);
         Drawable reddit = ResourcesCompat.getDrawable(mContext.getResources(), R.drawable.commentchange, null);
@@ -332,6 +335,7 @@ public class PopulateSubmissionViewHolder {
         hide.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         report.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         copy.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        saveOffline.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         open.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         share.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         reddit.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
@@ -352,12 +356,18 @@ public class PopulateSubmissionViewHolder {
             }
             if (Authentication.isLoggedIn) {
                 b.sheet(3, saved, save);
+
+            }
+            b.sheet(26, saveOffline, "Save Offline");
+            if (Authentication.isLoggedIn) {
                 b.sheet(12, report, mContext.getString(R.string.btn_report));
             }
+
         }
         if (submission.getSelftext() != null && !submission.getSelftext().isEmpty() && full) {
             b.sheet(25, copy, "Copy selftext");
         }
+
         boolean hidden = submission.isHidden();
         if (!full && Authentication.didOnline) {
             if (!hidden)
@@ -571,6 +581,10 @@ public class PopulateSubmissionViewHolder {
                         ClipData clip = ClipData.newPlainText("Selftext", Html.fromHtml(submission.getSelftext()));
                         clipboard.setPrimaryClip(clip);
                         Toast.makeText(mContext, "Selftext copied", Toast.LENGTH_SHORT).show();
+                        break;
+                    case 26:
+                        new CommentCacheAsync(Arrays.asList(submission),mContext, CommentCacheAsync.SAVED_SUBMISSIONS, new boolean[]{true,true}).execute();
+                        Toast.makeText(mContext, "Submission saved", Toast.LENGTH_SHORT).show();
                         break;
                 }
             }

--- a/app/src/main/res/layout/activity_manage_history.xml
+++ b/app/src/main/res/layout/activity_manage_history.xml
@@ -127,6 +127,34 @@
 
             </RelativeLayout>
 
+            <RelativeLayout
+                    android:id="@+id/comments_count"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:background="?android:selectableItemBackground"
+                    android:paddingEnd="16dp"
+                    android:paddingStart="16dp">
+
+                <LinearLayout
+                        android:layout_marginEnd="42dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/comments_count"
+                            android:textColor="?attr/font"
+                            android:textSize="16sp" />
+
+                </LinearLayout>
+
+            </RelativeLayout>
+
 
             <View
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -852,6 +852,7 @@
     <string name="go_offline">Go offline</string>
     <string name="cache_wifi_only">Only cache on WiFi</string>
     <string name="comments_depth">Depth of comments to cache</string>
+    <string name="comments_count">Number of comments to cache</string>
     <string name="misc_rate_title">Like Slide?</string>
     <string name="misc_rate_msg">Rate it!</string>
     <string name="sidebar_edit_flair">Edit your flair</string>


### PR DESCRIPTION
• Uses an executor to do caching. So one can continue to use the app while caching.Aysntask prevented that.
• removed caching progress from UI to a notification. Again, so one can continue to use the app while caching.
• Save individual posts offline
• Option for number of comments to cache. Fix #1990
• Multiple caches in parallel (if cached manually)

![screenshot_2016_08_09_15_20_09](https://cloud.githubusercontent.com/assets/6133816/17530786/0cc14a82-5e47-11e6-9c74-7d2d7d6bb3d6.png)
![screenshot_2016_08_09_15_20_38](https://cloud.githubusercontent.com/assets/6133816/17530785/0cc15ea0-5e47-11e6-812b-ead75957a51d.png)
![screenshot_2016_08_09_15_22_05](https://cloud.githubusercontent.com/assets/6133816/17530784/0cc1333a-5e47-11e6-8e11-8e87fe2bdbf8.png)
![screenshot_20160809-153809](https://cloud.githubusercontent.com/assets/6133816/17530847/5261e5ce-5e47-11e6-9ae8-c891a23176e0.png)

