### PR TITLE
Fixed wrong distinguish color on admins and added special (former admins) distinguish color

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -1178,8 +1178,17 @@ public class CommentAdapterHelper {
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         author.setSpan(new StyleSpan(Typeface.BOLD), 0, author.length(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        if (comment.getDistinguishedStatus() == DistinguishedStatus.MODERATOR
-                || comment.getDistinguishedStatus() == DistinguishedStatus.ADMIN) {
+        if (comment.getDistinguishedStatus() == DistinguishedStatus.ADMIN) {
+            author.replace(0, author.length(), " " + comment.getAuthor() + " ");
+            author.setSpan(
+                    new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_red_500, false),
+                    0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        } else if (comment.getDistinguishedStatus() == DistinguishedStatus.SPECIAL) {
+            author.replace(0, author.length(), " " + comment.getAuthor() + " ");
+            author.setSpan(
+                    new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_red_900, false),
+                    0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        } else if (comment.getDistinguishedStatus() == DistinguishedStatus.MODERATOR) {
             author.replace(0, author.length(), " " + comment.getAuthor() + " ");
             author.setSpan(
                     new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_green_300, false),

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
@@ -105,7 +105,11 @@ public class SubmissionCache {
         if (submission.getAuthor() != null) {
             if (Authentication.name != null && submission.getAuthor().toLowerCase().equals(Authentication.name.toLowerCase())) {
                 author.setSpan(new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_deep_orange_300, false), 0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            } else if (submission.getDistinguishedStatus() == DistinguishedStatus.MODERATOR || submission.getDistinguishedStatus() == DistinguishedStatus.ADMIN) {
+            } else if (submission.getDistinguishedStatus() == DistinguishedStatus.ADMIN) {
+                author.setSpan(new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_red_500, false), 0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            } else if (submission.getDistinguishedStatus() == DistinguishedStatus.SPECIAL) {
+                author.setSpan(new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_red_900, false), 0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            } else if (submission.getDistinguishedStatus() == DistinguishedStatus.MODERATOR) {
                 author.setSpan(new RoundedBackgroundSpan(mContext, R.color.white, R.color.md_green_300, false), 0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             } else if (authorcolor != 0) {
                 author.setSpan(new ForegroundColorSpan(authorcolor), 0, author.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);


### PR DESCRIPTION
Examples:
Admin: https://www.reddit.com/r/mildlyinfuriating/comments/4mt8r8/the_11year_clubs_picture_says_10_on_it/d3ymm5q
"Special" aka. former admin: https://www.reddit.com/r/IAmA/comments/2fgsv2/i_am_victoria_from_reddit_amaa/ck920ae