### PR TITLE
Added handling for reddit home page links opening Slide (reddit.com)

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
-import java.net.MalformedURLException;
 import java.util.Arrays;
 
 import me.ccrama.redditslide.Activities.CommentsScreenSingle;
 import me.ccrama.redditslide.Activities.LiveThread;
+import me.ccrama.redditslide.Activities.MainActivity;
 import me.ccrama.redditslide.Activities.Profile;
 import me.ccrama.redditslide.Activities.Search;
 import me.ccrama.redditslide.Activities.SendMessage;
@@ -202,6 +202,11 @@ public class OpenRedditLink {
                 context.startActivity(myIntent);
                 break;
             }
+            case HOME: {
+                Intent intent = new Intent(context, MainActivity.class);
+                context.startActivity(intent);
+                break;
+            }
             case OTHER: {
                 if (openIfOther) {
                     if (context instanceof Activity) {
@@ -318,6 +323,9 @@ public class OpenRedditLink {
         } else if (url.matches("(?i)reddit\\.com/u(?:ser)?/[a-z0-9-_]+.*")) {
             // User. Format: reddit.com/u [or user]/$username/$page [optional]
             return RedditLinkType.USER;
+        } else if (url.matches("^reddit\\.com$")) {
+            // Reddit home link
+            return RedditLinkType.HOME;
         } else {
             //Open all links that we can't open in another app
             return RedditLinkType.OTHER;
@@ -336,6 +344,7 @@ public class OpenRedditLink {
         MESSAGE,
         MULTIREDDIT,
         LIVE,
+        HOME,
         OTHER
     }
 

--- a/app/src/test/java/me/ccrama/redditslide/test/OpenRedditLinkTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/OpenRedditLinkTest.java
@@ -70,6 +70,11 @@ public class OpenRedditLinkTest {
     }
 
     @Test
+    public void detectHome() {
+        assertThat(getType(formatURL("https://www.reddit.com/")), is(RedditLinkType.HOME));
+    }
+
+    @Test
     public void detectsOther() {
         assertThat(getType(formatURL("https://www.reddit.com/r/pics/about/moderators")), is(RedditLinkType.OTHER));
         assertThat(getType(formatURL("https://www.reddit.com/live/x9gf3donjlkq/discussions")), is(RedditLinkType.OTHER));


### PR DESCRIPTION
Fixes https://github.com/ccrama/Slide/issues/2630

Reddit home page links (reddit.com) were not handled and were falling back to OTHER link types.

This change makes it so a reddit.com link opened from another app will just open the Slide MainActivity directly as if the user opened it from their launcher.