### PR TITLE
Fixed error retry dialogs in Submit to display messages correctly

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Submit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Submit.java
@@ -440,42 +440,11 @@ public class Submit extends BaseActivity {
                         runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                new AlertDialogWrapper.Builder(Submit.this).setTitle(
-                                        R.string.err_title)
-                                        .setMessage(getString(R.string.misc_err)
-                                                + ": "
-                                                + e.getExplanation()
-                                                + "\n"
-                                                + getString(R.string.misc_retry_draft))
-                                        .setNegativeButton(R.string.btn_no,
-                                                new DialogInterface.OnClickListener() {
-                                                    @Override
-                                                    public void onClick(
-                                                            DialogInterface dialogInterface,
-                                                            int i) {
-                                                        finish();
-                                                    }
-                                                })
-                                        .setPositiveButton(R.string.btn_yes,
-                                                new DialogInterface.OnClickListener() {
-                                                    @Override
-                                                    public void onClick(
-                                                            DialogInterface dialogInterface,
-                                                            int i) {
-                                                        ((FloatingActionButton) findViewById(
-                                                                R.id.send)).show();
-                                                    }
-                                                })
-                                        .setOnDismissListener(
-                                                new DialogInterface.OnDismissListener() {
-                                                    @Override
-                                                    public void onDismiss(DialogInterface dialog) {
-                                                        ((FloatingActionButton) findViewById(
-                                                                R.id.send)).show();
-                                                    }
-                                                })
-                                        .create()
-                                        .show();
+                                showErrorRetryDialog(getString(R.string.misc_err)
+                                        + ": "
+                                        + e.getExplanation()
+                                        + "\n"
+                                        + getString(R.string.misc_retry_draft));
                             }
                         });
                     }
@@ -505,72 +474,19 @@ public class Submit extends BaseActivity {
                             public void run() {
 
                                 if (e instanceof ApiException) {
-                                    new AlertDialogWrapper.Builder(Submit.this).setTitle(
-                                            R.string.err_title)
-                                            .setMessage(R.string.misc_err
+                                    showErrorRetryDialog(
+                                            getString(R.string.misc_err)
                                                     + ": "
                                                     + e.getExplanation()
                                                     + "\n"
-                                                    + R.string.misc_retry)
-                                            .setNegativeButton(R.string.btn_no,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            finish();
-                                                        }
-                                                    })
-                                            .setPositiveButton(R.string.btn_yes,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .setOnDismissListener(
-                                                    new DialogInterface.OnDismissListener() {
-                                                        @Override
-                                                        public void onDismiss(
-                                                                DialogInterface dialog) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .create()
-                                            .show();
+                                                    + getString(R.string.misc_retry));
                                 } else {
-                                    new AlertDialogWrapper.Builder(Submit.this).setTitle(
-                                            R.string.err_title)
-                                            .setMessage(R.string.misc_err
+                                    showErrorRetryDialog(
+                                            getString(R.string.misc_err)
                                                     + ": "
                                                     + getString(R.string.err_invalid_url)
                                                     + "\n"
-                                                    + R.string.misc_retry)
-                                            .setNegativeButton(R.string.btn_no,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            finish();
-                                                        }
-                                                    })
-                                            .setPositiveButton(R.string.btn_yes,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .create()
-                                            .show();
+                                                    + getString(R.string.misc_retry));
                                 }
                             }
                         });
@@ -597,81 +513,19 @@ public class Submit extends BaseActivity {
                             @Override
                             public void run() {
                                 if (e instanceof ApiException) {
-                                    new AlertDialogWrapper.Builder(Submit.this).setTitle(
-                                            R.string.err_title)
-                                            .setMessage(R.string.misc_err
+                                    showErrorRetryDialog(
+                                            getString(R.string.misc_err)
                                                     + ": "
                                                     + ((ApiException) e).getExplanation()
                                                     + "\n"
-                                                    + R.string.misc_retry)
-                                            .setNegativeButton(R.string.btn_no,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            finish();
-                                                        }
-                                                    })
-                                            .setPositiveButton(R.string.btn_yes,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .setOnDismissListener(
-                                                    new DialogInterface.OnDismissListener() {
-                                                        @Override
-                                                        public void onDismiss(
-                                                                DialogInterface dialog) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .create()
-                                            .show();
+                                                    + getString(R.string.misc_retry));
                                 } else {
-                                    new AlertDialogWrapper.Builder(Submit.this).setTitle(
-                                            R.string.err_title)
-                                            .setMessage(R.string.misc_err
+                                    showErrorRetryDialog(
+                                            getString(R.string.misc_err)
                                                     + ": "
                                                     + getString(R.string.err_invalid_url)
                                                     + "\n"
-                                                    + R.string.misc_retry)
-                                            .setNegativeButton(R.string.btn_no,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            finish();
-                                                        }
-                                                    })
-                                            .setPositiveButton(R.string.btn_yes,
-                                                    new DialogInterface.OnClickListener() {
-                                                        @Override
-                                                        public void onClick(
-                                                                DialogInterface dialogInterface,
-                                                                int i) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .setOnDismissListener(
-                                                    new DialogInterface.OnDismissListener() {
-                                                        @Override
-                                                        public void onDismiss(
-                                                                DialogInterface dialog) {
-                                                            ((FloatingActionButton) findViewById(
-                                                                    R.id.send)).show();
-                                                        }
-                                                    })
-                                            .create()
-                                            .show();
+                                                    + getString(R.string.misc_retry));
                                 }
                             }
                         });
@@ -683,33 +537,7 @@ public class Submit extends BaseActivity {
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        new AlertDialogWrapper.Builder(Submit.this).setTitle(R.string.err_title)
-                                .setMessage(R.string.misc_retry)
-                                .setNegativeButton(R.string.btn_no,
-                                        new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(DialogInterface dialogInterface,
-                                                    int i) {
-                                                finish();
-                                            }
-                                        })
-                                .setPositiveButton(R.string.btn_yes,
-                                        new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(DialogInterface dialogInterface,
-                                                    int i) {
-                                                ((FloatingActionButton) findViewById(
-                                                        R.id.send)).show();
-                                            }
-                                        })
-                                .setOnDismissListener(new DialogInterface.OnDismissListener() {
-                                    @Override
-                                    public void onDismiss(DialogInterface dialog) {
-                                        ((FloatingActionButton) findViewById(R.id.send)).show();
-                                    }
-                                })
-                                .create()
-                                .show();
+                        showErrorRetryDialog(getString(R.string.misc_retry));
                     }
                 });
             }
@@ -1138,6 +966,31 @@ public class Submit extends BaseActivity {
             dialog.setContent("Image " + uploadCount + "/" + totalCount);
             dialog.setProgress(progress);
         }
+    }
+
+    private void showErrorRetryDialog(String message) {
+        new AlertDialogWrapper.Builder(Submit.this).setTitle(R.string.err_title)
+                .setMessage(message)
+                .setNegativeButton(R.string.btn_no, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        finish();
+                    }
+                })
+                .setPositiveButton(R.string.btn_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        ((FloatingActionButton) findViewById(R.id.send)).show();
+                    }
+                })
+                .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                    @Override
+                    public void onDismiss(DialogInterface dialog) {
+                        ((FloatingActionButton) findViewById(R.id.send)).show();
+                    }
+                })
+                .create()
+                .show();
     }
 
 }


### PR DESCRIPTION
Not related to any open issue

In the Submit class, error dialogs for "retry" were displaying resource ids since getString was not called on the resource ids for the message creation.

I just condensed all the logic into a single reusable method since all dialogs here do the same thing except minus the error message.

This change went through a few iterations so make sure I didn't screw up any of the messages.