### PR TITLE
add setting to allow single column view in multi-window mode

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
@@ -1,6 +1,8 @@
 package me.ccrama.redditslide.Activities;
 
+import android.app.Activity;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -196,7 +198,11 @@ public class Gallery extends FullScreenActivity implements SubmissionDisplay {
 
     private int getNumColumns(final int orientation) {
         final int numColumns;
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
+        boolean singleColumnMultiWindow = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            singleColumnMultiWindow = Gallery.this.isInMultiWindowMode() && SettingValues.singleColumnMultiWindow;
+        }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI && !singleColumnMultiWindow) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT
                 && SettingValues.dualPortrait) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Search.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Search.java
@@ -1,8 +1,11 @@
 package me.ccrama.redditslide.Activities;
 
+import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.SwipeRefreshLayout;
@@ -253,7 +256,7 @@ public class Search extends BaseActivityAnim {
         rv = ((RecyclerView) findViewById(R.id.vertical_content));
         final RecyclerView.LayoutManager mLayoutManager;
         mLayoutManager =
-                createLayoutManager(getNumColumns(getResources().getConfiguration().orientation));
+                createLayoutManager(getNumColumns(getResources().getConfiguration().orientation, Search.this));
         rv.setLayoutManager(mLayoutManager);
 
         rv.addOnScrollListener(new ToolbarScrollHideHandler(mToolbar, findViewById(R.id.header)) {
@@ -322,7 +325,7 @@ public class Search extends BaseActivityAnim {
         final CatchStaggeredGridLayoutManager mLayoutManager =
                 (CatchStaggeredGridLayoutManager) rv.getLayoutManager();
 
-        mLayoutManager.setSpanCount(getNumColumns(currentOrientation));
+        mLayoutManager.setSpanCount(getNumColumns(currentOrientation, Search.this));
     }
     @NonNull
     private RecyclerView.LayoutManager createLayoutManager(final int numColumns) {
@@ -330,9 +333,13 @@ public class Search extends BaseActivityAnim {
                 CatchStaggeredGridLayoutManager.VERTICAL);
     }
 
-    public static int getNumColumns(final int orientation) {
+    public static int getNumColumns(final int orientation, Context context) {
         final int numColumns;
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
+        boolean singleColumnMultiWindow = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            singleColumnMultiWindow = ((Activity)context).isInMultiWindowMode() && SettingValues.singleColumnMultiWindow;
+        }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI && !singleColumnMultiWindow) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT
                 && SettingValues.dualPortrait) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -326,6 +326,17 @@ public class Settings extends BaseActivity {
                                     .apply();
                         }
                     });
+                    SwitchCompat s3 = (SwitchCompat) dialog.findViewById(R.id.singlecolumnmultiwindow);
+                    s3.setChecked(SettingValues.singleColumnMultiWindow);
+                    s3.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                        @Override
+                        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                            SettingValues.singleColumnMultiWindow = isChecked;
+                            SettingValues.prefs.edit()
+                                    .putBoolean(SettingValues.PREF_SINGLE_COLUMN_MULTI, isChecked)
+                                    .apply();
+                        }
+                    });
                 } else {
                     new AlertDialogWrapper.Builder(Settings.this).setTitle(
                             "Mutli-Column Settings are a Pro feature")

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -73,7 +73,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public void setError(Boolean b) {
        listView.setAdapter(new ErrorAdapter());
         isError = true;
-        listView.setLayoutManager(SubmissionsView.createLayoutManager(SubmissionsView.getNumColumns(context.getResources().getConfiguration().orientation)));
+        listView.setLayoutManager(SubmissionsView.createLayoutManager(SubmissionsView.getNumColumns(context.getResources().getConfiguration().orientation, context)));
     }
 
     public boolean isError;
@@ -100,7 +100,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public void undoSetError() {
         listView.setAdapter(this);
         isError = false;
-        listView.setLayoutManager(SubmissionsView.createLayoutManager(SubmissionsView.getNumColumns(context.getResources().getConfiguration().orientation)));
+        listView.setLayoutManager(SubmissionsView.createLayoutManager(SubmissionsView.getNumColumns(context.getResources().getConfiguration().orientation, context)));
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -72,7 +72,11 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
 
     private int getNumColumns(final int orientation) {
         final int numColumns;
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
+        boolean singleColumnMultiWindow = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            singleColumnMultiWindow = getActivity().isInMultiWindowMode() && SettingValues.singleColumnMultiWindow;
+        }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI && !singleColumnMultiWindow) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT && SettingValues.dualPortrait) {
             numColumns = 2;

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -1,5 +1,6 @@
 package me.ccrama.redditslide.Fragments;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -81,7 +82,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         final CatchStaggeredGridLayoutManager mLayoutManager =
                 (CatchStaggeredGridLayoutManager) rv.getLayoutManager();
 
-        mLayoutManager.setSpanCount(getNumColumns(currentOrientation));
+        mLayoutManager.setSpanCount(getNumColumns(currentOrientation, getActivity()));
     }
 
     Runnable mLongPressRunnable;
@@ -107,7 +108,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
 
         final RecyclerView.LayoutManager mLayoutManager;
         mLayoutManager =
-                createLayoutManager(getNumColumns(getResources().getConfiguration().orientation));
+                createLayoutManager(getNumColumns(getResources().getConfiguration().orientation, getActivity()));
 
         if (!(getActivity() instanceof SubredditView)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
@@ -310,9 +311,13 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
                 CatchStaggeredGridLayoutManager.VERTICAL);
     }
 
-    public static int getNumColumns(final int orientation) {
+    public static int getNumColumns(final int orientation, Activity context) {
         final int numColumns;
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI) {
+        boolean singleColumnMultiWindow = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            singleColumnMultiWindow = context.isInMultiWindowMode() && SettingValues.singleColumnMultiWindow;
+        }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE && SettingValues.tabletUI && !singleColumnMultiWindow) {
             numColumns = Reddit.dpWidth;
         } else if (orientation == Configuration.ORIENTATION_PORTRAIT
                 && SettingValues.dualPortrait) {

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -60,6 +60,7 @@ public class SettingValues {
     public static final String PREF_COLLAPSE_COMMENTS_DEFAULT = "collapseCommentsDefault";
     public static final String PREF_RIGHT_HANDED_COMMENT_MENU = "rightHandedCommentMenu";
     public static final String PREF_DUAL_PORTRAIT             = "dualPortrait";
+    public static final String PREF_SINGLE_COLUMN_MULTI       = "singleColumnMultiWindow";
     public static final String PREF_CROP_IMAGE                = "cropImage";
     public static final String PREF_COMMENT_FAB               = "commentFab";
     public static final String PREF_SWITCH_THUMB              = "switchThumb";
@@ -188,6 +189,7 @@ public class SettingValues {
     public static boolean tabletUI;
     public static boolean customtabs;
     public static boolean dualPortrait;
+    public static boolean singleColumnMultiWindow;
     public static boolean nightMode;
     public static boolean imageSubfolders;
     public static boolean autoTime;
@@ -327,6 +329,7 @@ public class SettingValues {
         largeLinks = prefs.getBoolean(PREF_LARGE_LINKS, false);
 
         dualPortrait = prefs.getBoolean(PREF_DUAL_PORTRAIT, false);
+        singleColumnMultiWindow = prefs.getBoolean(PREF_SINGLE_COLUMN_MULTI, false);
         colorSubName = prefs.getBoolean(PREF_COLOR_SUB_NAME, false);
 
         cropImage = prefs.getBoolean(PREF_CROP_IMAGE, true);

--- a/app/src/main/res/layout/tabletui.xml
+++ b/app/src/main/res/layout/tabletui.xml
@@ -58,6 +58,20 @@
                         android:max="5" />
 
                     <android.support.v7.widget.SwitchCompat
+                            android:id="@+id/singlecolumnmultiwindow"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_marginBottom="8dp"
+                            android:layout_marginTop="8dp"
+                            android:backgroundTint="?attr/tint"
+                            android:button="@null"
+                            android:buttonTint="?attr/tint"
+                            android:hapticFeedbackEnabled="true"
+                            android:text="@string/single_column_multi_window"
+                            android:textColor="?attr/font"
+                            android:textColorHint="?attr/font" />
+
+                    <android.support.v7.widget.SwitchCompat
                         android:id="@+id/dualcolumns"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="multi_column_title">Multi-column</string>
     <string name="multi_column_landscape">Landscape</string>
     <string name="multi_column_portrait">Dual columns in portrait mode</string>
+    <string name="single_column_multi_window">Single column in multi-window mode</string>
 
 
     <!-- Drawer items (That's the one on the left) -->


### PR DESCRIPTION
This pull request aims to add a new feature to Slide. This feature will add a new setting to the multi-column settings window called "Single column in multi-window mode". It is disabled by default. When the setting is enabled and the app is in multi window mode, only a single column for submissionview, gallery, search, and multireddits should appear. The setting should have no effect if the app is not in multi-window mode. 

The reason this came up is I like to have dual columns in landscape mode. However, when using the app in multi-window mode, the app still considers itself in landscape mode (even if the phone is held in portrait). This happens because the width is greater than the height. This makes it hard to read the submissions as they are shown in dual column mode on a very small width. This setting should make it much easier to browse when using this configuration

Let me know if you have any questions.