### PR TITLE
Bugfix/submissionview refresh recyclerview crash

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CommentsScreen.java
@@ -309,6 +309,11 @@ public class CommentsScreen extends BaseActivityAnim implements SubmissionDispla
 
     }
 
+    @Override
+    public void onAdapterUpdated() {
+        comments.notifyDataSetChanged();
+    }
+
     public class OverviewPagerAdapter extends FragmentStatePagerAdapter {
         private CommentPage   mCurrentFragment;
         public  BlankFragment blankPage;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
@@ -1,6 +1,5 @@
 package me.ccrama.redditslide.Activities;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Gallery.java
@@ -190,6 +190,11 @@ public class Gallery extends FullScreenActivity implements SubmissionDisplay {
         recyclerAdapter.notifyDataSetChanged();
     }
 
+    @Override
+    public void onAdapterUpdated() {
+        recyclerAdapter.notifyDataSetChanged();
+    }
+
     @NonNull
     private RecyclerView.LayoutManager createLayoutManager(final int numColumns) {
         return new CatchStaggeredGridLayoutManager(numColumns,

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Shadowbox.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Shadowbox.java
@@ -143,6 +143,11 @@ public class Shadowbox extends FullScreenActivity implements SubmissionDisplay {
 
     }
 
+    @Override
+    public void onAdapterUpdated() {
+        submissionsPager.notifyDataSetChanged();
+    }
+
     public class OverviewPagerAdapter extends FragmentStatePagerAdapter {
 
         public OverviewPagerAdapter(FragmentManager fm) {

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -9,7 +9,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.RecyclerView;
@@ -40,7 +39,6 @@ import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionViews.PopulateSubmissionViewHolder;
 import me.ccrama.redditslide.Views.CatchStaggeredGridLayoutManager;
 import me.ccrama.redditslide.Views.CreateCardView;
-import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
 
 
@@ -324,7 +322,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                                                                    }
                                                                });
                                                                View view = s.getView();
-                                                               TextView tv = (TextView) view.findViewById(
+                                                               TextView tv = view.findViewById(
                                                                        android.support.design.R.id.snackbar_text);
                                                                tv.setTextColor(Color.WHITE);
                                                                s.show();
@@ -436,7 +434,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(
+                            TextView tv = view.findViewById(
                                     android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
@@ -454,7 +452,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(
+                            TextView tv = view.findViewById(
                                     android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -356,7 +356,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         .setOnClickListener(new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {
-                                dataSet.loadMore(context, displayer, true);
+                                ((SubmissionsView)displayer).forceRefresh();
                             }
                         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionDisplay.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionDisplay.java
@@ -34,4 +34,6 @@ public interface SubmissionDisplay {
     void updateError();
 
     void updateViews();
+
+    void onAdapterUpdated();
 }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
@@ -291,6 +291,15 @@ public class SubredditPosts implements PostLoader {
         public int start;
 
         @Override
+        public void onPreExecute()
+        {
+            if(reset) {
+                posts.clear();
+                displayer.onAdapterUpdated();
+            }
+        }
+
+        @Override
         public void onPostExecute(final List<Submission> submissions) {
             loading = false;
             if (error != null) {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -39,7 +39,6 @@ import me.ccrama.redditslide.Adapters.SubmissionDisplay;
 import me.ccrama.redditslide.Constants;
 import me.ccrama.redditslide.HasSeen;
 import me.ccrama.redditslide.Hidden;
-import me.ccrama.redditslide.LastComments;
 import me.ccrama.redditslide.OfflineSubreddit;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
@@ -92,13 +91,13 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
 
         View v = inflater.inflate(R.layout.fragment_verticalcontent, container, false);
 
-        rv = ((RecyclerView) v.findViewById(R.id.vertical_content));
+        rv = v.findViewById(R.id.vertical_content);
         final RecyclerView.LayoutManager mLayoutManager =
                 createLayoutManager(getNumColumns(getResources().getConfiguration().orientation));
 
         rv.setLayoutManager(mLayoutManager);
         if (SettingValues.fab) {
-            fab = (FloatingActionButton) v.findViewById(R.id.post_floating_action_button);
+            fab = v.findViewById(R.id.post_floating_action_button);
 
             if (SettingValues.fabType == Constants.FAB_POST) {
                 fab.setOnClickListener(new View.OnClickListener() {
@@ -176,7 +175,7 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
                         };*/
                         Snackbar s = Snackbar.make(rv, getResources().getString(R.string.posts_hidden_forever), Snackbar.LENGTH_LONG);
                         View view = s.getView();
-                        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                        TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                         tv.setTextColor(Color.WHITE);
                         s.show();
 
@@ -187,7 +186,7 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
         } else {
             v.findViewById(R.id.post_floating_action_button).setVisibility(View.GONE);
         }
-        refreshLayout = (SwipeRefreshLayout) v.findViewById(R.id.activity_main_swipe_refresh_layout);
+        refreshLayout = v.findViewById(R.id.activity_main_swipe_refresh_layout);
 
         /**
          * If using List view mode, we need to remove the start margin from the SwipeRefreshLayout.

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MultiredditView.java
@@ -390,4 +390,9 @@ public class MultiredditView extends Fragment implements SubmissionDisplay {
 
         }
     }
+
+    @Override
+    public void onAdapterUpdated() {
+        adapter.notifyDataSetChanged();
+    }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/NewsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/NewsView.java
@@ -39,7 +39,6 @@ import me.ccrama.redditslide.Activities.BaseActivity;
 import me.ccrama.redditslide.Activities.MainActivity;
 import me.ccrama.redditslide.Activities.Submit;
 import me.ccrama.redditslide.Activities.SubredditView;
-import me.ccrama.redditslide.Adapters.SubmissionAdapter;
 import me.ccrama.redditslide.Adapters.SubmissionDisplay;
 import me.ccrama.redditslide.Adapters.SubmissionNewsAdapter;
 import me.ccrama.redditslide.Adapters.SubredditPostsRealm;
@@ -104,7 +103,7 @@ public class NewsView extends Fragment implements SubmissionDisplay {
         if (getActivity() instanceof MainActivity) {
             v.findViewById(R.id.back).setBackgroundResource(0);
         }
-        rv = ((RecyclerView) v.findViewById(R.id.vertical_content));
+        rv = v.findViewById(R.id.vertical_content);
 
         rv.setHasFixedSize(true);
 
@@ -123,8 +122,7 @@ public class NewsView extends Fragment implements SubmissionDisplay {
         rv.setItemAnimator(new SlideUpAlphaAnimator());
         rv.getLayoutManager().scrollToPosition(0);
 
-        mSwipeRefreshLayout =
-                (SwipeRefreshLayout) v.findViewById(R.id.activity_main_swipe_refresh_layout);
+        mSwipeRefreshLayout = v.findViewById(R.id.activity_main_swipe_refresh_layout);
         mSwipeRefreshLayout.setColorSchemeColors(Palette.getColors(id, getContext()));
 
         /**
@@ -158,7 +156,7 @@ public class NewsView extends Fragment implements SubmissionDisplay {
                 HEADER_OFFSET + Constants.PTR_OFFSET_BOTTOM);
 
         if (SettingValues.fab) {
-            fab = (FloatingActionButton) v.findViewById(R.id.post_floating_action_button);
+            fab = v.findViewById(R.id.post_floating_action_button);
 
             if (SettingValues.fabType == Constants.FAB_POST) {
                 fab.setImageResource(R.drawable.add);
@@ -257,7 +255,7 @@ public class NewsView extends Fragment implements SubmissionDisplay {
                             }
                         });*/
                         View view = s.getView();
-                        TextView tv = (TextView) view.findViewById(
+                        TextView tv = view.findViewById(
                                 android.support.design.R.id.snackbar_text);
                         tv.setTextColor(Color.WHITE);
                         s.show();

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/NewsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/NewsView.java
@@ -550,6 +550,11 @@ public class NewsView extends Fragment implements SubmissionDisplay {
         }
     }
 
+    @Override
+    public void onAdapterUpdated() {
+        adapter.notifyDataSetChanged();
+    }
+
     public void resetScroll() {
         if (toolbarScroll == null) {
             toolbarScroll =

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -443,7 +443,8 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
     }
 
     public void forceRefresh() {
-        rv.scrollToPosition(0);
+        toolbarScroll.toolbarShow();
+        rv.getLayoutManager().scrollToPosition(0);
         mSwipeRefreshLayout.post(new Runnable() {
             @Override
             public void run() {
@@ -540,6 +541,11 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
                 }
             }
         }
+    }
+
+    @Override
+    public void onAdapterUpdated() {
+        adapter.notifyDataSetChanged();
     }
 
     public void resetScroll() {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -54,7 +54,6 @@ import me.ccrama.redditslide.Views.CatchStaggeredGridLayoutManager;
 import me.ccrama.redditslide.Views.CreateCardView;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.handler.ToolbarScrollHideHandler;
-import me.ccrama.redditslide.util.LogUtil;
 
 public class SubmissionsView extends Fragment implements SubmissionDisplay {
     private static int               adapterPosition;
@@ -103,7 +102,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         if (getActivity() instanceof MainActivity) {
             v.findViewById(R.id.back).setBackgroundResource(0);
         }
-        rv = ((RecyclerView) v.findViewById(R.id.vertical_content));
+        rv = v.findViewById(R.id.vertical_content);
 
         rv.setHasFixedSize(true);
 
@@ -122,8 +121,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
         rv.setItemAnimator(new SlideUpAlphaAnimator());
         rv.getLayoutManager().scrollToPosition(0);
 
-        mSwipeRefreshLayout =
-                (SwipeRefreshLayout) v.findViewById(R.id.activity_main_swipe_refresh_layout);
+        mSwipeRefreshLayout = v.findViewById(R.id.activity_main_swipe_refresh_layout);
         mSwipeRefreshLayout.setColorSchemeColors(Palette.getColors(id, getContext()));
 
         /**
@@ -157,7 +155,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
                 HEADER_OFFSET + Constants.PTR_OFFSET_BOTTOM);
 
         if (SettingValues.fab) {
-            fab = (FloatingActionButton) v.findViewById(R.id.post_floating_action_button);
+            fab = v.findViewById(R.id.post_floating_action_button);
 
             if (SettingValues.fabType == Constants.FAB_POST) {
                 fab.setImageResource(R.drawable.add);
@@ -253,7 +251,7 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
                             }
                         });*/
                         View view = s.getView();
-                        TextView tv = (TextView) view.findViewById(
+                        TextView tv = view.findViewById(
                                 android.support.design.R.id.snackbar_text);
                         tv.setTextColor(Color.WHITE);
                         s.show();

--- a/app/src/main/java/me/ccrama/redditslide/handler/ToolbarScrollHideHandler.java
+++ b/app/src/main/java/me/ccrama/redditslide/handler/ToolbarScrollHideHandler.java
@@ -116,6 +116,11 @@ public class ToolbarScrollHideHandler extends RecyclerView.OnScrollListener {
         }
     }
 
+    public void toolbarShow()
+    {
+        mAppBar.setTranslationY(0);
+    }
+
     private void toolbarAnimateShow(final int verticalOffset) {
         mAppBar.animate()
                 .translationY(0)


### PR DESCRIPTION
Resolves issue https://github.com/ccrama/Slide/issues/2690

I decided to keep the ToolbarScrollHideHandler in this change instead of trying to replace it. It works and there's no reason to remove it. I just worked around it a bit.

The issue explains the problem and resolution pretty well but generally:

- If the content in the adapter for the RecyclerView is being updated on another thread and a user tries to interact with the RecyclerView (scrolling up out of range of the latest content in the adapter), an IndexOutOfBounds would occur
     - To reproduce, reach the end of a subreddit's post listing, press "Refresh" and scroll up
- This change does two things to resolve
    - It consolidates the logic for refreshing the view by calling the method SubmissionView.forceRefresh() from the SubmissionAdapter. I explicitly cast the type because I can't fathom why this adapter would be used elsewhere. There are better patterns for this and if you can think of one easily added, let me know
    - The List (?) storng all the Submission data is cleared on forceRefresh, the view is pushed to the top, and the toolbar is forcibly shown. This prevents the user from scrolling into soon-to-be stale data on refresh
        - In this, I added a new method to the SubmissionDisplayer interface to make it easier. All implementations now have a method that lets the View know that the adapter was changed in someway from somewhere else. This is helpful when the changes happen outside of the adapter, but the view is still available (like a hacky MVP).

I separated the commits in a functionality change and a cleanup change to make it easier to see what had to change
