### PR TITLE
sort pinned subreddits when dragged

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/DragSort/ReorderSubreddits.java
+++ b/app/src/main/java/me/ccrama/redditslide/DragSort/ReorderSubreddits.java
@@ -71,6 +71,8 @@ import me.ccrama.redditslide.UserSubscriptions;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.LogUtil;
 
+import static me.ccrama.redditslide.UserSubscriptions.setPinned;
+
 public class ReorderSubreddits extends BaseActivityAnim {
 
     private CaseInsensitiveArrayList subs;
@@ -292,6 +294,16 @@ public class ReorderSubreddits extends BaseActivityAnim {
                 String item = subs.remove(from);
                 subs.add(to, item);
                 adapter.notifyDataSetChanged();
+
+                CaseInsensitiveArrayList pinned = UserSubscriptions.getPinned();
+                if (pinned.contains(item) && pinned.size() != 1) {
+                    pinned.remove(item);
+                    if (to > pinned.size()) {
+                        to = pinned.size();
+                    }
+                    pinned.add(to, item);
+                    setPinned(pinned);
+                }
             }
         });
 


### PR DESCRIPTION
Currently, when sorting subreddits alphabetically, the pinned subreddits are sorted by when they were added to the pinned list. This pull request will update the sort of the pinned list every time one of the pinned subreddits is moved. This will help keep the pinned subreddits in the order the user wants when sorting the list alphabetically.