### PR TITLE
[Opinions needed] Fixed Always open externally not working for pages that redirect the user

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MakeExternal.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MakeExternal.java
@@ -1,9 +1,6 @@
 package me.ccrama.redditslide.Activities;
 
 import android.app.Activity;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
@@ -37,7 +34,9 @@ public class MakeExternal extends Activity {
                     }
                 }
 
-                domains.add(u.getHost());
+                if (!domains.contains(u.getHost())) {
+                    domains.add(u.getHost());
+                }
 
                 SharedPreferences.Editor e = SettingValues.prefs.edit();
                 e.putString(SettingValues.PREF_ALWAYS_EXTERNAL, Reddit.arrayToString(domains));

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -1,7 +1,6 @@
 package me.ccrama.redditslide.Activities;
 
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
@@ -34,15 +33,9 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Views.NestedWebView;
-import me.ccrama.redditslide.Views.WebViewOverScrollDecoratorAdapter;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.AdBlocker;
-import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
-import me.everything.android.ui.overscroll.HorizontalOverScrollBounceEffectDecorator;
-import me.everything.android.ui.overscroll.IOverScrollDecor;
-import me.everything.android.ui.overscroll.IOverScrollState;
-import me.everything.android.ui.overscroll.IOverScrollStateListener;
 
 public class Website extends BaseActivityAnim {
 
@@ -104,7 +97,7 @@ public class Website extends BaseActivityAnim {
                 return true;
             case R.id.external:
                 Intent inte = new Intent(this, MakeExternal.class);
-                inte.putExtra("url", v.getUrl());
+                inte.putExtra("url", url);
                 startActivity(inte);
                 return true;
             case R.id.store_cookies:


### PR DESCRIPTION
Please read issue #2095 first.

This PR would fix that issue by changing the "Always open this host externally" button to add the link the user clicked on to the list instead of the page the user is currently on.

In my opinion that would be the best solution.

Another solution would be to register a listener for when a new page is loaded (redirect, link click in webbrowser, ...) and check the new url against the open external list every time.
The problem with that would be that it would first open the browser before opening the external app instead of opening the external app directly.