### PR TITLE
Removed code path that allowed "Removed by true" to display to mods

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -44,7 +44,6 @@ import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.rey.material.util.ColorUtil;
 
 import net.dean.jraw.ApiException;
 import net.dean.jraw.http.oauth.InvalidScopeException;
@@ -1056,6 +1055,20 @@ public class CommentAdapterHelper {
         }.execute();
     }
 
+    public static SpannableStringBuilder createApprovedLine(String approvedBy, Context c) {
+        SpannableStringBuilder removedString = new SpannableStringBuilder("\n");
+        SpannableStringBuilder mod = new SpannableStringBuilder("Approved by ");
+        mod.append(approvedBy);
+        mod.setSpan(new StyleSpan(Typeface.BOLD), 0, mod.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        mod.setSpan(new RelativeSizeSpan(0.8f), 0, mod.length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_green_300)), 0,
+                mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        removedString.append(mod);
+        return removedString;
+    }
+
     public static SpannableStringBuilder createRemovedLine(String removedBy, Context c) {
         SpannableStringBuilder removedString = new SpannableStringBuilder("\n");
         SpannableStringBuilder mod = new SpannableStringBuilder("Removed by ");
@@ -1064,23 +1077,11 @@ public class CommentAdapterHelper {
         } else {
             mod.append(removedBy);
         }
-        mod.setSpan(new StyleSpan(Typeface.BOLD), 0, mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new RelativeSizeSpan(0.8f), 0, mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_red_300)), 0,
-                mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        removedString.append(mod);
-        return removedString;
-    }
-
-    public static SpannableStringBuilder createApprovedLine(String removedBy, Context c) {
-        SpannableStringBuilder removedString = new SpannableStringBuilder("\n");
-        SpannableStringBuilder mod = new SpannableStringBuilder("Approved by ");
-        mod.append(removedBy);
         mod.setSpan(new StyleSpan(Typeface.BOLD), 0, mod.length(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         mod.setSpan(new RelativeSizeSpan(0.8f), 0, mod.length(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_green_300)), 0,
+        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_red_300)), 0,
                 mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         removedString.append(mod);
         return removedString;

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
 import android.text.Html;
-import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.WeakHashMap;
 
+import me.ccrama.redditslide.Adapters.CommentAdapterHelper;
 import me.ccrama.redditslide.Views.RoundedBackgroundSpan;
 import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
@@ -312,12 +312,12 @@ public class SubmissionCache {
         }
         if (removed.contains(submission.getFullName()) || (submission.getBannedBy() != null
                 && !approved.contains(submission.getFullName()))) {
-            titleString.append(createRemovedLine(
+            titleString.append(CommentAdapterHelper.createRemovedLine(
                     (submission.getBannedBy() == null) ? Authentication.name : submission.getBannedBy(),
                     mContext));
         } else if (approved.contains(submission.getFullName()) || (submission.getApprovedBy()
                 != null && !removed.contains(submission.getFullName()))) {
-            titleString.append(createApprovedLine(
+            titleString.append(CommentAdapterHelper.createApprovedLine(
                     (submission.getApprovedBy() == null) ? Authentication.name
                             : submission.getApprovedBy(), mContext));
         }
@@ -402,34 +402,6 @@ public class SubmissionCache {
         }
         return titleString;
 
-    }
-
-    public static SpannableStringBuilder createRemovedLine(String removedBy, Context c) {
-        SpannableStringBuilder removedString = new SpannableStringBuilder("\n");
-        SpannableStringBuilder mod = new SpannableStringBuilder("Removed by ");
-        mod.append(removedBy);
-        mod.setSpan(new StyleSpan(Typeface.BOLD), 0, mod.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new RelativeSizeSpan(0.8f), 0, mod.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_red_300)), 0,
-                mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        removedString.append(mod);
-        return removedString;
-    }
-
-    public static SpannableStringBuilder createApprovedLine(String removedBy, Context c) {
-        SpannableStringBuilder removedString = new SpannableStringBuilder("\n");
-        SpannableStringBuilder mod = new SpannableStringBuilder("Approved by ");
-        mod.append(removedBy);
-        mod.setSpan(new StyleSpan(Typeface.BOLD), 0, mod.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new RelativeSizeSpan(0.8f), 0, mod.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        mod.setSpan(new ForegroundColorSpan(c.getResources().getColor(R.color.md_green_300)), 0,
-                mod.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        removedString.append(mod);
-        return removedString;
     }
 
     public static ArrayList<String> removed  = new ArrayList<>();


### PR DESCRIPTION
No github issue.
Fixes [issue from reddit](https://www.reddit.com/r/slideforreddit/comments/7sgm7d/when_moderating_what_does_removed_by_true_mean/)

Two code paths exist that create the removed line (I literally have no clue what that is). Both do the exact same thing but one does not verify the "removedBy" text is not "true". Per the reported issue on the subreddit, "removed by true" is displaying to the mod.
Presumably, according to the comment, we should just fallback to the "Removed by Reddit" text if this occurs.

I removed the duplicate code path, leaving the one in the helper class (I did the same for createApprovedLine... whatever that is).

I clearly did not test this but it compiles so it's probably squeaky clean.