### PR TITLE
Replaced usages of legacy "file://" logic for intents with FileProvider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,10 +20,9 @@
             android:resizeableActivity="true"
             android:roundIcon="@mipmap/icon_round"
             android:theme="@style/yellow_dark">
-
         <provider
                 android:name="android.support.v4.content.FileProvider"
-                android:authorities="${applicationId}.MediaView"
+                android:authorities="${applicationId}.provider"
                 android:exported="false"
                 android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -20,9 +20,9 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.FileProvider;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
-import android.support.v4.app.NotificationCompat;
 import android.text.Html;
 import android.util.Log;
 import android.view.View;
@@ -73,6 +73,7 @@ import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Views.ImageSource;
 import me.ccrama.redditslide.Views.MediaVideoView;
 import me.ccrama.redditslide.Views.SubsamplingScaleImageView;
+import me.ccrama.redditslide.util.FileUtil;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.HttpUtil;
 import me.ccrama.redditslide.util.LinkUtil;
@@ -383,14 +384,13 @@ public class MediaView extends FullScreenActivity
                                 new String[]{f.getAbsolutePath()}, null,
                                 new MediaScannerConnection.OnScanCompletedListener() {
                                     public void onScanCompleted(String path, Uri uri) {
-                                        Intent mediaScanIntent =
-                                                new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                                        Uri contentUri = Uri.parse("file://" + f.getAbsolutePath());
-                                        mediaScanIntent.setData(contentUri);
+                                        Intent mediaScanIntent = FileUtil.getFileIntent(f,
+                                                new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE),
+                                                MediaView.this);
                                         MediaView.this.sendBroadcast(mediaScanIntent);
 
                                         final Intent shareIntent = new Intent(Intent.ACTION_VIEW);
-                                        shareIntent.setDataAndType(contentUri, "image/gif");
+                                        shareIntent.setType("image/gif");
                                         PendingIntent contentIntent =
                                                 PendingIntent.getActivity(MediaView.this, 0,
                                                         shareIntent,
@@ -472,14 +472,13 @@ public class MediaView extends FullScreenActivity
                                 new String[]{f.getAbsolutePath()}, null,
                                 new MediaScannerConnection.OnScanCompletedListener() {
                                     public void onScanCompleted(String path, Uri uri) {
-                                        Intent mediaScanIntent =
-                                                new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                                        Uri contentUri = Uri.parse("file://" + f.getAbsolutePath());
-                                        mediaScanIntent.setData(contentUri);
+                                        Intent mediaScanIntent = FileUtil.getFileIntent(f,
+                                                new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE),
+                                                MediaView.this);
                                         MediaView.this.sendBroadcast(mediaScanIntent);
 
                                         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                                        shareIntent.setDataAndType(contentUri, "image/gif");
+                                        shareIntent.setType("image/gif");
                                         startActivity(
                                                 Intent.createChooser(shareIntent, "Share GIF"));
                                         NotificationManager mNotificationManager =

--- a/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
@@ -1,0 +1,37 @@
+package me.ccrama.redditslide.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.v4.content.FileProvider;
+
+import java.io.File;
+
+public class FileUtil {
+    private FileUtil() {
+    }
+
+    /**
+     * Modifies an {@code Intent} to open a file with the FileProvider
+     *
+     * @param file    the {@code File} to open
+     * @param intent  the {@Intent} to modify
+     * @param context Current context
+     * @return a base {@code Intent} with read and write permissions granted to the receiving
+     * application
+     */
+    public static Intent getFileIntent(File file, Intent intent, Context context) {
+        String packageName = context.getApplicationContext().getPackageName() + ".MediaView";
+
+        Uri selectedUri = FileProvider.getUriForFile(context, packageName, file);
+
+        context.grantUriPermission(packageName, selectedUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+
+        intent.setData(selectedUri);
+        intent.setFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+
+        return intent;
+    }
+}

--- a/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
@@ -21,7 +21,7 @@ public class FileUtil {
      * application
      */
     public static Intent getFileIntent(File file, Intent intent, Context context) {
-        String packageName = context.getApplicationContext().getPackageName() + ".MediaView";
+        String packageName = context.getApplicationContext().getPackageName() + ".provider";
 
         Uri selectedUri = FileProvider.getUriForFile(context, packageName, file);
 

--- a/app/src/noGPlay/java/me/ccrama/redditslide/Activities/SettingsBackup.java
+++ b/app/src/noGPlay/java/me/ccrama/redditslide/Activities/SettingsBackup.java
@@ -31,6 +31,7 @@ import java.util.Calendar;
 
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.SettingValues;
+import me.ccrama.redditslide.util.FileUtil;
 import me.ccrama.redditslide.util.LogUtil;
 
 
@@ -328,10 +329,9 @@ public class SettingsBackup extends BaseActivityAnim {
                                 new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
-                                        Uri selectedUri =
-                                                Uri.parse("file://" + file.getAbsolutePath());
-                                        Intent intent = new Intent(Intent.ACTION_VIEW);
-                                        intent.setData(selectedUri);
+                                        Intent intent = FileUtil.getFileIntent(file,
+                                                new Intent(Intent.ACTION_VIEW),
+                                                SettingsBackup.this);
                                         if (intent.resolveActivityInfo(getPackageManager(), 0)
                                                 != null) {
                                             startActivity(

--- a/app/src/withGPlay/java/me.ccrama.redditslide/Activities/SettingsBackup.java
+++ b/app/src/withGPlay/java/me.ccrama.redditslide/Activities/SettingsBackup.java
@@ -3,6 +3,7 @@ package me.ccrama.redditslide.Activities;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -11,7 +12,6 @@ import android.support.design.widget.Snackbar;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
-import android.graphics.Color;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -523,9 +523,9 @@ public class SettingsBackup extends BaseActivityAnim implements GoogleApiClient.
                         .setPositiveButton(R.string.btn_view, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                Uri selectedUri = Uri.parse("file://" + file.getAbsolutePath());
-                                Intent intent = new Intent(Intent.ACTION_VIEW);
-                                intent.setData(selectedUri);
+                                Intent intent =
+                                        FileUtil.getFileIntent(file, new Intent(Intent.ACTION_VIEW),
+                                                SettingsBackup.this);
                                 if (intent.resolveActivityInfo(getPackageManager(), 0) != null) {
                                     startActivity(Intent.createChooser(intent, "View backup"));
                                 } else {


### PR DESCRIPTION
I see no existing issue for this defect.

On Android N+, attempting to view the backup file after creating it causes a crash. This is due to a change in the file handling logic for "file://" that makes it no longer function for these purposes.

- This will resolve any crashing that occurs when attempting to read-write files from locations outside of Slide, including the above
- Additionally this resolves a defect where the camera would crash the app when opened for submission due to a defect in TedBottomPicker
     - https://github.com/ParkSangGwon/TedBottomPicker/issues/47