### PR TITLE
Handle app launched from third party app as separate task

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity
                 android:name=".Activities.Slide"
                 android:alwaysRetainTaskState="true"
+                android:taskAffinity=".SlideTask"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
                 android:icon="@mipmap/ic_launcher"
                 android:label="@string/app_name"
@@ -50,7 +51,6 @@
                 android:alwaysRetainTaskState="true"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
                 android:label="@string/app_name"
-                android:taskAffinity="me.ccrama.SubsOverview"
                 android:windowSoftInputMode="adjustResize">
         </activity>
         <!--Disable this for now
@@ -70,6 +70,7 @@
  -->
         <activity-alias
                 android:name=".Activities.SlideDefault"
+                android:taskAffinity=".Slide"
                 android:enabled="false"
                 android:icon="@mipmap/ic_launcher"
                 android:label="@string/app_name"
@@ -443,6 +444,7 @@
                 android:windowSoftInputMode="adjustResize"/>
         <activity
                 android:name=".Activities.OpenContent"
+                android:taskAffinity=".IntentTask"
                 android:label="View content">
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -214,8 +214,7 @@ public class OpenRedditLink {
         }
         if (i != null) {
             if (context instanceof OpenContent) {
-                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
-                        | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             }
             context.startActivity(i);
         }

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import me.ccrama.redditslide.Activities.CommentsScreenSingle;
 import me.ccrama.redditslide.Activities.LiveThread;
 import me.ccrama.redditslide.Activities.MainActivity;
+import me.ccrama.redditslide.Activities.OpenContent;
 import me.ccrama.redditslide.Activities.Profile;
 import me.ccrama.redditslide.Activities.Search;
 import me.ccrama.redditslide.Activities.SendMessage;
@@ -54,24 +55,23 @@ public class OpenRedditLink {
             parts = Arrays.copyOf(parts, parts.length - 1);
         }
 
+        Intent i = null;
         switch (type) {
             case SHORTENED: {
-                Intent i = new Intent(context, CommentsScreenSingle.class);
+                i = new Intent(context, CommentsScreenSingle.class);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBREDDIT, Reddit.EMPTY_STRING);
                 i.putExtra(CommentsScreenSingle.EXTRA_CONTEXT, Reddit.EMPTY_STRING);
                 i.putExtra(CommentsScreenSingle.EXTRA_NP, np);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBMISSION, parts[1]);
-                context.startActivity(i);
                 break;
             }
             case LIVE: {
-                Intent i = new Intent(context, LiveThread.class);
+                i = new Intent(context, LiveThread.class);
                 i.putExtra(LiveThread.EXTRA_LIVEURL, parts[2]);
-                context.startActivity(i);
                 break;
             }
             case WIKI: {
-                Intent i = new Intent(context, Wiki.class);
+                i = new Intent(context, Wiki.class);
                 i.putExtra(Wiki.EXTRA_SUBREDDIT, parts[2]);
                 String page;
                 if (parts.length >= 5) {
@@ -81,11 +81,10 @@ public class OpenRedditLink {
                     }
                     i.putExtra(Wiki.EXTRA_PAGE, page);
                 }
-                context.startActivity(i);
                 break;
             }
             case SEARCH: {
-                Intent i = new Intent(context, Search.class);
+                i = new Intent(context, Search.class);
                 String end = parts[parts.length - 1];
                 end = end.replace(":", "%3A");
 
@@ -117,11 +116,10 @@ public class OpenRedditLink {
                 if (urlParams.getQueryParameterNames().contains("site")) {
                     i.putExtra(Search.EXTRA_SITE, urlParams.getQueryParameter("site"));
                 }
-                context.startActivity(i);
                 break;
             }
             case COMMENT_PERMALINK: {
-                Intent i = new Intent(context, CommentsScreenSingle.class);
+                i = new Intent(context, CommentsScreenSingle.class);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBREDDIT, parts[2]);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBMISSION, parts[4]);
                 i.putExtra(CommentsScreenSingle.EXTRA_NP, np);
@@ -148,35 +146,31 @@ public class OpenRedditLink {
                         }
                     }
                 }
-                context.startActivity(i);
                 break;
             }
             case SUBMISSION: {
-                Intent i = new Intent(context, CommentsScreenSingle.class);
+                i = new Intent(context, CommentsScreenSingle.class);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBREDDIT, parts[2]);
                 i.putExtra(CommentsScreenSingle.EXTRA_CONTEXT, Reddit.EMPTY_STRING);
                 i.putExtra(CommentsScreenSingle.EXTRA_NP, np);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBMISSION, parts[4]);
-                context.startActivity(i);
                 break;
             }
             case SUBMISSION_WITHOUT_SUB: {
-                Intent i = new Intent(context, CommentsScreenSingle.class);
+                i = new Intent(context, CommentsScreenSingle.class);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBREDDIT, Reddit.EMPTY_STRING);
                 i.putExtra(CommentsScreenSingle.EXTRA_CONTEXT, Reddit.EMPTY_STRING);
                 i.putExtra(CommentsScreenSingle.EXTRA_NP, np);
                 i.putExtra(CommentsScreenSingle.EXTRA_SUBMISSION, parts[2]);
-                context.startActivity(i);
                 break;
             }
             case SUBREDDIT: {
-                Intent intent = new Intent(context, SubredditView.class);
-                intent.putExtra(SubredditView.EXTRA_SUBREDDIT, parts[2]);
-                context.startActivity(intent);
+                i = new Intent(context, SubredditView.class);
+                i.putExtra(SubredditView.EXTRA_SUBREDDIT, parts[2]);
                 break;
             }
             case MESSAGE: {
-                Intent i = new Intent(context, SendMessage.class);
+                i = new Intent(context, SendMessage.class);
                 try {
                     Uri urlParams = Uri.parse(oldUrl);
                     if (urlParams.getQueryParameterNames().contains("to")) {
@@ -188,7 +182,6 @@ public class OpenRedditLink {
                     if (urlParams.getQueryParameterNames().contains("message")) {
                         i.putExtra(SendMessage.EXTRA_MESSAGE, urlParams.getQueryParameter("message"));
                     }
-                    context.startActivity(i);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -197,14 +190,12 @@ public class OpenRedditLink {
             case USER: {
                 String name = parts[2];
                 if (name.equals("me") && Authentication.isLoggedIn) name = Authentication.name;
-                Intent myIntent = new Intent(context, Profile.class);
-                myIntent.putExtra(Profile.EXTRA_PROFILE, name);
-                context.startActivity(myIntent);
+                i = new Intent(context, Profile.class);
+                i.putExtra(Profile.EXTRA_PROFILE, name);
                 break;
             }
             case HOME: {
-                Intent intent = new Intent(context, MainActivity.class);
-                context.startActivity(intent);
+                i = new Intent(context, MainActivity.class);
                 break;
             }
             case OTHER: {
@@ -212,15 +203,21 @@ public class OpenRedditLink {
                     if (context instanceof Activity) {
                         LinkUtil.openUrl(oldUrl, Palette.getStatusBarColor(), (Activity) context);
                     } else {
-                        Intent i = new Intent(context, Website.class);
+                        i = new Intent(context, Website.class);
                         i.putExtra(Website.EXTRA_URL, oldUrl);
-                        context.startActivity(i);
                     }
                 } else {
                     return false;
                 }
                 break;
             }
+        }
+        if (i != null) {
+            if (context instanceof OpenContent) {
+                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                        | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            }
+            context.startActivity(i);
         }
         return true;
     }


### PR DESCRIPTION
Feature change based on https://github.com/ccrama/Slide/issues/2397
Merge conflict with https://github.com/ccrama/Slide/pull/2639. One of these branches will need a specific change to function together  

When Slide is opened from the user's launcher, the app will behave as it always has.
When Slide is opened via an intent from a third party application, a new task will be created in a separate affinity. This task will always start as a new task and omit itself from recents to avoid having two instances of Slide in the recents app screen.

After closing the task, it cannot be re-opened naturally by the user and history is functionally lost.

Tested:
- Opening Slide from launcher behaves as it did previously
- Opening Slide via Intent from third party app does not replace the standard Slide task
- New Slide affinity returns to previously opened app on back press / swipe back / close
- New Slide affinity is removed from recent apps when closed
- Launching another instance of the new Slide affinity after having already launched one does not retain previous history from old instance