### PR TITLE
Removed OR equals operator from hour to nightEnd check in isNight method

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -458,7 +458,7 @@ public class SettingValues {
 
     public static boolean isNight() {
         int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-        return (hour >= nightStart + 12 || hour <= nightEnd) && tabletUI && nightMode;
+        return (hour >= nightStart + 12 || hour < nightEnd) && tabletUI && nightMode;
     }
 
     public static Sorting getBaseSubmissionSort(String sub) {


### PR DESCRIPTION
Fixes https://github.com/ccrama/Slide/issues/2436
Night mode ends an hour late.

Get ready for a wild code review.
As I mentioned in my comment on the issue, I am not 100% convinced my boolean logic is right, but I am fairly sure it is.
In this "`isNight`" check, we should not be deciding it's night time if the current `hour` is equal to the `nightEnd` time, because that would indicate night mode remains on for the duration of the `nightEnd` hour.

I just removed the = operator off of the nightEnd check and we should be all fixed.