### PR TITLE
Bugfix/unescape all links leaving slide

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
@@ -1,15 +1,10 @@
 package me.ccrama.redditslide.Activities;
 
 import android.app.Activity;
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.media.MediaScannerConnection;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
@@ -17,7 +12,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
-import android.support.v4.app.NotificationCompat;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
@@ -53,6 +47,7 @@ import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Views.PreCachingLayoutManager;
 import me.ccrama.redditslide.Views.ToolbarColorizeHelper;
+import me.ccrama.redditslide.util.LinkUtil;
 
 /**
  * Created by ccrama on 3/5/2015. <p/> This class is responsible for accessing the Imgur api to get
@@ -104,7 +99,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
             finish();
         }
         if (id == R.id.external) {
-            Reddit.defaultShare(url, this);
+            LinkUtil.openExternally(url, this);
         }
         if (id == R.id.download) {
             for (final Image elem : images) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -44,7 +44,6 @@ import android.widget.Toast;
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
 import com.devspark.robototextview.RobotoTypefaces;
-import com.devspark.robototextview.RobotoTypefaces;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.assist.FailReason;
 import com.nostra13.universalimageloader.core.assist.ImageScaleType;
@@ -125,7 +124,7 @@ public class AlbumPager extends FullScreenActivity
             mToolbar.findViewById(R.id.grid).callOnClick();
         }
         if (id == R.id.external) {
-            Reddit.defaultShare(getIntent().getExtras().getString("url", ""), this);
+            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""), this);
         }
 
         if (id == R.id.comments) {
@@ -469,7 +468,7 @@ public class AlbumPager extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(contentUrl, AlbumPager.this, false);
+                        LinkUtil.openExternally(contentUrl, AlbumPager.this);
                     }
                     break;
                     case (3): {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -20,9 +20,9 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.FileProvider;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
-import android.support.v4.app.NotificationCompat;
 import android.text.Html;
 import android.util.Log;
 import android.view.View;
@@ -269,8 +269,8 @@ public class MediaView extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(StringEscapeUtils.unescapeHtml4(contentUrl),
-                                MediaView.this, true);
+                        LinkUtil.openExternally(contentUrl,
+                                MediaView.this);
                         break;
                     }
                     case (3): {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
@@ -14,7 +14,7 @@ import android.widget.Toast;
 import me.ccrama.redditslide.BuildConfig;
 import me.ccrama.redditslide.OpenRedditLink;
 import me.ccrama.redditslide.R;
-import me.ccrama.redditslide.Reddit;
+import me.ccrama.redditslide.util.LinkUtil;
 
 
 /**
@@ -69,7 +69,7 @@ public class SettingsAbout extends BaseActivityAnim {
         report.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Reddit.defaultShare("https://github.com/ccrama/Slide/issues", SettingsAbout.this);
+                LinkUtil.openExternally("https://github.com/ccrama/Slide/issues", SettingsAbout.this);
             }
         });
         findViewById(R.id.sub).setOnClickListener(new View.OnClickListener() {
@@ -91,7 +91,7 @@ public class SettingsAbout extends BaseActivityAnim {
         changelog.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Reddit.defaultShare("https://github.com/ccrama/Slide/blob/master/CHANGELOG.md", SettingsAbout.this);
+                LinkUtil.openExternally("https://github.com/ccrama/Slide/blob/master/CHANGELOG.md", SettingsAbout.this);
             }
         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
@@ -47,6 +47,7 @@ import me.ccrama.redditslide.Tumblr.Photo;
 import me.ccrama.redditslide.Tumblr.TumblrUtils;
 import me.ccrama.redditslide.Views.PreCachingLayoutManager;
 import me.ccrama.redditslide.Views.ToolbarColorizeHelper;
+import me.ccrama.redditslide.util.LinkUtil;
 
 /**
  * Created by ccrama on 9/7/2016. <p/> This class is responsible for accessing the Tumblr api to get
@@ -102,7 +103,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
             finish();
         }
         if (id == R.id.external) {
-            Reddit.defaultShare(url, this);
+            LinkUtil.openExternally(url, this);
         }
         if (id == R.id.download) {
             for (final Photo elem : images) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -2,9 +2,6 @@ package me.ccrama.redditslide.Activities;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
@@ -13,7 +10,6 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -23,7 +19,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.content.FileProvider;
 import android.support.v4.view.ViewPager;
-import android.support.v4.app.NotificationCompat;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -66,15 +61,12 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import me.ccrama.redditslide.Adapters.ImageGridAdapter;
 import me.ccrama.redditslide.Adapters.ImageGridAdapterTumblr;
 import me.ccrama.redditslide.ColorPreferences;
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.Fragments.BlankFragment;
 import me.ccrama.redditslide.Fragments.FolderChooserDialogCreate;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
-import me.ccrama.redditslide.ImgurAlbum.AlbumUtils;
-import me.ccrama.redditslide.ImgurAlbum.Image;
 import me.ccrama.redditslide.Notifications.ImageDownloadNotificationService;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
@@ -130,7 +122,7 @@ public class TumblrPager extends FullScreenActivity
             mToolbar.findViewById(R.id.grid).callOnClick();
         }
         if (id == R.id.external) {
-            Reddit.defaultShare(getIntent().getExtras().getString("url", ""), this);
+            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""), this);
         }
 
         if (id == R.id.comments) {
@@ -450,7 +442,7 @@ public class TumblrPager extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(contentUrl, TumblrPager.this, false);
+                        LinkUtil.openExternally(contentUrl, TumblrPager.this);
                     }
                     break;
                     case (3): {

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
@@ -6,11 +6,6 @@ import android.content.Intent;
 import android.graphics.Typeface;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.style.URLSpan;
-import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -35,7 +30,7 @@ import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Visuals.FontPreferences;
-import me.ccrama.redditslide.util.LogUtil;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -187,7 +182,7 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         myIntent.putExtra(MediaView.SUBREDDIT, subreddit);
                         main.startActivity(myIntent);
                     } else {
-                        Reddit.defaultShare(user.getImageUrl(), main);
+                        LinkUtil.openExternally(user.getImageUrl(), main);
                     }
                 }
             };

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
@@ -1,8 +1,5 @@
 package me.ccrama.redditslide.Adapters;
 
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
@@ -17,7 +14,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
-import android.widget.Toast;
 
 import com.cocosw.bottomsheet.BottomSheet;
 
@@ -177,11 +173,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         Reddit.defaultShareText("", submission.getUrl(), main);
                                         break;
                                     case R.id.copy_link:
-                                        ClipboardManager clipboard = (ClipboardManager) main.getSystemService(Context.CLIPBOARD_SERVICE);
-                                        ClipData clip = ClipData.newPlainText("Link", submission.getUrl());
-                                        clipboard.setPrimaryClip(clip);
-
-                                        Toast.makeText(main, R.string.submission_link_copied, Toast.LENGTH_SHORT).show();
+                                        LinkUtil.copyUrl(submission.getUrl(), main);
                                         break;
                                 }
                             }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
@@ -171,7 +171,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                             public void onClick(DialogInterface dialog, int which) {
                                 switch (which) {
                                     case R.id.open_link:
-                                        LinkUtil.openExternally(submission.getUrl(), main, true);
+                                        LinkUtil.openExternally(submission.getUrl(), main);
                                         break;
                                     case R.id.share_link:
                                         Reddit.defaultShareText("", submission.getUrl(), main);
@@ -206,7 +206,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                     myIntent.putExtra(MediaView.EXTRA_URL, submission.getUrl());
                                     main.startActivity(myIntent);
                                 } else {
-                                    Reddit.defaultShare(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl(), main);
                                 }
                                 break;
                             case IMGUR:
@@ -221,7 +221,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    Reddit.defaultShare(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl(), main);
                                 }
                                 break;
                             case REDDIT:
@@ -244,7 +244,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    Reddit.defaultShare(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl(), main);
 
                                 }
                                 break;
@@ -262,7 +262,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    Reddit.defaultShare(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl(), main);
 
                                 }
                                 break;
@@ -288,15 +288,15 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(sharingIntent);
 
                                     } catch (Exception e) {
-                                        Reddit.defaultShare(submission.getUrl(), main);
+                                        LinkUtil.openExternally(submission.getUrl(), main);
                                     }
                                 } else {
-                                    Reddit.defaultShare(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl(), main);
                                 }
                                 break;
                         }
                     } else {
-                        Reddit.defaultShare(submission.getUrl(), main);
+                        LinkUtil.openExternally(submission.getUrl(), main);
                     }
                 }
             });

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.graphics.Typeface;
-import android.net.Uri;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -25,17 +24,16 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import me.ccrama.redditslide.Activities.Album;
 import me.ccrama.redditslide.Activities.MediaView;
 import me.ccrama.redditslide.Activities.Tumblr;
 import me.ccrama.redditslide.ContentType;
-import me.ccrama.redditslide.ImgurAlbum.Image;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Tumblr.Photo;
 import me.ccrama.redditslide.Visuals.FontPreferences;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -175,7 +173,7 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         myIntent.putExtra(MediaView.EXTRA_URL, user.getOriginalSize().getUrl());
                         main.startActivity(myIntent);
                     } else {
-                        Reddit.defaultShare(user.getOriginalSize().getUrl(), main);
+                        LinkUtil.openExternally(user.getOriginalSize().getUrl(), main);
                     }
                 }
             };

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -784,7 +784,7 @@ public class CommentPage extends Fragment {
                                             getActivity().startActivity(myIntent);
 
                                         } else {
-                                            Reddit.defaultShare(adapter.submission.getUrl(),
+                                            LinkUtil.openExternally(adapter.submission.getUrl(),
                                                     getActivity());
                                         }
                                         break;
@@ -827,7 +827,7 @@ public class CommentPage extends Fragment {
                                                 getActivity().startActivity(i);
                                             }
                                         } else {
-                                            Reddit.defaultShare(adapter.submission.getUrl(),
+                                            LinkUtil.openExternally(adapter.submission.getUrl(),
                                                     getActivity());
                                         }
                                         break;
@@ -894,7 +894,7 @@ public class CommentPage extends Fragment {
                                                         R.anim.slideright, R.anim.fade_out);
                                             }
                                         } else {
-                                            Reddit.defaultShare(adapter.submission.getUrl(),
+                                            LinkUtil.openExternally(adapter.submission.getUrl(),
                                                     getActivity());
 
                                         }
@@ -920,7 +920,7 @@ public class CommentPage extends Fragment {
                                                         R.anim.slideright, R.anim.fade_out);
                                             }
                                         } else {
-                                            Reddit.defaultShare(adapter.submission.getUrl(),
+                                            LinkUtil.openExternally(adapter.submission.getUrl(),
                                                     getActivity());
 
                                         }
@@ -946,17 +946,17 @@ public class CommentPage extends Fragment {
                                                 getActivity().startActivity(sharingIntent);
 
                                             } catch (Exception e) {
-                                                Reddit.defaultShare(adapter.submission.getUrl(),
+                                                LinkUtil.openExternally(adapter.submission.getUrl(),
                                                         getActivity());
                                             }
                                         } else {
-                                            Reddit.defaultShare(adapter.submission.getUrl(),
+                                            LinkUtil.openExternally(adapter.submission.getUrl(),
                                                     getActivity());
                                         }
 
                                 }
                             } else {
-                                Reddit.defaultShare(adapter.submission.getUrl(), getActivity());
+                                LinkUtil.openExternally(adapter.submission.getUrl(), getActivity());
                             }
                         }
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
@@ -335,13 +335,13 @@ public class MediaFragment extends Fragment {
                                 contextActivity.startActivity(myIntent);
 
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
 
                         case EMBEDDED:
 
                             if (SettingValues.video) {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                 String data = submission.getDataNode()
                                         .get("media_embed")
                                         .get("content")
@@ -352,7 +352,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
                             break;
                         case REDDIT:
@@ -385,7 +385,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
                             break;
                         case TUMBLR:
@@ -403,7 +403,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
                             break;
                         case DEVIANTART:
@@ -428,10 +428,10 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(sharingIntent);
 
                                 } catch (Exception e) {
-                                    Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                    LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                 }
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
                     }
                 }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
@@ -51,6 +51,7 @@ import me.ccrama.redditslide.Views.MediaVideoView;
 import me.ccrama.redditslide.Views.SubsamplingScaleImageView;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.HttpUtil;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 import okhttp3.OkHttpClient;
@@ -318,7 +319,7 @@ public class MediaFragmentComment extends Fragment {
 
                                 contextActivity.startActivity(myIntent);
                             } else {
-                                Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
                             }
 
                             break;

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
-import java.net.MalformedURLException;
 import java.util.Arrays;
 
 import me.ccrama.redditslide.Activities.CommentsScreenSingle;
@@ -38,7 +37,7 @@ public class OpenRedditLink {
         LogUtil.v("Link is " + url);
         url = formatRedditUrl(url);
         if (url.isEmpty()) {
-            LinkUtil.openExternally(oldUrl, context, false);
+            LinkUtil.openExternally(oldUrl, context);
             return false;
         } else if (url.startsWith("np")) {
             np = true;

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -14,7 +14,6 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Typeface;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
@@ -70,7 +69,6 @@ import me.ccrama.redditslide.util.AdBlocker;
 import me.ccrama.redditslide.util.GifCache;
 import me.ccrama.redditslide.util.IabHelper;
 import me.ccrama.redditslide.util.IabResult;
-import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 import me.ccrama.redditslide.util.UpgradeUtil;
@@ -183,15 +181,6 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, title);
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, url);
         c.startActivity(Intent.createChooser(sharingIntent, c.getString(R.string.title_share)));
-    }
-
-    public static void defaultShare(String url, Context c) {
-        url = StringEscapeUtils.unescapeHtml4(Html.fromHtml(url).toString());
-        Uri webpage = LinkUtil.formatURL(url);
-        Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
-        if (intent.resolveActivity(c.getPackageManager()) != null) {
-            c.startActivity(intent);
-        }
     }
 
     public static boolean isPackageInstalled(final Context ctx, String s) {

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -623,13 +623,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                                 Reddit.defaultShareText("", url, finalActivity);
                                 break;
                             case R.id.copy_link:
-                                ClipboardManager clipboard =
-                                        (ClipboardManager) finalActivity.getSystemService(
-                                                Context.CLIPBOARD_SERVICE);
-                                ClipData clip = ClipData.newPlainText("Link", url);
-                                clipboard.setPrimaryClip(clip);
-                                Toast.makeText(finalActivity, R.string.submission_link_copied,
-                                        Toast.LENGTH_SHORT).show();
+                                LinkUtil.copyUrl(url, finalActivity);
                                 break;
                         }
                     }

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -414,7 +414,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                         intent2.putExtra(MediaView.SUBREDDIT, subreddit);
                         activity.startActivity(intent2);
                     } else {
-                        Reddit.defaultShare(url, activity);
+                        LinkUtil.openExternally(url, activity);
                     }
                     break;
                 case REDDIT:
@@ -444,7 +444,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(i);
                         }
                     } else {
-                        Reddit.defaultShare(url, activity);
+                        LinkUtil.openExternally(url, activity);
                     }
                     break;
                 case TUMBLR:
@@ -459,7 +459,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(i);
                         }
                     } else {
-                        Reddit.defaultShare(url, activity);
+                        LinkUtil.openExternally(url, activity);
                     }
                     break;
                 case IMAGE:
@@ -480,21 +480,21 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(sharingIntent);
 
                         } catch (Exception e) {
-                            Reddit.defaultShare(url, activity);
+                            LinkUtil.openExternally(url, activity);
                         }
                     } else {
-                        Reddit.defaultShare(url, activity);
+                        LinkUtil.openExternally(url, activity);
                     }
                 case SPOILER:
                     spoilerClicked = true;
                     setOrRemoveSpoilerSpans(xOffset, span);
                     break;
                 case EXTERNAL:
-                    Reddit.defaultShare(url, activity);
+                    LinkUtil.openExternally(url, activity);
                     break;
             }
         } else {
-            Reddit.defaultShare(url, context);
+            LinkUtil.openExternally(url, context);
         }
     }
 
@@ -578,7 +578,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                         peekView.addButton((R.id.external), new OnButtonUp() {
                             @Override
                             public void onButtonUp() {
-                                LinkUtil.openExternally(url, context, false);
+                                LinkUtil.openExternally(url, context);
                             }
                         });
                         peekView.setOnPop(new OnPop() {
@@ -617,7 +617,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                     public void onClick(DialogInterface dialog, int which) {
                         switch (which) {
                             case R.id.open_link:
-                                LinkUtil.openExternally(url, context, false);
+                                LinkUtil.openExternally(url, context);
                                 break;
                             case R.id.share_link:
                                 Reddit.defaultShareText("", url, finalActivity);
@@ -649,7 +649,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                 getContext().startActivity(myIntent);
             }
         } else {
-            Reddit.defaultShare(url, getContext());
+            LinkUtil.openExternally(url, getContext());
         }
     }
 
@@ -662,7 +662,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
             getContext().startActivity(myIntent);
 
         } else {
-            Reddit.defaultShare(url, getContext());
+            LinkUtil.openExternally(url, getContext());
         }
     }
 
@@ -673,7 +673,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
             myIntent.putExtra(MediaView.SUBREDDIT, subreddit);
             getContext().startActivity(myIntent);
         } else {
-            Reddit.defaultShare(submission, getContext());
+            LinkUtil.openExternally(submission, getContext());
         }
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
@@ -1,8 +1,6 @@
 package me.ccrama.redditslide.SubmissionViews;
 
 import android.app.Activity;
-import android.content.ClipData;
-import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.DialogInterface;
@@ -21,7 +19,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.cocosw.bottomsheet.BottomSheet;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,7 +31,6 @@ import net.dean.jraw.models.Submission;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.ForceTouch.PeekView;
 import me.ccrama.redditslide.ForceTouch.PeekViewActivity;
@@ -623,19 +619,13 @@ public class HeaderImageLinkView extends RelativeLayout {
                     public void onClick(DialogInterface dialog, int which) {
                         switch (which) {
                             case R.id.open_link:
-                                LinkUtil.openExternally(url, context, false);
+                                LinkUtil.openExternally(url, context);
                                 break;
                             case R.id.share_link:
                                 Reddit.defaultShareText("", url, finalActivity);
                                 break;
                             case R.id.copy_link:
-                                ClipboardManager clipboard =
-                                        (ClipboardManager) finalActivity.getSystemService(
-                                                Context.CLIPBOARD_SERVICE);
-                                ClipData clip = ClipData.newPlainText("Link", url);
-                                clipboard.setPrimaryClip(clip);
-                                Toast.makeText(finalActivity, R.string.submission_link_copied,
-                                        Toast.LENGTH_SHORT).show();
+                                LinkUtil.copyUrl(url, finalActivity);
                                 break;
                         }
                     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
@@ -2,38 +2,29 @@ package me.ccrama.redditslide.SubmissionViews;
 
 
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.res.ResourcesCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
 import android.text.style.AbsoluteSizeSpan;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.WindowManager;
-import android.widget.EditText;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -41,20 +32,11 @@ import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.devspark.robototextview.RobotoTypefaces;
 
 import net.dean.jraw.ApiException;
-import net.dean.jraw.fluent.FlairReference;
-import net.dean.jraw.fluent.FluentRedditClient;
-import net.dean.jraw.http.oauth.InvalidScopeException;
 import net.dean.jraw.managers.AccountManager;
-import net.dean.jraw.managers.ModerationManager;
 import net.dean.jraw.models.Contribution;
-import net.dean.jraw.models.DistinguishedStatus;
-import net.dean.jraw.models.FlairTemplate;
 import net.dean.jraw.models.Submission;
-import net.dean.jraw.models.Thing;
-import net.dean.jraw.models.VoteDirection;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
@@ -62,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.Album;
@@ -70,24 +51,20 @@ import me.ccrama.redditslide.Activities.AlbumPager;
 import me.ccrama.redditslide.Activities.FullscreenVideo;
 import me.ccrama.redditslide.Activities.MainActivity;
 import me.ccrama.redditslide.Activities.MediaView;
-import me.ccrama.redditslide.Activities.ModQueue;
 import me.ccrama.redditslide.Activities.MultiredditOverview;
 import me.ccrama.redditslide.Activities.PostReadLater;
 import me.ccrama.redditslide.Activities.Profile;
-import me.ccrama.redditslide.Activities.Reauthenticate;
 import me.ccrama.redditslide.Activities.Search;
 import me.ccrama.redditslide.Activities.SubredditView;
 import me.ccrama.redditslide.Activities.Tumblr;
 import me.ccrama.redditslide.Activities.TumblrPager;
 import me.ccrama.redditslide.Adapters.CommentAdapter;
 import me.ccrama.redditslide.Adapters.NewsViewHolder;
-import me.ccrama.redditslide.Adapters.SubmissionViewHolder;
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.CommentCacheAsync;
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.DataShare;
 import me.ccrama.redditslide.ForceTouch.PeekViewActivity;
-import me.ccrama.redditslide.Fragments.NewsView;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
 import me.ccrama.redditslide.HasSeen;
 import me.ccrama.redditslide.Hidden;
@@ -100,18 +77,12 @@ import me.ccrama.redditslide.ReadLater;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionCache;
-import me.ccrama.redditslide.UserSubscriptions;
-import me.ccrama.redditslide.Views.AnimateHelper;
 import me.ccrama.redditslide.Views.CreateCardView;
-import me.ccrama.redditslide.Views.DoEditorActions;
-import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.Vote;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
-import me.ccrama.redditslide.util.SubmissionParser;
 
 /**
  * Created by ccrama on 9/19/2015.
@@ -165,7 +136,7 @@ public class PopulateNewsViewHolder {
                                         myIntent.putExtra(MediaView.EXTRA_URL, submission.getUrl());
                                         contextActivity.startActivity(myIntent);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                                 case IMGUR:
@@ -185,7 +156,7 @@ public class PopulateNewsViewHolder {
                                             contextActivity.startActivity(i);
                                         }
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                                 case REDDIT:
@@ -223,7 +194,7 @@ public class PopulateNewsViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
 
                                     }
                                     break;
@@ -247,7 +218,7 @@ public class PopulateNewsViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
 
                                     }
                                     break;
@@ -277,16 +248,16 @@ public class PopulateNewsViewHolder {
                                             contextActivity.startActivity(sharingIntent);
 
                                         } catch (Exception e) {
-                                            Reddit.defaultShare(submission.getUrl(),
+                                            LinkUtil.openExternally(submission.getUrl(),
                                                     contextActivity);
                                         }
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                             }
                         } else {
-                            Reddit.defaultShare(submission.getUrl(), contextActivity);
+                            LinkUtil.openExternally(submission.getUrl(), contextActivity);
                         }
                     }
                 } else {
@@ -354,7 +325,7 @@ public class PopulateNewsViewHolder {
             contextActivity.startActivity(myIntent);
 
         } else {
-            Reddit.defaultShare(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl(), contextActivity);
         }
 
     }
@@ -438,7 +409,7 @@ public class PopulateNewsViewHolder {
             addAdaptorPosition(myIntent, submission, adapterPosition);
             contextActivity.startActivity(myIntent);
         } else {
-            Reddit.defaultShare(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl(), contextActivity);
         }
 
     }
@@ -824,7 +795,7 @@ public class PopulateNewsViewHolder {
                     }
                     break;
                     case 7:
-                        LinkUtil.openExternally(submission.getUrl(), mContext, true);
+                        LinkUtil.openExternally(submission.getUrl(), mContext);
                         if (submission.isNsfw() && !SettingValues.storeNSFWHistory) {
                             //Do nothing if the post is NSFW and storeNSFWHistory is not enabled
                         } else if (SettingValues.storeHistory) {

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
@@ -537,7 +537,7 @@ public class PopulateShadowboxInfo {
                             }
                             break;
                             case 7:
-                                LinkUtil.openExternally(submission.getUrl(), mContext, true);
+                                LinkUtil.openExternally(submission.getUrl(), mContext);
                                 break;
                             case 4:
                                 Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -26,7 +26,6 @@ import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
-import android.text.TextUtils;
 import android.text.style.AbsoluteSizeSpan;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
@@ -108,7 +107,6 @@ import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.Vote;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.LinkUtil;
-import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
@@ -168,7 +166,7 @@ public class PopulateSubmissionViewHolder {
                                                 holder.getAdapterPosition());
                                         contextActivity.startActivity(myIntent);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                                 case IMGUR:
@@ -188,7 +186,7 @@ public class PopulateSubmissionViewHolder {
                                             contextActivity.startActivity(i);
                                         }
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                                 case REDDIT:
@@ -226,7 +224,7 @@ public class PopulateSubmissionViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
 
                                     }
                                     break;
@@ -250,7 +248,7 @@ public class PopulateSubmissionViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
 
                                     }
                                     break;
@@ -280,16 +278,16 @@ public class PopulateSubmissionViewHolder {
                                             contextActivity.startActivity(sharingIntent);
 
                                         } catch (Exception e) {
-                                            Reddit.defaultShare(submission.getUrl(),
+                                            LinkUtil.openExternally(submission.getUrl(),
                                                     contextActivity);
                                         }
                                     } else {
-                                        Reddit.defaultShare(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
                                     }
                                     break;
                             }
                         } else {
-                            Reddit.defaultShare(submission.getUrl(), contextActivity);
+                            LinkUtil.openExternally(submission.getUrl(), contextActivity);
                         }
                     }
                 } else {
@@ -357,7 +355,7 @@ public class PopulateSubmissionViewHolder {
             contextActivity.startActivity(myIntent);
 
         } else {
-            Reddit.defaultShare(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl(), contextActivity);
         }
 
     }
@@ -447,7 +445,7 @@ public class PopulateSubmissionViewHolder {
             addAdaptorPosition(myIntent, submission, adapterPosition);
             contextActivity.startActivity(myIntent);
         } else {
-            Reddit.defaultShare(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl(), contextActivity);
         }
 
     }
@@ -823,7 +821,7 @@ public class PopulateSubmissionViewHolder {
                     }
                     break;
                     case 7:
-                        LinkUtil.openExternally(submission.getUrl(), mContext, true);
+                        LinkUtil.openExternally(submission.getUrl(), mContext);
                         if (submission.isNsfw() && !SettingValues.storeNSFWHistory) {
                             //Do nothing if the post is NSFW and storeNSFWHistory is not enabled
                         } else if (SettingValues.storeHistory) {

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -3,6 +3,8 @@ package me.ccrama.redditslide.util;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -21,17 +23,17 @@ import android.support.customtabs.CustomTabsSession;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.util.Log;
+import android.widget.Toast;
 
 import net.dean.jraw.models.Submission;
 
-import java.util.Set;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import me.ccrama.redditslide.Activities.MakeExternal;
 import me.ccrama.redditslide.Activities.ReaderMode;
 import me.ccrama.redditslide.Activities.Website;
 import me.ccrama.redditslide.BuildConfig;
 import me.ccrama.redditslide.R;
-import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionViews.PopulateSubmissionViewHolder;
 
@@ -68,7 +70,7 @@ public class LinkUtil {
     public static void openUrl(@NonNull String url, int color, @NonNull Activity contextActivity) {
         if (!SettingValues.web) {
             // External browser
-            Reddit.defaultShare(url, contextActivity);
+            LinkUtil.openExternally(url, contextActivity);
             return;
         }
 
@@ -94,7 +96,7 @@ public class LinkUtil {
                 customTabsIntent.launchUrl(contextActivity, formatURL(url));
             } catch (ActivityNotFoundException anfe) {
                 Log.w(LogUtil.getTag(), "Unknown url: " + anfe);
-                Reddit.defaultShare(url, contextActivity);
+                LinkUtil.openExternally(url, contextActivity);
             }
         } else {
             if(SettingValues.reader && (!SettingValues.readerNight || SettingValues.isNight())){
@@ -116,7 +118,7 @@ public class LinkUtil {
     public static void openUrl(@NonNull String url, int color, @NonNull Activity contextActivity, int adapterPosition, Submission submission) {
         if (!SettingValues.web) {
             // External browser
-            Reddit.defaultShare(url, contextActivity);
+            LinkUtil.openExternally(url, contextActivity);
             return;
         }
 
@@ -142,7 +144,7 @@ public class LinkUtil {
                 customTabsIntent.launchUrl(contextActivity, formatURL(url));
             } catch (ActivityNotFoundException anfe) {
                 Log.w(LogUtil.getTag(), "Unknown url: " + anfe);
-                Reddit.defaultShare(url, contextActivity);
+                LinkUtil.openExternally(url, contextActivity);
             }
         } else {
             if(SettingValues.reader && (!SettingValues.readerNight || SettingValues.isNight())){
@@ -193,25 +195,15 @@ public class LinkUtil {
     }
 
     /**
-     * Opens the {@code url} externally or shows an application chooser if it is set to open in this
-     * application
-     * @param url URL to open
-     * @param context Current context
-     * @param encoded If the URL is HTML encoded (e.g. includes {@code &amp;amp;})
-     */
-    public static void openExternally(String url, Context context, Boolean encoded) {
-        if (encoded) url = Html.fromHtml(url).toString();
-        Uri uri = formatURL(url);
-        openExternally(uri, context);
-    }
-
-    /**
      * Opens the {@code uri} externally or shows an application chooser if it is set to open in this
      * application
      * @param uri URI to open
      * @param context Current context
      */
-    public static void openExternally(Uri uri, Context context) {
+    public static void openExternally(String url, Context context) {
+        url = StringEscapeUtils.unescapeHtml4(Html.fromHtml(url).toString());
+        Uri uri = formatURL(url);
+
         final String id = BuildConfig.APPLICATION_ID;
         final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
         final PackageManager packageManager = context.getPackageManager();

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -239,4 +239,13 @@ public class LinkUtil {
         }
         return mCustomTabsSession;
     }
+
+    public static void copyUrl(String url, Context context) {
+        url = StringEscapeUtils.unescapeHtml4(Html.fromHtml(url).toString());
+        ClipboardManager clipboard =
+                (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = ClipData.newPlainText("Link", url);
+        clipboard.setPrimaryClip(clip);
+        Toast.makeText(context, R.string.submission_link_copied, Toast.LENGTH_SHORT).show();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/ccrama/Slide/issues/2615

I made this change fairly quickly, but I think I tested any cases I needed to (I made sure all link handling modes still function correctly). I do not believe there is an issue running `unescapeHtml `on a url that does not need it or already had it ran. The only issue is if that method has considerable overhead, which I also do not think it does for the benefit of always having URLs handled well.

- The change got rid of the, what was essentially, duplicate `Reddit.defaultShare `method in exchange for using the `LinkUtil.openExternally` method. If there is a reason to not do this, let me know, but it seemed like the functionality was the same and internal links are still handled fine.
- Additionally, copying text was moved out to a `LinkUtil.copyUrl` helper method to keep the logic consistent and `unescape `the html in the urls for copying.
- Custom tabs were also not always correctly unescaping the HTML. I moved the logic for opening a custom tab out to a `LinkUtil.openCustomTab` method and forced it to always unescape the HTML if a custom tab can be opened (prevents doing it twice if no custom tab can be opened)

Finally, every commit is an opportunity to run "optimize imports", so I did.
