### PR TITLE
replace legacy apache httpclient with okhttp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,6 @@ android {
         // Translations are crowd-sourced
         disable 'MissingTranslation'
     }
-    useLibrary 'org.apache.http.legacy'
     defaultConfig {
         applicationId "me.ccrama.redditslide"
         targetSdkVersion 24

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSynccit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsSynccit.java
@@ -10,6 +10,8 @@ import android.widget.EditText;
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.MaterialDialog;
 
+import java.util.Collections;
+
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Synccit.MySynccitReadTask;
@@ -61,6 +63,7 @@ public class SettingsSynccit extends BaseActivityAnim {
                                     e.apply();
                                     name.setText(SettingValues.synccitName);
                                     auth.setText(SettingValues.synccitAuth);
+                                    SynccitRead.visitedIds.removeAll(Collections.singleton("16noez"));
                                 }
                             }).setNegativeButton(R.string.btn_no, null)
                             .show();

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -58,8 +58,6 @@ import net.dean.jraw.paginators.Sorting;
 import net.dean.jraw.paginators.TimePeriod;
 import net.dean.jraw.paginators.UserRecordPaginator;
 
-import org.apache.http.auth.AUTH;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
@@ -14,7 +14,6 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.SystemClock;
 import android.support.v7.app.NotificationCompat;
 import android.text.Html;
 
@@ -24,10 +23,8 @@ import net.dean.jraw.paginators.InboxPaginator;
 import net.dean.jraw.paginators.SubmissionSearchPaginator;
 
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.http.auth.AUTH;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/MySynccitReadTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/MySynccitReadTask.java
@@ -13,7 +13,7 @@ import me.ccrama.redditslide.SettingValues;
 public class MySynccitReadTask extends SynccitReadTask {
 
     private static final String MY_DEV_NAME = "slide_for_reddit";
-    SubmissionDisplay displayer;
+    private SubmissionDisplay displayer;
 
     public MySynccitReadTask(SubmissionDisplay displayer) {
         super(MY_DEV_NAME);

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitRead.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitRead.java
@@ -9,11 +9,4 @@ import java.util.Set;
 public class SynccitRead {
     public static ArrayList<String> visitedIds = new ArrayList<>();
     public static ArrayList<String> newVisited = new ArrayList<>();
-
-    static void setVisited(Set<String> visitedIds2) {
-        visitedIds = new ArrayList<>();
-        for(String s : visitedIds2) {
-            visitedIds.add(s);
-        }
-    }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitReadTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitReadTask.java
@@ -11,11 +11,11 @@ import java.util.Scanner;
 /**
  * https://github.com/drakeapps/synccit#example-json-read-call
  */
-public abstract class SynccitReadTask extends SynccitTask {
+abstract class SynccitReadTask extends SynccitTask {
 	
 	private static final String READ_MODE = "read";
 	
-	public SynccitReadTask(String devName) {
+	SynccitReadTask(String devName) {
 		super(devName);
 	}
 
@@ -25,26 +25,20 @@ public abstract class SynccitReadTask extends SynccitTask {
 	}
 
 	@Override
-	protected SynccitResponse onInput(InputStream in) throws Exception {
+	protected SynccitResponse onInput(String in) throws Exception {
 		HashSet<String> visitedLinkIds = new HashSet<>();
-		
-		// read the entire stream into a String
-		Scanner s = new Scanner(in);
-		String json = s.useDelimiter("\\A").next();
-		
+
 		try {
-			JSONArray links = new JSONArray(json);
-			
+			JSONArray links = new JSONArray(in);
 			int length = links.length();
 			for (int i = 0; i < length; i++) {
 				JSONObject linkNode = (JSONObject) links.get(i);
 				visitedLinkIds.add(linkNode.get("id").toString());
 			}
-			
 			onVisited(visitedLinkIds);
 
 		} catch (JSONException ex) {
-			JSONObject node = new JSONObject(json);
+			JSONObject node = new JSONObject(in);
 			if (node.has("error")) {
 				return new SynccitResponse("error", node.get("error").toString());
 			}

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitResponse.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitResponse.java
@@ -3,7 +3,7 @@ package me.ccrama.redditslide.Synccit;
 /**
  * https://github.com/drakeapps/synccit#example-json-update-call
  */
-public class SynccitResponse {
+class SynccitResponse {
 	
 	private String key;
 	private String value;

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitTask.java
@@ -30,13 +30,8 @@ public abstract class SynccitTask extends HttpPostTask<SynccitResponse> {
 	/** developer name */
 	private String devName;
 	
-	public SynccitTask(String devName) {
+	SynccitTask(String devName) {
 		super(API_URL);
-		this.devName = devName;
-	}
-
-	public SynccitTask(String devName, String apiUrl) {
-		super(apiUrl);
 		this.devName = devName;
 	}
 

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitUpdateTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/SynccitUpdateTask.java
@@ -8,14 +8,14 @@ import java.util.Scanner;
 /**
  * https://github.com/drakeapps/synccit#example-json-update-call
  */
-public abstract class SynccitUpdateTask extends SynccitTask {
+abstract class SynccitUpdateTask extends SynccitTask {
 
 	@SuppressWarnings("unused")
 	private static final String TAG = SynccitUpdateTask.class.getSimpleName();
 	
 	private static final String UPDATE_MODE = "update";
-	
-	public SynccitUpdateTask(String devName) {
+
+	SynccitUpdateTask(String devName) {
 		super(devName);
 	}
 
@@ -25,15 +25,9 @@ public abstract class SynccitUpdateTask extends SynccitTask {
 	}
 
 	@Override
-	protected SynccitResponse onInput(InputStream in) throws Exception {
-		// read the entire stream into a String
-		Scanner s = new Scanner(in);
-		String json = s.useDelimiter("\\A").next();
-
-		JSONObject obj = new JSONObject(json);
+	protected SynccitResponse onInput(String in) throws Exception {
+		JSONObject obj = new JSONObject(in);
 		String key = obj.has("success") ? "success" : "error";
 		return new SynccitResponse(key, obj.get(key).toString());
 	}
-
-
 }

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/http/HttpClientFactory.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/http/HttpClientFactory.java
@@ -1,130 +1,34 @@
 package me.ccrama.redditslide.Synccit.http;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpResponseInterceptor;
-import org.apache.http.HttpVersion;
-import org.apache.http.client.HttpClient;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.entity.HttpEntityWrapper;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.CoreProtocolPNames;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.HttpContext;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.zip.GZIPInputStream;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.internal.Util;
 
-public class HttpClientFactory {
-	
+class HttpClientFactory {
+
 	@SuppressWarnings("unused")
 	private static final String TAG = HttpClientFactory.class.getSimpleName();
-	
-	private static DefaultHttpClient mGzipHttpClient;
-	
+
+    private static OkHttpClient client;
 	private static final int SOCKET_OPERATION_TIMEOUT = 60 * 1000;
+    private static final List<Protocol> PROTOCOLS = Util.immutableList(Protocol.HTTP_1_1);
 	
-	/**
-	 * http://hc.apache.org/httpcomponents-client/examples.html
-	 * @return a Gzip-enabled DefaultHttpClient
-	 */
-	synchronized public static HttpClient getGzipHttpClient() {
-		if (mGzipHttpClient == null) {
-			mGzipHttpClient = createGzipHttpClient();
+	synchronized static OkHttpClient getOkHttpClient() {
+		if (client == null) {
+            client = createOkHttpClient();
 		}
-		return mGzipHttpClient;
+		return client;
 	}
-	
-	private static DefaultHttpClient createGzipHttpClient() {
-		HttpParams params = new BasicHttpParams();
-		params.setParameter(CoreProtocolPNames.PROTOCOL_VERSION, HttpVersion.HTTP_1_1);
-		
-		DefaultHttpClient httpclient = new DefaultHttpClient(params) {
-		    @Override
-		    protected ClientConnectionManager createClientConnectionManager() {
-		        SchemeRegistry registry = new SchemeRegistry();
-		        registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-		        
-		        SSLSocketFactory sslSocketFactory = getHttpsSocketFactory();
-		        registry.register(new Scheme("https", sslSocketFactory, 443));
-		        
-		        HttpParams params = getParams();
-				HttpConnectionParams.setConnectionTimeout(params, SOCKET_OPERATION_TIMEOUT);
-				HttpConnectionParams.setSoTimeout(params, SOCKET_OPERATION_TIMEOUT);
-				HttpConnectionParams.setSocketBufferSize(params, 8192);
-		        return new ThreadSafeClientConnManager(params, registry);
-		    }
-		    
-		    private SSLSocketFactory getHttpsSocketFactory() {
-	        	return SSLSocketFactory.getSocketFactory();
-		    }
-		};
-		
-        httpclient.addRequestInterceptor(new HttpRequestInterceptor() {
-            @Override
-        	public void process(
-                    final HttpRequest request,
-                    final HttpContext context
-            ) throws HttpException, IOException {
-                if (!request.containsHeader("Accept-Encoding"))
-                    request.addHeader("Accept-Encoding", "gzip");
-                
-                if (!request.containsHeader("Cache-Control"))
-                	request.addHeader("Cache-Control", "no-cache");
-            }
-        });
-        httpclient.addResponseInterceptor(new HttpResponseInterceptor() {
-        	@Override
-            public void process(
-                    final HttpResponse response, 
-                    final HttpContext context) throws HttpException, IOException {
-                HttpEntity entity = response.getEntity();
-                Header ceheader = entity.getContentEncoding();
-                if (ceheader != null) {
-                    HeaderElement[] codecs = ceheader.getElements();
-                    for (int i = 0; i < codecs.length; i++) {
-                        if (codecs[i].getName().equalsIgnoreCase("gzip")) {
-                            response.setEntity(
-                                    new GzipDecompressingEntity(response.getEntity())); 
-                            return;
-                        }
-                    }
-                }
-            }
-        });
-        return httpclient;
-	}
-	
-    static class GzipDecompressingEntity extends HttpEntityWrapper {
-        public GzipDecompressingEntity(final HttpEntity entity) {
-            super(entity);
-        }
-        @Override
-        public InputStream getContent()
-            throws IOException, IllegalStateException {
-            // the wrapped entity's getContent() decides about repeatability
-            InputStream wrappedin = wrappedEntity.getContent();
-            return new GZIPInputStream(wrappedin);
-        }
-        @Override
-        public long getContentLength() {
-            // length of ungzipped content is not known
-            return -1;
-        }
+
+	private static OkHttpClient createOkHttpClient() {
+        return new OkHttpClient.Builder()
+                .protocols(PROTOCOLS)
+                .connectTimeout(SOCKET_OPERATION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(SOCKET_OPERATION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
     }
-    
 }
 

--- a/app/src/main/java/me/ccrama/redditslide/Synccit/http/HttpPostTask.java
+++ b/app/src/main/java/me/ccrama/redditslide/Synccit/http/HttpPostTask.java
@@ -2,36 +2,32 @@ package me.ccrama.redditslide.Synccit.http;
 
 import android.os.AsyncTask;
 import android.util.Log;
+import android.util.Pair;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.HTTP;
-
-import java.io.InputStream;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public abstract class HttpPostTask<Result> extends AsyncTask<String, Long, Result> {
-	
+
 	private static final String TAG = HttpPostTask.class.getSimpleName();
-	
-	protected static final int CONNECTION_TIMEOUT_MILLIS = 5000;
-	protected static final int SOCKET_TIMEOUT_MILLIS = 20000;
-	
-	protected final HttpClient mClient = HttpClientFactory.getGzipHttpClient();
-	
+	private static final int CONNECTION_TIMEOUT_MILLIS = 5000;
+	private static final int SOCKET_TIMEOUT_MILLIS = 20000;
+
+	private final OkHttpClient mClient = HttpClientFactory.getOkHttpClient().newBuilder()
+			.readTimeout(SOCKET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+			.connectTimeout(CONNECTION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).build();
+
 	private String mUrl;
-	
+
 	/**
 	 * @param url Required.
-	 * @param activity Optional. May be null.
 	 */
 	public HttpPostTask(String url) {
 		mUrl = url;
@@ -42,66 +38,49 @@ public abstract class HttpPostTask<Result> extends AsyncTask<String, Long, Resul
 	 */
 	@Override
 	protected Result doInBackground(String... params) {
-		
-		ArrayList<NameValuePair> nvps = getPostArgs(params);
-		
-		HttpEntity entity = null;
-		InputStream in = null;
-		
+
+		List<Pair<String, String>> nvps = getPostArgs(params);
+        MultipartBody.Builder formBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+
+		for(Pair<String, String> p : nvps) {
+            formBuilder.addFormDataPart(p.first, p.second);
+		}
+
+		Request request = new Request.Builder().url(mUrl)
+				.header("User-Agent", getUserAgent()).addHeader("Content-Encoding", "gzip")
+				.post(formBuilder.build())
+				.build();
 		try {
-			HttpPost httppost = new HttpPost(mUrl);
-			httppost.setHeader("User-Agent", getUserAgent());
-			httppost.setEntity(new UrlEncodedFormEntity(nvps, HTTP.UTF_8));
-			
-            // Set timeout to 45 seconds for login
-            HttpParams httpparams = httppost.getParams();
-	        HttpConnectionParams.setConnectionTimeout(httpparams, CONNECTION_TIMEOUT_MILLIS);
-	        HttpConnectionParams.setSoTimeout(httpparams, SOCKET_TIMEOUT_MILLIS);
-	        
-            // Perform the HTTP POST request
-        	HttpResponse response = mClient.execute(httppost);
-        	String status = response.getStatusLine().toString();
-        	if (!status.contains("OK")) {
-        		throw new HttpException(status);
-        	}
-        	
-        	entity = response.getEntity();
-        	in = entity.getContent();
-        	
-			return onInput(in);
-			
+			Response res = mClient.newCall(request).execute();
+			if (!res.isSuccessful()) {
+				throw new IOException("Unexpected code " + res);
+			}
+
+			return onInput(res.body().string());
+
 		} catch (Exception ex) {
 			Log.e(TAG, "Error during POST", ex);
-		} finally {
-			try {
-				if (in != null)
-					in.close();
-			} catch (Exception ignore) {}
-			try {
-				entity.consumeContent();
-			} catch (Exception ignore) {}
 		}
-			
 		return null;
 	}
-	
-	private ArrayList<NameValuePair> getPostArgs(String... params) {
-		ArrayList<NameValuePair> nvps = new ArrayList<>();
-		for (int i = 0; i < params.length; i += 2) {
+
+		private List<Pair<String, String>> getPostArgs(String... params) {
+			List<Pair<String, String>> nvps = new ArrayList<>();
+
+			for (int i = 0; i < params.length; i += 2) {
 			try {
-				nvps.add(new BasicNameValuePair(params[i], params[i+1]));
+				nvps.add(new Pair<>(params[i], params[i+1]));
 			} catch (ArrayIndexOutOfBoundsException ex) {
-				// it'll exit out of the for-loop, and just leave off the last param
 				Log.e(TAG, "Params didn't come in name/value pairs", ex);
 			}
 		}
 		return nvps;
 	}
-	
-	protected Result onInput(InputStream in) throws Exception {
+
+	protected Result onInput(String in) throws Exception {
 		return null;
 	}
-	
+
 	protected abstract String getUserAgent();
 
 }


### PR DESCRIPTION
The following PR replaces the legacy http client with OkHttp. 

Also, Limited the access to some variables in the process.

The PR also fixes a bug with the Synccit integration, under `SettingsSynccit`. To reproduce:

1. Login in successfully with a Synccit account.
2. Disconnect Synccit
3. Login with empty fields/invalid accounts.
4. Expected: Receive connection error dialog, Actual: The integration activation popup dialog shows.

This is because the static list `visitedIds` still contains the member "16noez". In that case, I'm just removing it from the list. 

I tried to limit the scope of this PR so as not to introduce breaking changes, ie. keeping the AsyncTasks as is and doing the OkHttp calls synchronously in there, using same protocol as before, timeout values, etc. It would be great to consider an okHttp and RxJava for network calls in the future since it would simplify a lot of the stuff done here.
Targets #2251 