### PR TITLE
Consolidated sharing logic into a helper class

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -2,9 +2,6 @@ package me.ccrama.redditslide.Activities;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
@@ -13,16 +10,12 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.media.MediaScannerConnection;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.content.FileProvider;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -50,14 +43,11 @@ import com.nostra13.universalimageloader.core.assist.ImageScaleType;
 import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
-import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.DecimalFormat;
@@ -84,6 +74,7 @@ import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
+import me.ccrama.redditslide.util.ShareUtil;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 
@@ -472,7 +463,7 @@ public class AlbumPager extends FullScreenActivity
                     }
                     break;
                     case (3): {
-                        shareImage(contentUrl);
+                        ShareUtil.shareImage(contentUrl, AlbumPager.this);
                     }
                     break;
                     case (5): {
@@ -756,125 +747,6 @@ public class AlbumPager extends FullScreenActivity
             }
         });
 
-    }
-
-    public void showNotifPhoto(final File localAbsoluteFilePath, final Bitmap loadedImage) {
-        MediaScannerConnection.scanFile(AlbumPager.this,
-                new String[]{localAbsoluteFilePath.getAbsolutePath()}, null,
-                new MediaScannerConnection.OnScanCompletedListener() {
-                    public void onScanCompleted(String path, Uri uri) {
-
-                        final Intent shareIntent = new Intent(Intent.ACTION_VIEW);
-                        shareIntent.setDataAndType(Uri.fromFile(localAbsoluteFilePath), "image/*");
-                        PendingIntent contentIntent =
-                                PendingIntent.getActivity(AlbumPager.this, 0, shareIntent,
-                                        PendingIntent.FLAG_CANCEL_CURRENT);
-
-
-                        Notification notif =
-                                new NotificationCompat.Builder(AlbumPager.this).setContentTitle(
-                                        getString(R.string.info_photo_saved))
-                                        .setSmallIcon(R.drawable.notif)
-                                        .setLargeIcon(loadedImage)
-                                        .setChannelId(Reddit.CHANNEL_IMG)
-                                        .setContentIntent(contentIntent)
-                                        .setStyle(
-                                                new NotificationCompat.BigPictureStyle().bigPicture(
-                                                        loadedImage))
-                                        .build();
-
-
-                        NotificationManager mNotificationManager =
-                                (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-                        mNotificationManager.notify(1, notif);
-                        loadedImage.recycle();
-                    }
-
-                });
-    }
-
-    private void shareImage(final String finalUrl) {
-        ((Reddit) getApplication()).getImageLoader()
-                .loadImage(finalUrl, new SimpleImageLoadingListener() {
-                    @Override
-                    public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
-                        shareImage(loadedImage);
-                    }
-                });
-    }
-
-    /**
-     * Deletes all files in a folder
-     *
-     * @param dir to clear contents
-     */
-    private void deleteFilesInDir(File dir) {
-        for (File child : dir.listFiles()) {
-            child.delete();
-        }
-    }
-
-    /**
-     * Converts an image to a PNG, stores it to the cache, then shares it. Saves the image to
-     * /cache/shared_image for easy deletion. If the /cache/shared_image folder already exists, we
-     * clear it's contents as to avoid increasing the cache size unnecessarily.
-     *
-     * @param bitmap image to share
-     */
-    private void shareImage(final Bitmap bitmap) {
-        File image; //image to share
-
-        //check to see if the cache/shared_images directory is present
-        final File imagesDir =
-                new File(this.getCacheDir().toString() + File.separator + "shared_image");
-        if (!imagesDir.exists()) {
-            imagesDir.mkdir(); //create the folder if it doesn't exist
-        } else {
-            deleteFilesInDir(imagesDir);
-        }
-
-        try {
-            //creates a file in the cache; filename will be prefixed with "img" and end with ".png"
-            image = File.createTempFile("img", ".png", imagesDir);
-            FileOutputStream out = null;
-
-            try {
-                //convert image to png
-                out = new FileOutputStream(image);
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
-            } finally {
-                if (out != null) {
-                    out.close();
-
-                    /**
-                     * If a user has both a debug build and a release build installed, the authority name needs to be unique
-                     */
-                    final String authority = (this.getPackageName()).concat(".")
-                            .concat(MediaView.class.getSimpleName());
-
-                    final Uri contentUri = FileProvider.getUriForFile(this, authority, image);
-
-                    if (contentUri != null) {
-                        final Intent shareImageIntent = new Intent(Intent.ACTION_SEND);
-                        shareImageIntent.addFlags(
-                                Intent.FLAG_GRANT_READ_URI_PERMISSION); //temp permission for receiving app to read this file
-                        shareImageIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
-                        shareImageIntent.setDataAndType(contentUri,
-                                getContentResolver().getType(contentUri));
-
-                        //Select a share option
-                        startActivity(Intent.createChooser(shareImageIntent,
-                                getString(R.string.misc_img_share)));
-                    } else {
-                        Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG)
-                                .show();
-                    }
-                }
-            }
-        } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
-            Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG).show();
-        }
     }
 
     public void showErrorDialog() {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Draw.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Draw.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
-import android.support.v4.content.FileProvider;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -29,6 +28,7 @@ import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.Views.CanvasView;
 import me.ccrama.redditslide.Views.DoEditorActions;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.FileUtil;
 
 
 /**
@@ -76,7 +76,7 @@ public class Draw extends BaseActivity implements ColorChooserDialog.ColorCallba
             if (!imagesDir.exists()) {
                 imagesDir.mkdir(); //create the folder if it doesn't exist
             } else {
-                deleteFilesInDir(imagesDir);
+                FileUtil.deleteFilesInDir(imagesDir);
             }
 
             try {
@@ -94,18 +94,9 @@ public class Draw extends BaseActivity implements ColorChooserDialog.ColorCallba
                     if (out != null) {
                         out.close();
 
-                        /**
-                         * If a user has both a debug build and a release build installed, the authority name needs to be unique
-                         */
-                        final String authority = (Draw.this.getPackageName()).concat(".")
-                                .concat(MediaView.class.getSimpleName());
-
-                        final Uri contentUri =
-                                FileProvider.getUriForFile(Draw.this, authority, image);
-
+                        final Uri contentUri = FileUtil.getFileUri(image, this);
                         if (contentUri != null) {
-                            Intent intent = new Intent();
-                            intent.setData(contentUri);
+                            Intent intent = FileUtil.getFileIntent(image, new Intent(), this);
                             setResult(RESULT_OK, intent);
                         } else {
                             //todo error Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG).show();
@@ -165,12 +156,6 @@ public class Draw extends BaseActivity implements ColorChooserDialog.ColorCallba
             }
         } else {
             finish();
-        }
-    }
-
-    private void deleteFilesInDir(File dir) {
-        for (File child : dir.listFiles()) {
-            child.delete();
         }
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -21,7 +21,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.v4.app.NotificationCompat;
-import android.support.v4.content.FileProvider;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.text.Html;
 import android.util.Log;
@@ -36,7 +35,6 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.cocosw.bottomsheet.BottomSheet;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
@@ -45,7 +43,6 @@ import com.nostra13.universalimageloader.core.assist.ImageScaleType;
 import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
-import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
@@ -79,6 +76,7 @@ import me.ccrama.redditslide.util.HttpUtil;
 import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
+import me.ccrama.redditslide.util.ShareUtil;
 
 import static me.ccrama.redditslide.Activities.AlbumPager.readableFileSize;
 
@@ -275,7 +273,7 @@ public class MediaView extends FullScreenActivity
                         break;
                     }
                     case (3): {
-                        shareImage(actuallyLoaded);
+                        ShareUtil.shareImage(actuallyLoaded, MediaView.this);
                         break;
                     }
                     case (5): {
@@ -390,7 +388,6 @@ public class MediaView extends FullScreenActivity
                                         MediaView.this.sendBroadcast(mediaScanIntent);
 
                                         final Intent shareIntent = new Intent(Intent.ACTION_VIEW);
-                                        shareIntent.setType("image/gif");
                                         PendingIntent contentIntent =
                                                 PendingIntent.getActivity(MediaView.this, 0,
                                                         shareIntent,
@@ -478,7 +475,6 @@ public class MediaView extends FullScreenActivity
                                         MediaView.this.sendBroadcast(mediaScanIntent);
 
                                         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                                        shareIntent.setType("image/gif");
                                         startActivity(
                                                 Intent.createChooser(shareIntent, "Share GIF"));
                                         NotificationManager mNotificationManager =
@@ -1319,133 +1315,6 @@ public class MediaView extends FullScreenActivity
                         .show();
             }
         });
-    }
-
-    private void shareImage(final String finalUrl) {
-        ((Reddit) getApplication()).getImageLoader()
-                .loadImage(finalUrl, new SimpleImageLoadingListener() {
-                    @Override
-                    public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
-                        shareImage(loadedImage, finalUrl);
-                    }
-                });
-    }
-
-    /**
-     * Converts an image to a PNG, stores it to the cache, then shares it. Saves the image to
-     * /cache/shared_image for easy deletion. If the /cache/shared_image folder already exists, we
-     * clear it's contents as to avoid increasing the cache size unnecessarily.
-     *
-     * @param bitmap image to share
-     */
-    private void shareImage(final Bitmap bitmap, String original) {
-        File image; //image to share
-
-        //check to see if the cache/shared_images directory is present
-        final File imagesDir =
-                new File(this.getCacheDir().toString() + File.separator + "shared_image");
-        if (!imagesDir.exists()) {
-            imagesDir.mkdir(); //create the folder if it doesn't exist
-        } else {
-            deleteFilesInDir(imagesDir);
-        }
-
-        try {
-            //creates a file in the cache; filename will be prefixed with "img" and end with ".png"
-            image = File.createTempFile("img", ".png", imagesDir);
-
-            File f = ((Reddit) getApplicationContext()).getImageLoader()
-                    .getDiscCache()
-                    .get(original);
-            if (f != null) {
-                try {
-                    Files.copy(f, image);
-                    shareFile(image);
-                } catch (IOException e) {
-                    doAlternativeImageSave(image, bitmap, original);
-                    shareFile(image);
-                    e.printStackTrace();
-                }
-            } else {
-                doAlternativeImageSave(image, bitmap, original);
-                shareFile(image);
-            }
-        } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
-            Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG).show();
-        }
-    }
-
-    public void shareFile(File image) {
-        final String authority =
-                (this.getPackageName()).concat(".").concat(MediaView.class.getSimpleName());
-
-        final Uri contentUri = FileProvider.getUriForFile(this, authority, image);
-
-        if (contentUri != null) {
-            final Intent shareImageIntent = new Intent(Intent.ACTION_SEND);
-            shareImageIntent.addFlags(
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION); //temp permission for receiving app to read this file
-            shareImageIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
-            shareImageIntent.setDataAndType(contentUri, getContentResolver().getType(contentUri));
-
-            //Select a share option
-            startActivity(
-                    Intent.createChooser(shareImageIntent, getString(R.string.misc_img_share)));
-        } else {
-            Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG).show();
-        }
-    }
-
-    public void doAlternativeImageSave(File image, Bitmap bitmap, String original)
-            throws IOException {
-        FileOutputStream out = null;
-
-        try {
-            //convert image to png
-            out = new FileOutputStream(image);
-            bitmap.compress(original.endsWith("png") ? Bitmap.CompressFormat.PNG
-                    : Bitmap.CompressFormat.JPEG, 100, out);
-        } finally {
-            if (out != null) {
-                out.close();
-
-                /**
-                 * If a user has both a debug build and a release build installed, the authority name needs to be unique
-                 */
-                final String authority =
-                        (this.getPackageName()).concat(".").concat(MediaView.class.getSimpleName());
-
-                final Uri contentUri = FileProvider.getUriForFile(this, authority, image);
-
-                if (contentUri != null) {
-                    final Intent shareImageIntent = new Intent(Intent.ACTION_SEND);
-                    shareImageIntent.addFlags(
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION); //temp permission for receiving app to read this file
-                    shareImageIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
-                    shareImageIntent.setDataAndType(contentUri,
-                            getContentResolver().getType(contentUri));
-
-                    //Select a share option
-                    startActivity(Intent.createChooser(shareImageIntent,
-                            getString(R.string.misc_img_share)));
-                } else {
-                    Toast.makeText(this, getString(R.string.err_share_image), Toast.LENGTH_LONG)
-                            .show();
-                }
-            }
-        }
-    }
-
-    /**
-     * Deletes all files in a folder
-     *
-     * @param dir to clear contents
-     */
-    private void deleteFilesInDir(File dir) {
-        for (File child : dir.listFiles()) {
-            child.delete();
-        }
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
@@ -13,7 +13,6 @@ import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.IBinder;
-import android.support.v4.content.FileProvider;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.view.View;
@@ -37,6 +36,7 @@ import me.ccrama.redditslide.Activities.DeleteFile;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
+import me.ccrama.redditslide.util.FileUtil;
 import me.ccrama.redditslide.util.LogUtil;
 
 /**
@@ -214,10 +214,8 @@ public class ImageDownloadNotificationService extends Service {
                     new MediaScannerConnection.OnScanCompletedListener() {
                         public void onScanCompleted(String path, Uri uri) {
                             PendingIntent pContentIntent, pShareIntent, pDeleteIntent, pEditIntent;
-                            Uri photoURI = FileProvider.getUriForFile(
-                                    ImageDownloadNotificationService.this,
-                                    getApplicationContext().getPackageName() + ".MediaView",
-                                    localAbsoluteFilePath);
+                            Uri photoURI = FileUtil.getFileUri(localAbsoluteFilePath,
+                                    ImageDownloadNotificationService.this);
 
                             {
                                 final Intent shareIntent = new Intent(Intent.ACTION_VIEW);

--- a/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/FileUtil.java
@@ -21,17 +21,37 @@ public class FileUtil {
      * application
      */
     public static Intent getFileIntent(File file, Intent intent, Context context) {
-        String packageName = context.getApplicationContext().getPackageName() + ".provider";
+        Uri selectedUri = getFileUri(file, context);
 
-        Uri selectedUri = FileProvider.getUriForFile(context, packageName, file);
-
-        context.grantUriPermission(packageName, selectedUri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-
-        intent.setData(selectedUri);
+        intent.setDataAndType(selectedUri, context.getContentResolver().getType(selectedUri));
         intent.setFlags(
                 Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
         return intent;
+    }
+
+    /**
+     * Gets a valid File Uri to a file in the system
+     *
+     * @param file    the {@code File} to open
+     * @param context Current context
+     * @return a File Uri to the given file
+     */
+    public static Uri getFileUri(File file, Context context) {
+        String packageName = context.getApplicationContext().getPackageName() + ".provider";
+        Uri selectedUri = FileProvider.getUriForFile(context, packageName, file);
+        context.grantUriPermission(packageName, selectedUri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        return selectedUri;
+    }
+
+    /**
+     * Deletes all files in a folder
+     *
+     * @param dir to clear contents
+     */
+    public static void deleteFilesInDir(File dir) {
+        for (File child : dir.listFiles()) {
+            child.delete();
+        }
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -8,7 +8,6 @@ import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
-import android.graphics.Movie;
 import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
@@ -30,7 +29,6 @@ import com.coremedia.iso.boxes.Container;
 import com.danikula.videocache.CacheListener;
 import com.danikula.videocache.HttpProxyCacheServer;
 import com.devbrackets.android.exomedia.listener.OnPreparedListener;
-import com.google.android.exoplayer2.extractor.mp4.Track;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.googlecode.mp4parser.authoring.builder.DefaultMp4Builder;
@@ -46,14 +44,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.CopyOption;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.text.DecimalFormat;
 import java.util.UUID;
 
@@ -89,7 +83,6 @@ public class GifUtils {
 
 
         final Intent shareIntent = FileUtil.getFileIntent(f, new Intent(Intent.ACTION_VIEW), c);
-        shareIntent.setType("video/*");
         PendingIntent contentIntent =
                 PendingIntent.getActivity(c, 0, shareIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 

--- a/app/src/main/java/me/ccrama/redditslide/util/ShareUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/ShareUtil.java
@@ -1,0 +1,87 @@
+package me.ccrama.redditslide.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.view.View;
+import android.widget.Toast;
+
+import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import me.ccrama.redditslide.R;
+import me.ccrama.redditslide.Reddit;
+
+public class ShareUtil {
+    private ShareUtil() {
+    }
+
+    public static void shareImage(final String finalUrl, final Context context) {
+        ((Reddit) context.getApplicationContext()).getImageLoader()
+                .loadImage(finalUrl, new SimpleImageLoadingListener() {
+                    @Override
+                    public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
+                        shareImage(loadedImage, context);
+                    }
+                });
+    }
+
+    /**
+     * Converts an image to a PNG, stores it to the cache, then shares it. Saves the image to
+     * /cache/shared_image for easy deletion. If the /cache/shared_image folder already exists, we
+     * clear it's contents as to avoid increasing the cache size unnecessarily.
+     *
+     * @param bitmap image to share
+     */
+    public static void shareImage(final Bitmap bitmap, Context context) {
+        File image; //image to share
+
+        //check to see if the cache/shared_images directory is present
+        final File imagesDir =
+                new File(context.getCacheDir().toString() + File.separator + "shared_image");
+        if (!imagesDir.exists()) {
+            imagesDir.mkdir(); //create the folder if it doesn't exist
+        } else {
+            FileUtil.deleteFilesInDir(imagesDir);
+        }
+
+        try {
+            //creates a file in the cache; filename will be prefixed with "img" and end with ".png"
+            image = File.createTempFile("img", ".png", imagesDir);
+            FileOutputStream out = null;
+
+            try {
+                //convert image to png
+                out = new FileOutputStream(image);
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            } finally {
+                if (out != null) {
+                    out.close();
+
+                    final Uri contentUri = FileUtil.getFileUri(image, context);
+                    if (contentUri != null) {
+                        final Intent shareImageIntent =
+                                FileUtil.getFileIntent(image, new Intent(Intent.ACTION_SEND),
+                                        context);
+                        shareImageIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
+
+                        //Select a share option
+                        context.startActivity(Intent.createChooser(shareImageIntent,
+                                context.getString(R.string.misc_img_share)));
+                    } else {
+                        Toast.makeText(context, context.getString(R.string.err_share_image),
+                                Toast.LENGTH_LONG).show();
+                    }
+                }
+            }
+        } catch (IOException | NullPointerException e) {
+            e.printStackTrace();
+            Toast.makeText(context, context.getString(R.string.err_share_image), Toast.LENGTH_LONG)
+                    .show();
+        }
+    }
+}


### PR DESCRIPTION
Fixes [Reddit reported issue](https://www.reddit.com/r/slideforreddit/comments/7v2nc4/v58alpha2_released/dtpetg0/)

Originally, the issue was I didn't replace all the `FileProvider `usages across the app when I created `FileUtil`. In these, the old provider name (.MediaView) was being used. I renamed the provider to be the generic `.provider` name to appease TedBottomPicker

In testing this, I ran into some confusion on why there were multiple `shareImage `methods that seemed to vary only slightly and in confusing ways, with the `MediaView#shareImage` logic just straight up not working. The only `shareImage `method I could get to work was the one in `AlbumPager`. This one was the simplest and had the fewest dependencies. When I converted ALL `shareImage `methods to be this same method, they all worked consistently without an issue.

I do not have answers for what special things those other methods were doing and why they were causing failures in sharing when using the `FileUtil#getFileIntent` method. I'm not ruling something out in how I wrote it, I'm just unsure.

Now, this time I DID test:
- Sharing links
- Sharing images
- Sharing from albums
- Sharing from tumblr albums
- Downloading images (notifications still work)
- Downloading from albums / tumblr albums (notifications still work)
- Downloading gifs (notifications still work)

Please verify that me removing those other methods and consolidating them into a single method does not break any required logic. I am not sure about edge cases they could have been resolving.

Additionally, this `Util `package is getting out of hand. Looking for incorrect usage of static helper classes (my new `ShareUtil `class included) could be a project.

EDIT: Yes I should have broken this into two commits. No it would not have fixed the depressingly large PR.