### PR TITLE
Fix full text stikethrough formatting

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -310,7 +310,8 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
 
         int start = -1;
         int end;
-        for (int i = 0; i < builder.length() - 4; i++) {
+
+        for (int i = 0; i < builder.length() - 3; i++) {
             if (builder.charAt(i) == '['
                     && builder.charAt(i + 1) == '['
                     && builder.charAt(i + 2) == 'd'


### PR DESCRIPTION
The upperbound for i was set to one too low, which meant if the ]d]]
marker was at the end of the text the loop would stop at the end of
text, just before the ].

One case where it broke is in the first table of [this post](https://www.reddit.com/r/GlobalOffensive/comments/4kjze9/virtuspro_vs_natus_vincere_starladder_ileague/).