### PR TITLE
Ignore amp. subdomain in reddit links

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -274,7 +274,7 @@ public class OpenRedditLink {
     public static String formatRedditUrl(String url) {
 
         // Strip unused prefixes that don't require special handling
-        url = url.replaceFirst("(?i)^(https?://)?(www\\.)?((ssl|pay)\\.)?", "");
+        url = url.replaceFirst("(?i)^(https?://)?(www\\.)?((ssl|pay|amp)\\.)?", "");
 
         if (url.matches("(?i)[a-z0-9-_]+\\.reddit\\.com.*")) { // tests for subdomain
             String subdomain = url.split("\\.", 2)[0];


### PR DESCRIPTION
Bug: https://redd.it/55e2sq

I don't believe the subdomain will produce any special links that need to be handled/ignored explicitly

https://www.reddit.com/r/changelog/comments/53q42z/read_reddit_faster_via_google_with_amp/