### PR TITLE
Bugfix/crash on null flair text

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -336,7 +336,7 @@ public class CommentAdapterHelper {
                                     Snackbar.LENGTH_SHORT);
                         }
                         View view = s.getView();
-                        TextView tv = (TextView) view.findViewById(
+                        TextView tv = view.findViewById(
                                 android.support.design.R.id.snackbar_text);
                         tv.setTextColor(Color.WHITE);
                         s.show();
@@ -439,9 +439,8 @@ public class CommentAdapterHelper {
                                                                                 View view =
                                                                                         s.getView();
                                                                                 TextView tv =
-                                                                                        (TextView) view
-                                                                                                .findViewById(
-                                                                                                        android.support.design.R.id.snackbar_text);
+                                                                                        view.findViewById(
+                                                                                                android.support.design.R.id.snackbar_text);
                                                                                 tv.setTextColor(
                                                                                         Color.WHITE);
                                                                                 s.show();
@@ -455,9 +454,8 @@ public class CommentAdapterHelper {
                                                                                 View view =
                                                                                         s.getView();
                                                                                 TextView tv =
-                                                                                        (TextView) view
-                                                                                                .findViewById(
-                                                                                                        android.support.design.R.id.snackbar_text);
+                                                                                        view.findViewById(
+                                                                                                android.support.design.R.id.snackbar_text);
                                                                                 tv.setTextColor(
                                                                                         Color.WHITE);
                                                                                 s.show();
@@ -493,7 +491,7 @@ public class CommentAdapterHelper {
                                                                 R.string.submission_info_saved,
                                                                 Snackbar.LENGTH_SHORT);
                                                         View view = s.getView();
-                                                        TextView tv = (TextView) view.findViewById(
+                                                        TextView tv = view.findViewById(
                                                                 android.support.design.R.id.snackbar_text);
                                                         tv.setTextColor(Color.WHITE);
                                                         s.show();
@@ -504,7 +502,7 @@ public class CommentAdapterHelper {
                                                                 R.string.category_set_error,
                                                                 Snackbar.LENGTH_SHORT);
                                                         View view = s.getView();
-                                                        TextView tv = (TextView) view.findViewById(
+                                                        TextView tv = view.findViewById(
                                                                 android.support.design.R.id.snackbar_text);
                                                         tv.setTextColor(Color.WHITE);
                                                         s.show();
@@ -784,7 +782,7 @@ public class CommentAdapterHelper {
 
                                             {
                                                 View view = s.getView();
-                                                TextView tv = (TextView) view.findViewById(
+                                                TextView tv = view.findViewById(
                                                         android.support.design.R.id.snackbar_text);
                                                 tv.setTextColor(Color.WHITE);
                                                 s.show();
@@ -811,8 +809,7 @@ public class CommentAdapterHelper {
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_distinguished,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -847,8 +844,7 @@ public class CommentAdapterHelper {
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_undistinguished,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -883,8 +879,7 @@ public class CommentAdapterHelper {
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_stickied,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -988,8 +983,7 @@ public class CommentAdapterHelper {
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_unstickied,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -1023,8 +1017,7 @@ public class CommentAdapterHelper {
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_removed,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
 
@@ -1248,8 +1241,7 @@ public class CommentAdapterHelper {
             titleString.append(pinned);
             titleString.append(" ");
         }
-        if (comment.getAuthorFlair() != null)
-        {
+        if (comment.getAuthorFlair() != null) {
             String flairText;
             if(comment.getAuthorFlair().getText() != null
                     && !comment.getAuthorFlair().getText().isEmpty()) {
@@ -1320,7 +1312,7 @@ public class CommentAdapterHelper {
         final View dialoglayout = inflater.inflate(R.layout.edit_comment, null);
         final AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(mContext);
 
-        final EditText e = (EditText) dialoglayout.findViewById(R.id.entry);
+        final EditText e = dialoglayout.findViewById(R.id.entry);
         e.setText(StringEscapeUtils.unescapeHtml4(baseNode.getComment().getBody()));
 
         DoEditorActions.doActions(e, dialoglayout, fm, (Activity) mContext,
@@ -1505,7 +1497,7 @@ public class CommentAdapterHelper {
             Snackbar s =
                     Snackbar.make(contextView, R.string.msg_report_sent, Snackbar.LENGTH_SHORT);
             View view = s.getView();
-            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+            TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
             tv.setTextColor(Color.WHITE);
             s.show();
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -1248,34 +1248,29 @@ public class CommentAdapterHelper {
             titleString.append(pinned);
             titleString.append(" ");
         }
-        if (comment.getAuthorFlair() != null
-                && !comment.getAuthorFlair().getText().isEmpty()
-                && !comment.getAuthorFlair().getText().isEmpty()) {
+        if (comment.getAuthorFlair() != null)
+        {
+            String flairText;
+            if(comment.getAuthorFlair().getText() != null
+                    && !comment.getAuthorFlair().getText().isEmpty()) {
+                flairText = comment.getAuthorFlair().getText();
+            } else {
+                flairText = comment.getAuthorFlair().getCssClass();
+            }
+
             TypedValue typedValue = new TypedValue();
             Resources.Theme theme = mContext.getTheme();
             theme.resolveAttribute(R.attr.activity_background, typedValue, true);
             int color = typedValue.data;
             SpannableStringBuilder pinned = new SpannableStringBuilder(
-                    "\u00A0" + Html.fromHtml(comment.getAuthorFlair().getText()) + "\u00A0");
-            pinned.setSpan(
-                    new RoundedBackgroundSpan(holder.firstTextView.getCurrentTextColor(), color,
-                            false, mContext), 0, pinned.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            titleString.append(pinned);
-            titleString.append(" ");
-        } else if (comment.getAuthorFlair() != null
-                && !comment.getAuthorFlair().getText().isEmpty()) {
-            TypedValue typedValue = new TypedValue();
-            Resources.Theme theme = mContext.getTheme();
-            theme.resolveAttribute(R.attr.activity_background, typedValue, true);
-            int color = typedValue.data;
-            SpannableStringBuilder pinned = new SpannableStringBuilder(
-                    "\u00A0" + Html.fromHtml(comment.getAuthorFlair().getCssClass()) + "\u00A0");
+                    "\u00A0" + Html.fromHtml(flairText) + "\u00A0");
             pinned.setSpan(
                     new RoundedBackgroundSpan(holder.firstTextView.getCurrentTextColor(), color,
                             false, mContext), 0, pinned.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             titleString.append(pinned);
             titleString.append(" ");
         }
+
         if (adapter.removed.contains(comment.getFullName()) || (comment.getBannedBy() != null
                 && !adapter.approved.contains(comment.getFullName()))) {
             titleString.append(CommentAdapterHelper.createRemovedLine(


### PR DESCRIPTION
Resolves issue https://github.com/ccrama/Slide/issues/2699
Additionally it resolves [this reddit issue](https://www.reddit.com/r/slideforreddit/comments/885mil/v585alpha1_released_firefox_support_flair_fix_and/dwi61zu/) which I believe is the same issue with flairs.

Previously, the logic for checking if flair was null did this check

```
if (comment.getAuthorFlair() != null 
    && !comment.getAuthorFlair().getText().isEmpty() 
    && !comment.getAuthorFlair().getText().isEmpty())
```

This would allow a null pointer to get thrown since you'd be checking isEmpty on a potentially null value. I modified the check to see if getText is null before checking isEmpty as well as consolidated the code a bit.

As always, preview the two commits separately to see the functionality change without the cleanup in the way