### PR TITLE
Fix tablet nav drawer swipe sensitivity

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -3939,7 +3939,11 @@ public class MainActivity extends BaseActivity
                     .show();
         } else {
             drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
-            setDrawerEdge(this, Constants.DRAWER_SWIPE_EDGE, drawerLayout);
+            if (!getResources().getBoolean(R.bool.isTablet)) {
+                setDrawerEdge(this, Constants.DRAWER_SWIPE_EDGE, drawerLayout);
+            } else {
+                setDrawerEdge(this, Constants.DRAWER_SWIPE_EDGE_TABLET, drawerLayout);
+            }
 
             if (loader != null) {
                 header.setVisibility(View.VISIBLE);

--- a/app/src/main/java/me/ccrama/redditslide/Constants.java
+++ b/app/src/main/java/me/ccrama/redditslide/Constants.java
@@ -35,7 +35,7 @@ public class Constants {
      * swipe area becomes. This is a percentage of the screen width.
      */
     public static final float DRAWER_SWIPE_EDGE = 0.07f;
-    public static final float DRAWER_SWIPE_EDGE_TABLET = 0.05f;
+    public static final float DRAWER_SWIPE_EDGE_TABLET = 0.03f;
 
     /** The client ID to use when making requests to the Imgur Mashape API */
     public static final String IMGUR_MASHAPE_CLIENT_ID = "bef87913eb202e9";

--- a/app/src/main/java/me/ccrama/redditslide/Constants.java
+++ b/app/src/main/java/me/ccrama/redditslide/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
      * swipe area becomes. This is a percentage of the screen width.
      */
     public static final float DRAWER_SWIPE_EDGE = 0.07f;
+    public static final float DRAWER_SWIPE_EDGE_TABLET = 0.05f;
 
     /** The client ID to use when making requests to the Imgur Mashape API */
     public static final String IMGUR_MASHAPE_CLIENT_ID = "bef87913eb202e9";

--- a/app/src/main/res/values-xlarge/bools.xml
+++ b/app/src/main/res/values-xlarge/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isTablet">true</bool>
+</resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isTablet">false</bool>
+</resources>


### PR DESCRIPTION
* Swiping sensitivity is too high on tablets

I created a bool to detect if the device is a tablet or not; this lets us use a different value for the edge sensitivity per type of device.

I found the `0.03f` value to be optimal for tablets.