### PR TITLE
Attempt to fix crash with CyanogenMod (disable AAPT2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,8 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Fix for CyanogenMod 12/13 -- LineageOS 13 -- Replicant 6
+# https://issuetracker.google.com/issues/64434571
+# https://developer.android.com/studio/build/gradle-plugin-3-0-0.html
+android.enableAapt2=false


### PR DESCRIPTION
Try to fix #2555 

See:
- https://issuetracker.google.com/issues/64434571
- https://developer.android.com/studio/build/gradle-plugin-3-0-0.html