### PR TITLE
Fixed non default subreddits closing themselfes when not logged in

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -1272,7 +1272,7 @@ public class SubredditView extends BaseActivityAnim {
                 currentlySubbed =
                         (!Authentication.isLoggedIn && UserSubscriptions.getSubscriptions(this)
                                 .contains(subreddit.getDisplayName().toLowerCase()))
-                                || subreddit.isUserSubscriber();
+                                || (Authentication.isLoggedIn && subreddit.isUserSubscriber());
                 doSubscribeButtonText(currentlySubbed, subscribe);
 
                 subscribe.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Calling subreddit.isUserSubscriber() when the user is not logged in throws a NullPointerException, which is caught in line 1842 and wrongly interpreted as the activity being killed.