### PR TITLE
Speed increase

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -206,7 +206,8 @@ public class MainActivity extends BaseActivity {
     boolean                     currentlySubbed;
     int                         back;
     private AsyncGetSubreddit mAsyncGetSubreddit = null;
-    private int headerHeight; //height of the header
+    private int     headerHeight; //height of the header
+    public int     reloadItemNumber = -2;
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -3472,14 +3473,16 @@ public class MainActivity extends BaseActivity {
         if (current < 0) {
             current = 0;
         }
+        reloadItemNumber = current;
         if (adapter instanceof OverviewPagerAdapterComment) {
+            pager.setAdapter(null);
             adapter = new OverviewPagerAdapterComment(getSupportFragmentManager());
             pager.setAdapter(adapter);
         } else {
             adapter = new OverviewPagerAdapter(getSupportFragmentManager());
             pager.setAdapter(adapter);
         }
-
+        reloadItemNumber = -2;
         shouldLoad = usedArray.get(current);
         pager.setCurrentItem(current);
         if (mTabLayout != null) {
@@ -4507,7 +4510,7 @@ public class MainActivity extends BaseActivity {
     }
 
     public class OverviewPagerAdapter extends FragmentStatePagerAdapter {
-        private SubmissionsView mCurrentFragment;
+        protected SubmissionsView mCurrentFragment;
 
         public OverviewPagerAdapter(FragmentManager fm) {
             super(fm);
@@ -4616,8 +4619,17 @@ public class MainActivity extends BaseActivity {
 
         @Override
         public void setPrimaryItem(ViewGroup container, int position, Object object) {
-            super.setPrimaryItem(container, position, object);
-            if (usedArray.size() >= position) doSetPrimary(object, position);
+            if (reloadItemNumber == position || reloadItemNumber < 0) {
+                super.setPrimaryItem(container, position, object);
+                if (usedArray.size() >= position) doSetPrimary(object, position);
+            } else {
+                shouldLoad = usedArray.get(reloadItemNumber);
+                if (multiNameToSubsMap.containsKey(usedArray.get(reloadItemNumber))) {
+                    shouldLoad = multiNameToSubsMap.get(usedArray.get(reloadItemNumber));
+                } else {
+                    shouldLoad = usedArray.get(reloadItemNumber);
+                }
+            }
         }
 
         @Override
@@ -4666,7 +4678,6 @@ public class MainActivity extends BaseActivity {
     public class OverviewPagerAdapterComment extends OverviewPagerAdapter {
         public int size = usedArray.size();
         public  Fragment        storedFragment;
-        private SubmissionsView mCurrentFragment;
         private CommentPage     mCurrentComments;
 
         public OverviewPagerAdapterComment(FragmentManager fm) {
@@ -4713,12 +4724,6 @@ public class MainActivity extends BaseActivity {
 
                 }
             });
-            if (pager.getAdapter() != null) {
-                pager.getAdapter().notifyDataSetChanged();
-                pager.setCurrentItem(1);
-                pager.setCurrentItem(0);
-
-            }
         }
 
         @Override

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SideArrayAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SideArrayAdapter.java
@@ -148,8 +148,10 @@ public class SideArrayAdapter extends ArrayAdapter<String> {
                             ((MainActivity) getContext()).openingComments = null;
                             ((MainActivity) getContext()).toOpenComments = -1;
                             ((MainActivity.OverviewPagerAdapterComment) ((MainActivity) getContext()).adapter).size = (((MainActivity) getContext()).usedArray.size() + 1);
+                            ((MainActivity) getContext()).reloadItemNumber = ((MainActivity) getContext()).usedArray.indexOf(base);
                             ((MainActivity) getContext()).adapter.notifyDataSetChanged();
                             ((MainActivity) getContext()).doPageSelectedComments(((MainActivity) getContext()).usedArray.indexOf(base));
+                            ((MainActivity) getContext()).reloadItemNumber = -2;
                         }
                         try {
                             //Hide the toolbar search UI with an animation because we're just changing tabs

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -80,6 +80,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         mLayoutManager.setSpanCount(getNumColumns(currentOrientation));
     }
 
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {


### PR DESCRIPTION
We have had a fair share of posts with feedback that Slide is slow. A month ago, some changes were made which resolved most of the issues. 

Latest thread is from 2 days ago : https://www.reddit.com/r/slideforreddit/comments/50ck12/slide_is_so_slow_now_a_days/

Though I agree that many a times cache is large, etc is the cause and clearing cache, fixes the issue, but I personally feel some things in slide were slow. 

So digging into it, I fixed a few issues. 

Results : 

-If you are using comment pane and I assume many people use it, then this loading a sub is 2x faster now. In other cases, there should be no effect. 

- Sorting. Sorting posts in a sub, is now 3-4x times faster, sometimes even 5x. 

When I say x times faster, it is that the number of network calls have reduced by x times and assuming network calls is the biggest factor in latency. 