### PR TITLE
Fix crosspost crash on startup

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
@@ -96,7 +96,7 @@ public class SubmissionCache {
         String spacer = mContext.getString(R.string.submission_properties_seperator);
         SpannableStringBuilder titleString = new SpannableStringBuilder("Crosspost" + spacer);
         JsonNode json = s.getDataNode();
-        if (!json.has("crosspost_parent_list") && json.get("crosspost_parent_list").get(0) != null) { //is not a crosspost
+        if (!json.has("crosspost_parent_list") || json.get("crosspost_parent_list").get(0) == null) { //is not a crosspost
             return new SpannableStringBuilder();
         }
         json = json.get("crosspost_parent_list").get(0);


### PR DESCRIPTION
The logic flow before was:
  Check if json does not have crosspost_parent_list AND
  get member 0 of json's crosspost_parent_list to check if it's not null

The problem is if the first condition is true(json does not have crosspost_parent_list),
AND can't short-circut and it will move on to evaluate the second side, so it will
try and get member 0 of a crosspost_parent_list, which will be null as we figured out
in the first conditional.

Now the logic flow is:
  Check if json does not have crosspost_parent_list OR
  get member 0 of json's crosspost_parent_list to check if it's null

This way, the OR can short circut on the first true condition, so the get member 0
logic won't trigger unless the json does have crosspost_parent_list.