### PR TITLE
Add a Share GIF feature in the MediaView activity

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -927,6 +927,8 @@
     <string name="mediaview_converting_fail_btn">Open in web</string>
     <string name="mediaview_save">Save %1$s</string>
     <string name="mediaview_saving">Saving %1$s</string>
+    <string name="mediaview_share">Share %1$s</string>
+    <string name="mediaview_sharing">Sharing %1$s</string>
 
     <!-- Drafts -->
     <string name="draft_saving">Saving draft</string>


### PR DESCRIPTION
Here's a PoC PR that enables GIF sharing directly to apps like WhatsApp.

This is merely a proof of concept and not the final version as I have a bunch of questions regarding this feature (and potentially other):
- I wanted to re-use the code between the "Share Image" and "Share GIF" feature but noticed there was a Bitmap to PNG conversion going on: what's the reason behind this? I mostly curious about it, and at first I thought that it'd be a penalty when using mobile and sharing a JPEG image for instance.
- I also wanted to use an horizontal ProgressBar in the BottomSheet instead of progress notification as it seems to be the [recommended material design way](https://material.google.com/components/progress-activity.html) but I saw that you're using https://github.com/soarcn/BottomSheet when a Google implementation that is more complete has been provided starting in the Android Support Library v23.2

Feel free to point me towards any direction that you'd like. I'd be happy to help make bigger changes if you wish.