### PR TITLE
Changed comment textview to match parent width

### DIFF
--- a/app/src/main/res/layout/comment.xml
+++ b/app/src/main/res/layout/comment.xml
@@ -66,7 +66,7 @@
 
     <me.ccrama.redditslide.SpoilerRobotoTextView
         android:id="@+id/firstTextView"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/content"
         android:paddingLeft="10dp"


### PR DESCRIPTION
Fixes https://github.com/ccrama/Slide/issues/2455

Another wild, single line change.
Comment text was wrapping content, which works fine for ltr content. When rtl content was displayed, it wrapped as if it was ltr, so it would display in the center of the comment text view much of the time.

This change expands the comment text view to be full width so rtl content displays correctly, starting at the very right side of the text view.

![How RTL displays before change](https://user-images.githubusercontent.com/5879831/35489954-e000d204-0469-11e8-8bda-bcb726e2c59b.png)


![How RTL displays after change](https://user-images.githubusercontent.com/5879831/35489878-3740cebc-0469-11e8-8374-ae0f2726f707.png)
