### PR TITLE
use android-27 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
   - tools
   - platform-tools
   - build-tools-26.0.2
-  - android-26
+  - android-27
   - extra-android-m2repository
   - extra-google-m2repository
   - extra-google-google_play_services


### PR DESCRIPTION
fixes the build failure (this license thing is a real pain)