### PR TITLE
More data saving options

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -522,7 +522,7 @@ public class AlbumPager extends FullScreenActivity
                 if (SettingValues.loadImageLq && (SettingValues.lowResAlways || (!NetworkUtil.isConnectedWifi(getActivity())
                         && SettingValues.lowResMobile))) {
                     String lqurl = url.substring(0, url.lastIndexOf("."))
-                            + (SettingValues.imgurLq ? "m" : "h")
+                            + (SettingValues.lqLow ? "m" : (SettingValues.lqMid ? "l" : "h"))
                             + url.substring(url.lastIndexOf("."), url.length());
                     loadImage(rootView, this, lqurl, ((AlbumPager) getActivity()).images.size() == 1);
                     lq = true;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -632,12 +632,11 @@ public class MediaView extends FullScreenActivity
                 }
             });
         } else if (ContentType.isImgurImage(contentUrl)
-                && SettingValues.imgurLq
                 && SettingValues.loadImageLq
                 && (SettingValues.lowResAlways || (!NetworkUtil.isConnectedWifi(this)
                 && SettingValues.lowResMobile))) {
             String url = contentUrl;
-            url = url.substring(0, url.lastIndexOf(".")) + "m" + url.substring(url.lastIndexOf("."),
+            url = url.substring(0, url.lastIndexOf(".")) + (SettingValues.lqLow ? "m" : (SettingValues.lqMid ? "l" : "h"))  + url.substring(url.lastIndexOf("."),
                     url.length());
 
             displayImage(url);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsData.java
@@ -23,7 +23,9 @@ public class SettingsData extends BaseActivityAnim {
         setContentView(R.layout.activity_settings_datasaving);
         setupAppBar(R.id.toolbar, R.string.settings_data, true, true);
         //Image mode multi choice
-        ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) : (SettingValues.imgurLq ? getString(R.string.load_medium_quality_imgur_images) : getString(R.string.low_quality_through_reddit_lower_resolution)));
+        ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) :
+                (SettingValues.lqLow ? getString(R.string.load_low_quality) :
+                        (SettingValues.lqMid ? getString(R.string.load_medium_quality) : getString(R.string.load_high_quality))));
 
         findViewById(R.id.datasavequality).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -45,10 +47,12 @@ public class SettingsData extends BaseActivityAnim {
                                             .putBoolean(SettingValues.PREF_IMAGE_LQ, true)
                                             .apply();
                                     break;
-                                case R.id.reddit:
+                                case R.id.low:
                                     SettingValues.loadImageLq = true;
-                                    SettingValues.imgurLq = false;
                                     SettingValues.noImages = false;
+                                    SettingValues.lqLow = true;
+                                    SettingValues.lqMid = false;
+                                    SettingValues.lqHigh = false;
                                     SettingValues.prefs.edit()
                                             .putBoolean(SettingValues.PREF_IMAGE_LQ, true)
                                             .apply();
@@ -56,25 +60,63 @@ public class SettingsData extends BaseActivityAnim {
                                             .putBoolean(SettingValues.PREF_NO_IMAGES, false)
                                             .apply();
                                     SettingValues.prefs.edit()
-                                            .putBoolean(SettingValues.PREF_IMGUR_LQ, false)
+                                            .putBoolean(SettingValues.PREF_LQ_LOW, true)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_MID, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_HIGH, false)
                                             .apply();
                                     break;
-                                case R.id.imgur:
+                                case R.id.medium:
                                     SettingValues.loadImageLq = true;
-                                    SettingValues.imgurLq = true;
                                     SettingValues.noImages = false;
-                                    SettingValues.prefs.edit()
-                                            .putBoolean(SettingValues.PREF_NO_IMAGES, false)
-                                            .apply();
+                                    SettingValues.lqLow = false;
+                                    SettingValues.lqMid = true;
+                                    SettingValues.lqHigh = false;
                                     SettingValues.prefs.edit()
                                             .putBoolean(SettingValues.PREF_IMAGE_LQ, true)
                                             .apply();
                                     SettingValues.prefs.edit()
-                                            .putBoolean(SettingValues.PREF_IMGUR_LQ, true)
+                                            .putBoolean(SettingValues.PREF_NO_IMAGES, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_LOW, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_MID, true)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_HIGH, false)
+                                            .apply();
+                                    break;
+                                case R.id.high:
+                                    SettingValues.loadImageLq = true;
+                                    SettingValues.noImages = false;
+                                    SettingValues.lqLow = false;
+                                    SettingValues.lqMid = false;
+                                    SettingValues.lqHigh = true;
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_IMAGE_LQ, true)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_NO_IMAGES, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_LOW, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_MID, false)
+                                            .apply();
+                                    SettingValues.prefs.edit()
+                                            .putBoolean(SettingValues.PREF_LQ_HIGH, true)
                                             .apply();
                                     break;
                             }
-                            ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) : (SettingValues.imgurLq ? getString(R.string.load_medium_quality_imgur_images) : getString(R.string.low_quality_through_reddit_lower_resolution)));
+                            ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) :
+                                    (SettingValues.lqLow ? getString(R.string.load_low_quality) :
+                                            (SettingValues.lqMid ? getString(R.string.load_medium_quality) : getString(R.string.load_high_quality))));
                             return true;
                         }
                     });
@@ -120,7 +162,9 @@ public class SettingsData extends BaseActivityAnim {
                             ((TextView) findViewById(R.id.currentmode)).setText("Enable datasaving mode");
                         } else {
                             findViewById(R.id.datasavequality).setAlpha(1f);
-                            ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) : (SettingValues.imgurLq ? getString(R.string.load_medium_quality_imgur_images) : getString(R.string.low_quality_through_reddit_lower_resolution)));
+                            ((TextView) findViewById(R.id.currentmode)).setText(SettingValues.noImages ? getString(R.string.never_load_images) :
+                                    (SettingValues.lqLow ? getString(R.string.load_low_quality) :
+                                            (SettingValues.lqMid ? getString(R.string.load_medium_quality) : getString(R.string.load_high_quality))));
                         }
                         return true;
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/MultiredditPosts.java
@@ -95,7 +95,30 @@ public class MultiredditPosts implements PostLoader {
                     if (((!NetworkUtil.isConnectedWifi(c) && SettingValues.lowResMobile) || SettingValues.lowResAlways) && submission.getThumbnails() != null && submission.getThumbnails().getVariations() != null) {
 
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(submission.getThumbnails().getVariations()[length / 2].getUrl()).toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
 
                     } else {
                         if (submission.getDataNode().has("preview") && submission.getDataNode().get("preview").get("images").get(0).get("source").has("height")) { //Load the preview image which has probably already been cached in memory instead of the direct link
@@ -133,7 +156,30 @@ public class MultiredditPosts implements PostLoader {
                     if (((!NetworkUtil.isConnectedWifi(c) && SettingValues.lowResMobile) || SettingValues.lowResAlways) && submission.getThumbnails().getVariations().length != 0) {
 
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(submission.getThumbnails().getVariations()[length / 2].getUrl()).toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
 
                     } else {
                         url = Html.fromHtml(submission.getThumbnails().getSource().getUrl()).toString(); //unescape url characters

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
@@ -103,9 +103,30 @@ public class SubredditPosts implements PostLoader {
                                 && submission.getThumbnails().getVariations().length > 0) {
 
                             int length = submission.getThumbnails().getVariations().length;
-                            url = Html.fromHtml(
-                                    submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                    .toString(); //unescape url characters
+                            if (SettingValues.lqLow && length >= 3)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[2].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else if (SettingValues.lqMid && length >= 4)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[3].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else if (length >= 5)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getSource().getUrl())
+                                        .toString(); //unescape url characters
+                            }
 
                         } else {
                             if (submission.getDataNode().has("preview") && submission.getDataNode()
@@ -159,9 +180,30 @@ public class SubredditPosts implements PostLoader {
                                 && submission.getThumbnails().getVariations().length != 0) {
 
                             int length = submission.getThumbnails().getVariations().length;
-                            url = Html.fromHtml(
-                                    submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                    .toString(); //unescape url characters
+                            if (SettingValues.lqLow && length >= 3)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[2].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else if (SettingValues.lqMid && length >= 4)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[3].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else if (length >= 5)
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                        .toString(); //unescape url characters
+                            }
+                            else
+                            {
+                                url = Html.fromHtml(
+                                        submission.getThumbnails().getSource().getUrl())
+                                        .toString(); //unescape url characters
+                            }
 
                         } else {
                             url = Html.fromHtml(submission.getThumbnails().getSource().getUrl())

--- a/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
+++ b/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
@@ -91,9 +91,30 @@ public class CommentCacheAsync extends AsyncTask {
                             && submission.getThumbnails().getVariations().length > 0) {
 
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(
-                                submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                .toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
 
                     } else {
                         if (submission.getDataNode().has("preview") && submission.getDataNode()
@@ -147,9 +168,30 @@ public class CommentCacheAsync extends AsyncTask {
                             && submission.getThumbnails().getVariations().length != 0) {
 
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(
-                                submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                .toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
 
                     } else {
                         url = Html.fromHtml(submission.getThumbnails().getSource().getUrl())

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -71,7 +71,9 @@ public class SettingValues {
     public static final String PREF_CARD_TEXT                 = "cardText";
     public static final String PREF_ZOOM_DEFAULT              = "zoomDefault";
     public static final String PREF_SUBREDDIT_SEARCH_METHOD   = "subredditSearchMethod";
-    public static final String PREF_IMGUR_LQ                  = "imgurLq";
+    public static final String PREF_LQ_LOW              = "lqLow";
+    public static final String PREF_LQ_MID              = "lqMid";
+    public static final String PREF_LQ_HIGH              = "lqHigh";
     public static final String PREF_SOUND_NOTIFS              = "soundNotifs";
     public static final String PREF_COOKIES                   = "storeCookies";
     public static final String PREF_NIGHT_START               = "nightStart";
@@ -191,7 +193,9 @@ public class SettingValues {
     public static boolean showDomain;
     public static boolean cardText;
     public static boolean alwaysZoom;
-    public static boolean imgurLq = true;
+    public static boolean lqLow = false;
+    public static boolean lqMid = true;
+    public static boolean lqHigh = false;
     public static int     currentTheme; //current base theme (Light, Dark, Dark blue, etc.)
     public static int     nightTheme;
     public static boolean typeInText;
@@ -258,7 +262,10 @@ public class SettingValues {
         typeInfoLine = prefs.getBoolean(PREF_TYPE_INFO_LINE, false);
         votesInfoLine = prefs.getBoolean(PREF_VOTES_INFO_LINE, false);
 
-        imgurLq = prefs.getBoolean(PREF_IMGUR_LQ, true);
+        lqLow = prefs.getBoolean(PREF_LQ_LOW, false);
+        lqMid = prefs.getBoolean(PREF_LQ_MID, true);
+        lqHigh = prefs.getBoolean(PREF_LQ_HIGH, false);
+
         noImages = prefs.getBoolean(PREF_NO_IMAGES, false);
 
         abbreviateScores = prefs.getBoolean(PREF_ABBREVIATE_SCORES, true);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
@@ -263,13 +263,33 @@ public class HeaderImageLinkView extends RelativeLayout {
 
                     if (ContentType.isImgurImage(submission.getUrl())) {
                         url = submission.getUrl();
-                        url = url.substring(0, url.lastIndexOf(".")) + (SettingValues.imgurLq ? "m"
-                                : "h") + url.substring(url.lastIndexOf("."), url.length());
+                        url = url.substring(0, url.lastIndexOf(".")) + (SettingValues.lqLow ? "m" : (SettingValues.lqMid ? "l" : "h")) + url.substring(url.lastIndexOf("."), url.length());
                     } else {
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(
-                                submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                .toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
                     }
                     lq = true;
 
@@ -335,13 +355,33 @@ public class HeaderImageLinkView extends RelativeLayout {
                 if (loadLq && submission.getThumbnails().getVariations().length != 0) {
                     if (ContentType.isImgurImage(submission.getUrl())) {
                         url = submission.getUrl();
-                        url = url.substring(0, url.lastIndexOf(".")) + (SettingValues.imgurLq ? "m"
-                                : "h") + url.substring(url.lastIndexOf("."), url.length());
+                        url = url.substring(0, url.lastIndexOf(".")) + (SettingValues.lqLow ? "m" : (SettingValues.lqMid ? "l" : "h"))  + url.substring(url.lastIndexOf("."), url.length());
                     } else {
                         int length = submission.getThumbnails().getVariations().length;
-                        url = Html.fromHtml(
-                                submission.getThumbnails().getVariations()[length / 2].getUrl())
-                                .toString(); //unescape url characters
+                        if (SettingValues.lqLow && length >= 3)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[2].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (SettingValues.lqMid && length >= 4)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[3].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else if (length >= 5)
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getVariations()[length - 1].getUrl())
+                                    .toString(); //unescape url characters
+                        }
+                        else
+                        {
+                            url = Html.fromHtml(
+                                    submission.getThumbnails().getSource().getUrl())
+                                    .toString(); //unescape url characters
+                        }
                     }
                     lq = true;
 

--- a/app/src/main/res/menu/imagequality_mode.xml
+++ b/app/src/main/res/menu/imagequality_mode.xml
@@ -5,11 +5,15 @@
         android:title="@string/never_load_images"/>
 
     <item
-        android:id="@+id/imgur"
-        android:title="@string/load_medium_quality_imgur_images"/>
+        android:id="@+id/low"
+        android:title="@string/load_low_quality"/>
 
     <item
-        android:id="@+id/reddit"
-        android:title="@string/low_quality_through_reddit_lower_resolution"/>
+        android:id="@+id/medium"
+        android:title="@string/load_medium_quality"/>
+
+    <item
+        android:id="@+id/high"
+        android:title="@string/load_high_quality"/>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -955,6 +955,9 @@
     <string name="load_high_quality_image_every_time">Otherwise, load high quality image every time</string>
     <string name="load_lower_quality_imgur">If enabled, will attempt to load an even lower quality Imgur image</string>
     <string name="load_medium_quality_imgur_images">Load medium quality Imgur images</string>
+    <string name="load_low_quality">Load low quality images (max. 320x320)</string>
+    <string name="load_medium_quality">Load medium quality images (max. 640x640)</string>
+    <string name="load_high_quality">Load high quality images (max. 1080x1080)</string>
     <string name="choose_color_title">Choose a color</string>
     <string name="enter_text_to_filter_click_enter_to_add">Enter text to filter, click enter to add</string>
     <string name="mode_desktop_compact">Desktop compact</string>


### PR DESCRIPTION
My attempt at implementing #2319. I'm a real novice when it comes to programming, and it's my first time using GitHub, so I apologize beforehand for any mistakes/issues. 

Basically, this will give the user three different data saving modes:

Low: uses Imgur m and reddit 320
Mid: uses Imgur l and reddit 640
High: uses Imgur h and reddit 1080 (falls back to 960 if 1080 is not available)

For non-Imgur images, when there isn't a preview in the desired size, it's supposed fall back to the full sized preview from reddit (not to be confused with the actual image), since that's closer to the desired resolution than the highest resolution resized reddit preview.

So far I haven't found any issues while testing. I'm really enjoying being able to choose a specific quality, and having it behave more consistently across different images, so I'd really, really appreciate it if you could consider merging this.

Thanks for the awesome app!

(I redid the pull request because the previous one was 4 commits)