### PR TITLE
fix crash when syncing subreddits while user is not logged in

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/UserSubscriptions.java
+++ b/app/src/main/java/me/ccrama/redditslide/UserSubscriptions.java
@@ -8,6 +8,7 @@ import android.os.AsyncTask;
 import android.widget.Toast;
 
 import net.dean.jraw.ApiException;
+import net.dean.jraw.http.NetworkException;
 import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.managers.MultiRedditManager;
 import net.dean.jraw.models.MultiReddit;
@@ -303,6 +304,8 @@ public class UserSubscriptions {
                 }
             }
         } catch (ApiException e) {
+            e.printStackTrace();
+        } catch (NetworkException e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
when the user is not logged in and tries to sync subreddits (settings -> Manage your subreddits -> Sync subscriptions button), the app will currently crash because of an unhandled exception. This PR solves it by catching the additional exception thrown by MultiRedditManager.java