### PR TITLE
Fixed travis build failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-25.0.2
-  - android-25
+  - build-tools-26.0.1
+  - android-26
   - extra-android-m2repository
   - extra-google-m2repository
   - extra-google-google_play_services


### PR DESCRIPTION
This fixes the .travis.yml file, so travis builds will pass again.