### PR TITLE
Added support for opening mailto: links externally

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -127,6 +127,10 @@ public class ContentType {
             return Type.SPOILER;
         }
 
+        if (url.startsWith("mailto:")) {
+            return Type.EXTERNAL;
+        }
+
         if (url.startsWith("//")) url = "https:" + url;
         if (url.startsWith("/")) url = "reddit.com" + url;
         if (!url.contains("://")) url = "http://" + url;

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -178,7 +178,7 @@ public class LinkUtil {
         if (url.startsWith("/")) {
             url = "https://reddit.com" + url;
         }
-        if (!url.contains("://")) {
+        if (!url.contains("://")  && !url.startsWith("mailto:")) {
             url = "http://" + url;
         }
 


### PR DESCRIPTION
For #2420.

ContentType.getContentType returns EXTERNAL for urls that start with 'mailto:'.
When LinkUtil.formatURL checks if a url doesn't contain '://', it also makes sure the url doesn't start with 'mailto'.

There still exists an issue with markdown links for mailto as described in this issue -> reddit/snudown#67