### PR TITLE
Ability to read posts later

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -2005,13 +2005,6 @@ public class MainActivity extends BaseActivity {
                     Reddit.forceRestart(MainActivity.this);
                 }
             });
-            header.findViewById(R.id.later).setOnClickListener(new OnSingleClickListener() {
-                @Override
-                public void onSingleClick(View view) {
-                    Intent inte = new Intent(MainActivity.this, PostReadLater.class);
-                    MainActivity.this.startActivity(inte);
-                }
-            });
 
         }
         header.findViewById(R.id.manage).setOnClickListener(new OnSingleClickListener() {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/PostReadLater.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/PostReadLater.java
@@ -29,12 +29,12 @@ public class PostReadLater extends BaseActivityAnim {
         mToolbar.setPopupTheme(new ColorPreferences(this).getFontStyle().getBaseId());
 
         pager = (ViewPager) findViewById(R.id.content_view);
-        pager.setAdapter(new ProfilePagerAdapter(getSupportFragmentManager()));
+        pager.setAdapter(new ReadLaterAdaptor(getSupportFragmentManager()));
     }
 
-    public class ProfilePagerAdapter extends FragmentStatePagerAdapter {
+    public class ReadLaterAdaptor extends FragmentStatePagerAdapter {
 
-        public ProfilePagerAdapter(FragmentManager fm) {
+        public ReadLaterAdaptor(FragmentManager fm) {
             super(fm);
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/HistoryPosts.java
@@ -18,7 +18,6 @@ import java.util.TreeMap;
 
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.PostMatch;
-import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.util.LogUtil;
 
 /**
@@ -121,6 +120,7 @@ public class HistoryPosts extends GeneralPosts {
                         values = KVStore.getInstance().getByPrefix(prefix);
                     }
 
+
                     for (Map.Entry<String, String> entry : values.entrySet()) {
                         Object done;
                         if (entry.getValue().equals("true") || entry.getValue().equals("false")) {
@@ -145,7 +145,7 @@ public class HistoryPosts extends GeneralPosts {
                             if(!key.contains("_")){
                                 key = "t3_" + key;
                             }
-                            ids.add(key.replace(prefix, ""));
+                            idsSorted.put((Long) done, key.replace(prefix, ""));
                         }
                     }
 
@@ -160,6 +160,7 @@ public class HistoryPosts extends GeneralPosts {
 
 
                 }
+
                 if (!paginator.hasNext()) {
                     nomore = true;
                     return new ArrayList<>();

--- a/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
+++ b/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
@@ -38,7 +38,7 @@ import me.ccrama.redditslide.util.NetworkUtil;
  */
 public class CommentCacheAsync extends AsyncTask{
 
-    public static final String SAVED_SUBMISSIONS = "saved submissions";
+    public static final String SAVED_SUBMISSIONS = "read later";
     List<Submission> alreadyReceived;
 
     NotificationManager mNotifyManager;
@@ -264,7 +264,9 @@ public class CommentCacheAsync extends AsyncTask{
                 }
 
                 OfflineSubreddit.newSubreddit(sub).writeToMemory(newFullnames);
-                mNotifyManager.cancel(random);
+                if (mBuilder != null) {
+                    mNotifyManager.cancel(random);
+                }
                 success.add(sub);
             }
         }

--- a/app/src/main/java/me/ccrama/redditslide/OfflineSubreddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/OfflineSubreddit.java
@@ -154,6 +154,29 @@ public class OfflineSubreddit {
         }
     }
 
+    public void deleteFromMemory(String name) {
+        if (subreddit != null) {
+            String title = subreddit.toLowerCase() + "," + (time);
+            if (subreddit.equals(CommentCacheAsync.SAVED_SUBMISSIONS)) {
+                Map<String, ?> offlineSubs = Reddit.cachedData.getAll();
+                for (String offlineSub : offlineSubs.keySet()) {
+                    if (offlineSub.contains(CommentCacheAsync.SAVED_SUBMISSIONS)) {
+                        savedSubmissionsSubreddit = offlineSub;
+                        break;
+                    }
+                }
+                String savedSubmissions =
+                        Reddit.cachedData.getString(OfflineSubreddit.savedSubmissionsSubreddit,
+                                name);
+                if (!savedSubmissions.equals(name)) {
+                    Reddit.cachedData.edit().remove(savedSubmissionsSubreddit).apply();
+                    String modifiedSavedSubmissions = savedSubmissions.replace(name + ",", "");
+                    saveToCache(title, modifiedSavedSubmissions);
+                }
+            }
+        }
+    }
+
     private void saveToCache(String title, String submissions) {
         Reddit.cachedData.edit().putString(title, submissions).apply();
     }

--- a/app/src/main/java/me/ccrama/redditslide/ReadLater.java
+++ b/app/src/main/java/me/ccrama/redditslide/ReadLater.java
@@ -12,11 +12,15 @@ public class ReadLater {
     public static void setReadLater(Submission s, boolean readLater) {
         if (readLater) {
             KVStore.getInstance()
-                    .insert("readLater" + s.getFullName(), "true");
+                    .insert("readLater" + s.getFullName(), String.valueOf(System.currentTimeMillis()));
         } else {
             if (!KVStore.getInstance().getByContains("readLater" + s.getFullName()).isEmpty()) {
                 KVStore.getInstance().delete("readLater" + s.getFullName());
             }
         }
+    }
+
+    public static boolean isToBeReadLater(Submission s) {
+        return !KVStore.getInstance().getByContains("readLater" + s.getFullName()).isEmpty();
     }
 }

--- a/app/src/main/res/layout/drawer_loggedin.xml
+++ b/app/src/main/res/layout/drawer_loggedin.xml
@@ -216,7 +216,7 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
                 android:paddingStart="24dp"
-                android:text="Read later"
+                android:text="@string/profile_read_later"
                 android:textSize="14sp"/>
         <TextView
                 android:id="@+id/saved"

--- a/app/src/main/res/layout/drawer_offline.xml
+++ b/app/src/main/res/layout/drawer_offline.xml
@@ -100,32 +100,6 @@
             android:textStyle="bold" />
     </LinearLayout>
     <LinearLayout
-            android:id="@+id/later"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:background="?android:selectableItemBackground"
-            android:orientation="horizontal"
-
-            android:paddingStart="0dp">
-
-        <ImageView
-                android:layout_width="26dp"
-                android:layout_height="match_parent"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="26dp"
-                app:srcCompat="@drawable/savecontent"
-                android:tint="?attr/tint" />
-
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:gravity="center_vertical"
-                android:text="Read later"
-                android:textColor="?attr/font"
-                android:textSize="14sp"
-                android:textStyle="bold" />
-    </LinearLayout>
-    <LinearLayout
         android:id="@+id/settings"
         android:layout_width="match_parent"
         android:layout_height="48dp"

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -47,7 +47,6 @@ Möchten Sie Slide for Reddit unterstützen?</string>
   <string name="submission_tap_gif">Tippe, um das GIF zu laden</string>
   <string name="submission_not_found">Beitrag nicht gefunden</string>
   <string name="submission_not_found_msg">Der Beitrag konnte leider nicht gefunden werden</string>
-  <string name="submission_save_offline">Offline speichern</string>
   <string name="submission_copy_text">Text kopieren</string>
   <string name="submission_comment_saved">Kommentar wurde gespeichert</string>
   <string name="submission_comment_unsaved">Kommentar nicht mehr gespeichert</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -41,7 +41,6 @@
   <string name="submission_tap_gif">Tap to load GIF</string>
   <string name="submission_not_found">Uh oh, post not found!</string>
   <string name="submission_not_found_msg">Sorry, this post could not be found</string>
-  <string name="submission_save_offline">Save offline</string>
   <string name="submission_comment_saved">Comment saved</string>
   <string name="submission_comment_unsaved">Comment un-saved</string>
   <string name="submission_comment_copied">Comment text copied</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -31,7 +31,6 @@
   <string name="submission_tap_gif">Pulsa para cargar el GIF</string>
   <string name="submission_not_found">¡Oh oh, post no encontrado!</string>
   <string name="submission_not_found_msg">Lo siento, no he encontrado el post</string>
-  <string name="submission_save_offline">Guardar sin conexión</string>
   <string name="submission_comment_saved">Comentario guardado</string>
   <string name="submission_comment_unsaved">Comentario no guardado</string>
   <string name="submission_share_permalink">Compartir post</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -41,7 +41,6 @@
   <string name="submission_tap_gif">タップすると GIF を読み込みます</string>
   <string name="submission_not_found">投稿が見つかりません!</string>
   <string name="submission_not_found_msg">申し訳ありませんが、この投稿は見つかりませんでした</string>
-  <string name="submission_save_offline">オフライン保存</string>
   <string name="submission_copy_text">テキストをコピー</string>
   <string name="submission_comment_saved">保存されたコメント</string>
   <string name="submission_comment_unsaved">保存されていないコメント</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -42,7 +42,6 @@
   <string name="submission_tap_gif">Naciśnij, aby załadować GIFa</string>
   <string name="submission_not_found">O nie, nie znaleziono posta!</string>
   <string name="submission_not_found_msg">Przepraszamy, nie mogliśmy odnaleźć tego postu</string>
-  <string name="submission_save_offline">Zapisz do offline</string>
   <string name="submission_copy_text">Skopiuj tekst</string>
   <string name="submission_comment_saved">Komentarz zapisany</string>
   <string name="submission_comment_unsaved">Komentarz wypisany</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,6 @@
     <string name="submission_tap_gif">Tap to load GIF</string>
     <string name="submission_not_found">Uh oh, post not found!</string>
     <string name="submission_not_found_msg">Sorry, this post could not be found</string>
-    <string name="submission_save_offline">Save offline</string>
     <string name="submission_copy_text">Copy text</string>
     <string name="submission_comment_saved">Comment saved</string>
     <string name="submission_comment_unsaved">Comment un-saved</string>
@@ -129,6 +128,7 @@
     <string name="profile_karma_comment">Comment karma</string>
     <string name="profile_message">Private message</string>
     <string name="profile_saved">Saved</string>
+    <string name="profile_read_later">Read Later</string>
     <string name="profile_upvoted">Upvoted</string>
     <string name="profile_err_title">User not found</string>
     <string name="profile_err_msg">Reddit user could not be retrieved</string>


### PR DESCRIPTION
This PR finishes the read later work started by @ccrama 
	• Can store posts for reading them later.
	• These posts can be accessed both offline(cached when marked) and online
	• Can "Mark as read" the posts marked for reading later.
	• Mark as read option also in offline mode and for any offline content.
	• "Read later" is in reverse chronological order.
	• Merged read later and save offline.
	• fix  #2117 
![image](https://cloud.githubusercontent.com/assets/6133816/18226769/07179356-71df-11e6-8338-2de254827249.png)
![image](https://cloud.githubusercontent.com/assets/6133816/18226792/5cb4911a-71df-11e6-8626-d9c6c883f55d.png)
![image](https://cloud.githubusercontent.com/assets/6133816/18226793/606f6122-71df-11e6-8b66-ac78f5e9de03.png)
![image](https://cloud.githubusercontent.com/assets/6133816/18226795/6a0a72bc-71df-11e6-94f1-1e2b37ca4314.png)
