### PR TITLE
Immersive Fullscreen Mode Fixes

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/BaseActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/BaseActivity.java
@@ -57,7 +57,7 @@ public class BaseActivity extends PeekViewActivity
     public void onWindowFocusChanged(final boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (SettingValues.immersiveMode) {
-            if (!hasFocus) {
+            if (hasFocus) {
                 hideDecor();
             }
         }
@@ -72,6 +72,23 @@ public class BaseActivity extends PeekViewActivity
                     | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                     | View.SYSTEM_UI_FLAG_FULLSCREEN
                     | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+            decorView.setOnSystemUiVisibilityChangeListener(
+                    new View.OnSystemUiVisibilityChangeListener() {
+                        @Override
+                        public void onSystemUiVisibilityChange(int visibility) {
+                            if ((visibility) == 0) {
+                                decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                        | View.SYSTEM_UI_FLAG_FULLSCREEN);
+                            } else {
+                                decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                            }
+                        }
+                    });
         }
     }
 

--- a/app/src/main/res/layout/drawer_loggedin.xml
+++ b/app/src/main/res/layout/drawer_loggedin.xml
@@ -585,7 +585,7 @@
     <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:descendantFocusability="beforeDescendants"
+            android:descendantFocusability="afterDescendants"
             android:focusableInTouchMode="true">
 
         <EditText

--- a/app/src/main/res/layout/drawer_loggedout.xml
+++ b/app/src/main/res/layout/drawer_loggedout.xml
@@ -254,7 +254,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="beforeDescendants"
+        android:descendantFocusability="afterDescendants"
         android:focusableInTouchMode="true">
 
         <EditText

--- a/app/src/main/res/layout/drawer_offline.xml
+++ b/app/src/main/res/layout/drawer_offline.xml
@@ -139,7 +139,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="beforeDescendants"
+        android:descendantFocusability="afterDescendants"
         android:focusableInTouchMode="true">
 
         <EditText


### PR DESCRIPTION
I reintroduced the onSystemUiVisibilityChange listener because it fixes the appearance when selecting and deselecting text fields. It was sensible to remove it given the EditText issue, but I think I have resolved that.

Regarding the EditText problem, it looks like the issue was caused by `descendantFocusability=beforeDescendants` being set in drawer_loggedin.xml. Setting this to `descendantFocusability=afterDescendants` seems to clear the issue right up. I'm not exactly sure why it's being explicitly set to `beforeDescendants` here, but my change doesn't seem to have any adverse effect. With this change, I don't think we need to go through and implement a custom EditText class.

[Reference](http://stackoverflow.com/questions/20406472/edittext-in-listview-loses-focus-when-pressed-on-android-4-x)

Commit Notes:
- Set onWindowFocusChanged check back to if(hasFocus) instead of if(!hasFocus)
- Exiting fullscreen mode on text entry fields should now properly re-enable status/nav bars
- Fixed focus issue on "Go to subreddit" EditText element
- Tested on Google Pixel running v7.1.1 (NMF26Q)