### PR TITLE
Confirm with user before backing up / restoring from google drive

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Generic text used anywhere -->
+    <string name="general_confirm">Confirm</string>
     <string name="general_confirm_exit">Confirm exit</string>
     <string name="general_confirm_exit_msg">Do you really want to exit Slide?</string>
     <string name="general_enable_shadowbox">Shadowbox mode</string>
@@ -434,6 +435,8 @@
     <string name="backup_btn_restore">Restore</string>
     <string name="backup_btn_file">Backup to file</string>
     <string name="backup_btn_restore_file">Restore from file</string>
+    <string name="backup_confirm">Are you sure you want to backup? Your previous backup will over overwritten</string>
+    <string name="backup_restore_confirm">Are you sure you want to restore? Your current settings will over overwritten</string>
 
 
     <!-- Vote -->

--- a/app/src/withGPlay/java/me.ccrama.redditslide/Activities/SettingsBackup.java
+++ b/app/src/withGPlay/java/me.ccrama.redditslide/Activities/SettingsBackup.java
@@ -389,22 +389,39 @@ public class SettingsBackup extends BaseActivityAnim
                 @Override
                 public void onClick(View v) {
                     if (mGoogleApiClient.isConnected()) {
-                        File prefsdir = new File(getApplicationInfo().dataDir, "shared_prefs");
+                        new AlertDialogWrapper.Builder(SettingsBackup.this).setTitle(
+                                R.string.general_confirm)
+                                .setMessage(R.string.backup_confirm)
+                                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                                    @Override
+                                    public void onCancel(DialogInterface dialog) {
+                                    }
+                                })
+                                .setPositiveButton(R.string.btn_ok,
+                                        new DialogInterface.OnClickListener() {
+                                            public void onClick(DialogInterface dialog,
+                                                    int whichButton) {
+                                                File prefsdir = new File(getApplicationInfo().dataDir, "shared_prefs");
 
-                        if (prefsdir.exists() && prefsdir.isDirectory()) {
+                                                if (prefsdir.exists() && prefsdir.isDirectory()) {
 
-                            String[] list = prefsdir.list();
-                            progress = new MaterialDialog.Builder(SettingsBackup.this).title(
-                                    R.string.backup_backing_up)
-                                    .progress(false, list.length)
-                                    .cancelable(false)
-                                    .build();
-                            progress.show();
-                            appFolder.listChildren(mGoogleApiClient)
-                                    .setResultCallback(newCallback2);
+                                                    String[] list = prefsdir.list();
+                                                    progress = new MaterialDialog.Builder(
+                                                            SettingsBackup.this).title(
+                                                            R.string.backup_backing_up)
+                                                            .progress(false, list.length)
+                                                            .cancelable(false)
+                                                            .build();
+                                                    progress.show();
+                                                    appFolder.listChildren(mGoogleApiClient)
+                                                            .setResultCallback(newCallback2);
 
-                        }
-
+                                                }
+                                            }
+                                        })
+                                .setNegativeButton(R.string.btn_no, null)
+                                .setCancelable(false)
+                                .show();
                     } else {
                         new AlertDialogWrapper.Builder(SettingsBackup.this).setTitle(
                                 R.string.settings_google)
@@ -432,14 +449,31 @@ public class SettingsBackup extends BaseActivityAnim
                 @Override
                 public void onClick(View v) {
                     if (mGoogleApiClient.isConnected()) {
-                        progress = new MaterialDialog.Builder(SettingsBackup.this).title(
-                                R.string.backup_restoring)
-                                .content(R.string.misc_please_wait)
-                                .cancelable(false)
-                                .progress(true, 1)
-                                .build();
-                        progress.show();
-                        appFolder.listChildren(mGoogleApiClient).setResultCallback(newCallback);
+                        new AlertDialogWrapper.Builder(SettingsBackup.this).setTitle(
+                                R.string.general_confirm)
+                                .setMessage(R.string.backup_restore_confirm)
+                                .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                                    @Override
+                                    public void onCancel(DialogInterface dialog) {
+                                    }
+                                })
+                                .setPositiveButton(R.string.btn_ok,
+                                        new DialogInterface.OnClickListener() {
+                                            public void onClick(DialogInterface dialog,
+                                                    int whichButton) {
+                                                progress = new MaterialDialog.Builder(SettingsBackup.this).title(
+                                                        R.string.backup_restoring)
+                                                        .content(R.string.misc_please_wait)
+                                                        .cancelable(false)
+                                                        .progress(true, 1)
+                                                        .build();
+                                                progress.show();
+                                                appFolder.listChildren(mGoogleApiClient).setResultCallback(newCallback);
+                                            }
+                                        })
+                                .setNegativeButton(R.string.btn_no, null)
+                                .setCancelable(false)
+                                .show();
                     } else {
                         new AlertDialogWrapper.Builder(SettingsBackup.this).setTitle(
                                 R.string.settings_google)


### PR DESCRIPTION
Recently, I accidentally clicked "backup" on a new install of Slide so all my previous backed up settings were gone. This PR adds a dialog to have users confirm whether they want to backup/restore.

Let me know if you have any feedback/concerns/etc.