### PR TITLE
Fixed robototextview including too many fonts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,16 +63,15 @@ android {
 }
 
 robototextview {
-    include "RobotoSlab-Light",
-            "RobotoSlab",
-            "RobotoCondensed-Light",
-            "RobotoCondensed",
-            "Roboto-Light",
-            "Roboto",
+    include "Roboto-Light",
+            "Roboto-Regular",
             "Roboto-Bold",
             "Roboto-Medium",
+            "RobotoSlab-Light",
+            "RobotoSlab-Regular",
+            "RobotoCondensed-Light",
+            "RobotoCondensed-Regular",
             "RobotoCondensed-Bold"
-    log = true
 }
 
 ext {


### PR DESCRIPTION
Important: This needs a complete rebuild in order to apply. The robototextview gradle plugin doesn't recognize changes to it's config and will continue including the old fonts without a full rebuild!

@ccrama  