### PR TITLE
show toast when no posts found in search

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditSearchPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditSearchPosts.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import me.ccrama.redditslide.Activities.MultiredditOverview;
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.PostMatch;
+import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.util.LogUtil;
 
@@ -137,6 +138,9 @@ public class SubredditSearchPosts extends GeneralPosts {
                 // end of submissions
                 nomore = true;
                 adapter.notifyDataSetChanged();
+                if (reset) {
+                    Toast.makeText(adapter.mContext, R.string.no_posts_found, Toast.LENGTH_LONG).show();
+                }
             } else if (!nomore) {
                 // error
                 adapter.setError(true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -527,6 +527,7 @@
     <string name="search_top">Top</string>
     <string name="search_new">New</string>
     <string name="search_comments">Comments</string>
+    <string name="no_posts_found">No posts found</string>
 
 
     <!-- Captcha -->


### PR DESCRIPTION
Let me know if I missed anything. Currently, no toast shows up when no posts are found in a search (overflow menu -> search). This pull request aims to fix that.