### PR TITLE
Fixed failing build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,11 @@ plugins {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.devspark.robototextview.gradle-plugin'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
     lintOptions {
         quiet true
         abortOnError false
@@ -62,8 +63,21 @@ android {
 
 }
 
+robototextview {
+    include "RobotoSlab-Light",
+            "RobotoSlab",
+            "RobotoCondensed-Light",
+            "RobotoCondensed",
+            "Roboto-Light",
+            "Roboto",
+            "Roboto-Bold",
+            "Roboto-Medium",
+            "RobotoCondensed-Bold"
+    log = true
+}
+
 ext {
-    supportLibVersion = '26.0.1'
+    supportLibVersion = '26.1.0'
     robolectricVersion = '3.3.1'
 }
 dependencies {
@@ -80,7 +94,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:$supportLibVersion"
     compile "com.android.support:support-v13:$supportLibVersion"
     compile "com.android.support:cardview-v7:$supportLibVersion"
-    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.android.support:multidex:1.0.2'
     withGPlayCompile 'com.google.android.gms:play-services-drive:10.2.0'
     compile 'com.github.rey5137:material:1.2.4'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
@@ -90,7 +104,7 @@ dependencies {
     compile 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'jp.wasabeef:blurry:2.1.0'
-    compile 'com.github.ccrama:Android-RobotoTextView:28b71bcd9c'
+    compile 'com.github.johnkil.android-robototextview:robototextview:4.0.0'
     // ↑ minor
     compile 'com.makeramen:roundedimageview:2.2.1'
     compile 'com.getbase:floatingactionbutton:1.10.1'

--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -43,7 +43,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.assist.FailReason;
 import com.nostra13.universalimageloader.core.assist.ImageScaleType;
@@ -586,7 +586,7 @@ public class AlbumPager extends FullScreenActivity
                         int type = new FontPreferences(getContext()).getFontTypeComment().getTypeface();
                         Typeface typeface;
                         if (type >= 0) {
-                            typeface = RobotoTypefaceManager.obtainTypeface(getContext(), type);
+                            typeface = RobotoTypefaces.obtainTypeface(getContext(), type);
                         } else {
                             typeface = Typeface.DEFAULT;
                         }
@@ -597,7 +597,7 @@ public class AlbumPager extends FullScreenActivity
                         int type = new FontPreferences(getContext()).getFontTypeTitle().getTypeface();
                         Typeface typeface;
                         if (type >= 0) {
-                            typeface = RobotoTypefaceManager.obtainTypeface(getContext(), type);
+                            typeface = RobotoTypefaces.obtainTypeface(getContext(), type);
                         } else {
                             typeface = Typeface.DEFAULT;
                         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -43,7 +43,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.assist.FailReason;
 import com.nostra13.universalimageloader.core.assist.ImageScaleType;
@@ -563,7 +563,7 @@ public class TumblrPager extends FullScreenActivity
                     int type = new FontPreferences(getContext()).getFontTypeComment().getTypeface();
                     Typeface typeface;
                     if (type >= 0) {
-                        typeface = RobotoTypefaceManager.obtainTypeface(getContext(), type);
+                        typeface = RobotoTypefaces.obtainTypeface(getContext(), type);
                     } else {
                         typeface = Typeface.DEFAULT;
                     }
@@ -573,7 +573,7 @@ public class TumblrPager extends FullScreenActivity
                     int type = new FontPreferences(getContext()).getFontTypeTitle().getTypeface();
                     Typeface typeface;
                     if (type >= 0) {
-                        typeface = RobotoTypefaceManager.obtainTypeface(getContext(), type);
+                        typeface = RobotoTypefaces.obtainTypeface(getContext(), type);
                     } else {
                         typeface = Typeface.DEFAULT;
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
@@ -21,7 +21,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -136,7 +136,7 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 int type = new FontPreferences(holder.body.getContext()).getFontTypeComment().getTypeface();
                 Typeface typeface;
                 if (type >= 0) {
-                    typeface = RobotoTypefaceManager.obtainTypeface(holder.body.getContext(), type);
+                    typeface = RobotoTypefaces.obtainTypeface(holder.body.getContext(), type);
                 } else {
                     typeface = Typeface.DEFAULT;
                 }
@@ -146,7 +146,7 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 int type = new FontPreferences(holder.body.getContext()).getFontTypeTitle().getTypeface();
                 Typeface typeface;
                 if (type >= 0) {
-                    typeface = RobotoTypefaceManager.obtainTypeface(holder.body.getContext(), type);
+                    typeface = RobotoTypefaces.obtainTypeface(holder.body.getContext(), type);
                 } else {
                     typeface = Typeface.DEFAULT;
                 }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -37,7 +37,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 import com.lusfold.androidkeyvaluestore.KVStore;
 import com.mikepenz.itemanimators.AlphaInAnimator;
 import com.mikepenz.itemanimators.SlideRightAlphaAnimator;
@@ -405,7 +405,7 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             int type = new FontPreferences(mContext).getFontTypeComment().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(mContext, type);
+                typeface = RobotoTypefaces.obtainTypeface(mContext, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
@@ -31,7 +31,7 @@ import android.view.ViewGroup;
 import android.widget.Filter;
 import android.widget.Filterable;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.models.Comment;
 import net.dean.jraw.models.CommentNode;
@@ -231,7 +231,7 @@ public class CommentAdapterSearch extends RecyclerView.Adapter<RecyclerView.View
         int type = new FontPreferences(mContext).getFontTypeComment().getTypeface();
         Typeface typeface;
         if (type >= 0) {
-            typeface = RobotoTypefaceManager.obtainTypeface(mContext, type);
+            typeface = RobotoTypefaces.obtainTypeface(mContext, type);
         } else {
             typeface = Typeface.DEFAULT;
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
@@ -32,7 +32,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.models.Comment;
@@ -410,7 +410,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             int type = new FontPreferences(mContext).getFontTypeComment().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(mContext, type);
+                typeface = RobotoTypefaces.obtainTypeface(mContext, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/InboxAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/InboxAdapter.java
@@ -38,7 +38,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.ApiException;
 import net.dean.jraw.managers.InboxManager;
@@ -400,7 +400,7 @@ public class InboxAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
             int type = new FontPreferences(mContext).getFontTypeComment().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(mContext, type);
+                typeface = RobotoTypefaces.obtainTypeface(mContext, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.graphics.Typeface;
-import android.net.Uri;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -17,7 +16,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -25,11 +24,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import me.ccrama.redditslide.Activities.Album;
 import me.ccrama.redditslide.Activities.MediaView;
 import me.ccrama.redditslide.Activities.Tumblr;
 import me.ccrama.redditslide.ContentType;
-import me.ccrama.redditslide.ImgurAlbum.Image;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
@@ -134,7 +131,7 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 int type = new FontPreferences(holder.body.getContext()).getFontTypeComment().getTypeface();
                 Typeface typeface;
                 if (type >= 0) {
-                    typeface = RobotoTypefaceManager.obtainTypeface(holder.body.getContext(), type);
+                    typeface = RobotoTypefaces.obtainTypeface(holder.body.getContext(), type);
                 } else {
                     typeface = Typeface.DEFAULT;
                 }
@@ -144,7 +141,7 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 int type = new FontPreferences(holder.body.getContext()).getFontTypeTitle().getTypeface();
                 Typeface typeface;
                 if (type >= 0) {
-                    typeface = RobotoTypefaceManager.obtainTypeface(holder.body.getContext(), type);
+                    typeface = RobotoTypefaces.obtainTypeface(holder.body.getContext(), type);
                 } else {
                     typeface = Typeface.DEFAULT;
                 }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -39,7 +39,7 @@ import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.ApiException;
 import net.dean.jraw.fluent.FlairReference;
@@ -2701,7 +2701,7 @@ public class PopulateSubmissionViewHolder {
             int typef = new FontPreferences(mContext).getFontTypeComment().getTypeface();
             Typeface typeface;
             if (typef >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(mContext, typef);
+                typeface = RobotoTypefaces.obtainTypeface(mContext, typef);
             } else {
                 typeface = Typeface.DEFAULT;
             }
@@ -2734,7 +2734,7 @@ public class PopulateSubmissionViewHolder {
                 int typef = new FontPreferences(mContext).getFontTypeComment().getTypeface();
                 Typeface typeface;
                 if (typef >= 0) {
-                    typeface = RobotoTypefaceManager.obtainTypeface(mContext, typef);
+                    typeface = RobotoTypefaces.obtainTypeface(mContext, typef);
                 } else {
                     typeface = Typeface.DEFAULT;
                 }

--- a/app/src/main/java/me/ccrama/redditslide/Views/CommentOverflow.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/CommentOverflow.java
@@ -14,7 +14,7 @@ import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import java.util.List;
 
@@ -88,7 +88,7 @@ public class CommentOverflow extends LinearLayout {
         Context context = getContext();
         int type = new FontPreferences(context).getFontTypeComment().getTypeface();
         if (type >= 0) {
-            typeface = RobotoTypefaceManager.obtainTypeface(context, type);
+            typeface = RobotoTypefaces.obtainTypeface(context, type);
         } else {
             typeface = Typeface.DEFAULT;
         }

--- a/app/src/main/java/me/ccrama/redditslide/Views/RedditItemView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/RedditItemView.java
@@ -23,7 +23,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.models.Account;
 import net.dean.jraw.models.Comment;
@@ -398,7 +398,7 @@ public class RedditItemView extends RelativeLayout {
         int type = new FontPreferences(getContext()).getFontTypeComment().getTypeface();
         Typeface typeface;
         if (type >= 0) {
-            typeface = RobotoTypefaceManager.obtainTypeface(getContext(), type);
+            typeface = RobotoTypefaces.obtainTypeface(getContext(), type);
         } else {
             typeface = Typeface.DEFAULT;
         }

--- a/app/src/main/java/me/ccrama/redditslide/Views/RoundedBackgroundSpan.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/RoundedBackgroundSpan.java
@@ -8,7 +8,7 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.text.style.ReplacementSpan;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 /**
  * Created by carlo_000 on 3/11/2016.
@@ -44,7 +44,7 @@ public class RoundedBackgroundSpan extends ReplacementSpan {
             offset = (bottom - top) / 6;
         }
 
-        paint.setTypeface(RobotoTypefaceManager.obtainTypeface(c, RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_BOLD));
+        paint.setTypeface(RobotoTypefaces.obtainTypeface(c, RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_BOLD));
 
         if (half) {
             paint.setTextSize(paint.getTextSize() / 2);
@@ -62,7 +62,7 @@ public class RoundedBackgroundSpan extends ReplacementSpan {
 
     @Override
     public int getSize(Paint paint, CharSequence text, int start, int end, Paint.FontMetricsInt fm) {
-        paint.setTypeface(RobotoTypefaceManager.obtainTypeface(c, RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_BOLD));
+        paint.setTypeface(RobotoTypefaces.obtainTypeface(c, RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_BOLD));
         final int size = Math.round(paint.measureText(text, start, end));
 
         if (half) {

--- a/app/src/main/java/me/ccrama/redditslide/Views/TitleTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/TitleTextView.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Visuals.FontPreferences;
@@ -19,7 +19,7 @@ public class TitleTextView extends SpoilerRobotoTextView {
             int type = new FontPreferences(getContext()).getFontTypeTitle().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(c, type);
+                typeface = RobotoTypefaces.obtainTypeface(c, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }
@@ -34,7 +34,7 @@ public class TitleTextView extends SpoilerRobotoTextView {
             int type = new FontPreferences(getContext()).getFontTypeTitle().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(c, type);
+                typeface = RobotoTypefaces.obtainTypeface(c, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }
@@ -48,7 +48,7 @@ public class TitleTextView extends SpoilerRobotoTextView {
             int type = new FontPreferences(getContext()).getFontTypeTitle().getTypeface();
             Typeface typeface;
             if (type >= 0) {
-                typeface = RobotoTypefaceManager.obtainTypeface(c, type);
+                typeface = RobotoTypefaces.obtainTypeface(c, type);
             } else {
                 typeface = Typeface.DEFAULT;
             }

--- a/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
+++ b/app/src/main/java/me/ccrama/redditslide/Visuals/FontPreferences.java
@@ -3,7 +3,7 @@ package me.ccrama.redditslide.Visuals;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.devspark.robototextview.util.RobotoTypefaceManager;
+import com.devspark.robototextview.RobotoTypefaces;
 
 import me.ccrama.redditslide.R;
 
@@ -116,10 +116,10 @@ public class FontPreferences {
 
 
     public enum FontTypeComment {
-        Slab(RobotoTypefaceManager.Typeface.ROBOTO_SLAB_REGULAR, "Slab"),
-        Condensed(RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_REGULAR, "Condensed"),
-        Light(RobotoTypefaceManager.Typeface.ROBOTO_LIGHT, "Light"),
-        Regular(RobotoTypefaceManager.Typeface.ROBOTO_REGULAR, "Regular"),
+        Slab(RobotoTypefaces.TYPEFACE_ROBOTO_SLAB_REGULAR, "Slab"),
+        Condensed(RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_REGULAR, "Condensed"),
+        Light(RobotoTypefaces.TYPEFACE_ROBOTO_LIGHT, "Light"),
+        Regular(RobotoTypefaces.TYPEFACE_ROBOTO_REGULAR, "Regular"),
         System(-1, "System");
 
         private final int typeface;
@@ -139,15 +139,15 @@ public class FontPreferences {
         }
     }
     public enum FontTypeTitle {
-        Slab(RobotoTypefaceManager.Typeface.ROBOTO_SLAB_LIGHT, "Slab Light"),
-        SlabReg(RobotoTypefaceManager.Typeface.ROBOTO_SLAB_REGULAR, "Slab Regular"),
-        Condensed(RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_LIGHT, "Condensed Light"),
-        CondensedReg(RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_REGULAR, "Condensed Regular"),
-        Light(RobotoTypefaceManager.Typeface.ROBOTO_LIGHT, "Light"),
-        Regular(RobotoTypefaceManager.Typeface.ROBOTO_REGULAR, "Regular"),
-        Bold(RobotoTypefaceManager.Typeface.ROBOTO_BOLD, "Bold"),
-        Medium(RobotoTypefaceManager.Typeface.ROBOTO_MEDIUM, "Medium"),
-        CondensedBold(RobotoTypefaceManager.Typeface.ROBOTO_CONDENSED_BOLD, "Condensed Bold"),
+        Slab(RobotoTypefaces.TYPEFACE_ROBOTO_SLAB_LIGHT, "Slab Light"),
+        SlabReg(RobotoTypefaces.TYPEFACE_ROBOTO_SLAB_REGULAR, "Slab Regular"),
+        Condensed(RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_LIGHT, "Condensed Light"),
+        CondensedReg(RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_REGULAR, "Condensed Regular"),
+        Light(RobotoTypefaces.TYPEFACE_ROBOTO_LIGHT, "Light"),
+        Regular(RobotoTypefaces.TYPEFACE_ROBOTO_REGULAR, "Regular"),
+        Bold(RobotoTypefaces.TYPEFACE_ROBOTO_BOLD, "Bold"),
+        Medium(RobotoTypefaces.TYPEFACE_ROBOTO_MEDIUM, "Medium"),
+        CondensedBold(RobotoTypefaces.TYPEFACE_ROBOTO_CONDENSED_BOLD, "Condensed Bold"),
         System(-1, "System");
 
         private final int typeface;

--- a/app/src/main/res/layout/activity_settings_font.xml
+++ b/app/src/main/res/layout/activity_settings_font.xml
@@ -202,7 +202,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_regular"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_regular"/>
+                        app:robotoTypeface="roboto_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/cslab"
@@ -211,7 +211,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_slab"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_slab_regular"/>
+                        app:robotoTypeface="roboto_slab_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/ccond"
@@ -220,7 +220,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_condensed"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_condensed_regular"/>
+                        app:robotoTypeface="roboto_condensed_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/clight"
@@ -229,7 +229,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_light"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_light"/>
+                        app:robotoTypeface="roboto_light"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/cnone"
@@ -327,7 +327,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_regular"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_regular"/>
+                        app:robotoTypeface="roboto_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/sbold"
@@ -336,7 +336,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_bold"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_bold"/>
+                        app:robotoTypeface="roboto_bold"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/smed"
@@ -345,7 +345,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_medium"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_medium"/>
+                        app:robotoTypeface="roboto_medium"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/sregl"
@@ -354,7 +354,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_light"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_light"/>
+                        app:robotoTypeface="roboto_light"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/sslab"
@@ -363,7 +363,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_slab"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_slab_regular"/>
+                        app:robotoTypeface="roboto_slab_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/sslabl"
@@ -372,7 +372,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_slab_light"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_slab_light"/>
+                        app:robotoTypeface="roboto_slab_light"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/scond"
@@ -381,7 +381,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_condensed"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_condensed_regular"/>
+                        app:robotoTypeface="roboto_condensed_regular"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/scondl"
@@ -390,7 +390,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_condensed_light"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_condensed_light"/>
+                        app:robotoTypeface="roboto_condensed_light"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/scondb"
@@ -399,7 +399,7 @@
                         android:background="?android:selectableItemBackground"
                         android:text="@string/settings_font_condensed_bold"
                         android:textColor="?attr/font"
-                        app:typeface="roboto_condensed_bold"/>
+                        app:robotoTypeface="roboto_condensed_bold"/>
 
                 <com.devspark.robototextview.widget.RobotoRadioButton
                         android:id="@+id/snone"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -16,7 +16,7 @@
     <declare-styleable name="Theme">
         <attr name="activity_background" format="color" />
         <attr name="card_background" format="color" />
-        <attr name="font" format="color" />
+        <attr name="font_color" format="color" />
         <attr name="tint" format="color" />
 
         <attr name="list_background" format="color" />

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -185,7 +185,7 @@
         <item name="md_background_color">#000000</item>
         <item name="list_background">#000000</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.AMOLED</item>
-        <item name="font">#DEFFFFFF</item> <!-- 87% white -->
+        <item name="font_color">#DEFFFFFF</item> <!-- 87% white -->
         <item name="tint">#8AFFFFFF</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -201,7 +201,7 @@
         <item name="md_background_color">#121212</item>
         <item name="list_background">#000000</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.AMOLED</item>
-        <item name="font">#DEFFFFFF</item> <!-- 87% white -->
+        <item name="font_color">#DEFFFFFF</item> <!-- 87% white -->
         <item name="tint">#8AFFFFFF</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -215,7 +215,7 @@
         <item name="card_background">#303030</item>
         <item name="list_background">#212121</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.Dark</item>
-        <item name="font">#DEFFFFFF</item> <!-- 87% white -->
+        <item name="font_color">#DEFFFFFF</item> <!-- 87% white -->
         <item name="tint">#8AFFFFFF</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -231,7 +231,7 @@
         <item name="md_background_color">#37474F</item>
         <item name="list_background">#263238</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.Dark_Blue</item>
-        <item name="font">#DEFFFFFF</item> <!-- 87% white -->
+        <item name="font_color">#DEFFFFFF</item> <!-- 87% white -->
         <item name="tint">#8AFFFFFF</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -247,7 +247,7 @@
         <item name="md_background_color">#2d2d2d</item>
         <item name="list_background">#3a3a3a</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.PIXEL</item>
-        <item name="font">#DEFFFFFF</item> <!-- 87% white -->
+        <item name="font_color">#DEFFFFFF</item> <!-- 87% white -->
         <item name="tint">#8AFFFFFF</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -263,7 +263,7 @@
         <item name="md_background_color">#402c2c</item>
         <item name="list_background">#261a1a</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.Night_Red</item>
-        <item name="font">#defff7ed</item> <!-- 87% white -->
+        <item name="font_color">#defff7ed</item> <!-- 87% white -->
         <item name="tint">#8affebcf</item> <!-- 54% white -->
         <item name="android:windowBackground">@null</item>
         <item name="android:alertDialogStyle">@style/AlertDialog.AppCompat</item>
@@ -279,7 +279,7 @@
         <item name="android:colorBackground">#e2dfd7</item>
         <item name="md_background_color">#e2dfd7</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.Sepia</item>
-        <item name="font">#de3e3d36</item> <!-- 87% black -->
+        <item name="font_color">#de3e3d36</item> <!-- 87% black -->
         <item name="tint">#8A3e3d36</item> <!-- 54% black -->
         <item name="android:textColorPrimary">#DE3e3d36</item> <!-- 87% black -->
         <item name="android:textColorSecondary">#8A3e3d36</item> <!-- 54% black -->
@@ -298,7 +298,7 @@
         <item name="card_background">#FFFFFF</item>
         <item name="list_background">#e5e5e5</item>
         <item name="bs_bottomSheetStyle">@style/BottomSheet.StyleDialog.Light</item>
-        <item name="font">#DE000000</item> <!-- 87% black -->
+        <item name="font_color">#DE000000</item> <!-- 87% black -->
         <item name="tint">#8A000000</item> <!-- 54% black -->
         <item name="android:textColorPrimary">#DE000000</item> <!-- 87% black -->
         <item name="android:textColorSecondary">#8A000000</item> <!-- 54% black -->

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,14 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
     repositories {
         jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta6'
         // ./gradlew dependencyUpdates
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
-
+        classpath 'com.github.johnkil.android-robototextview:robototextview-gradle-plugin:3.0.0-SNAPSHOT'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This fixes build failing with API level 26, by resolving a naming conflict (attr/font) and updating robototextview. 
In addition robototextview is switched back from the fork to the upstream version
and the gradle plugin is used to exclude unneeded fonts

Sadly this now crashed when starting the app, but at least it's better than not building at all.