### PR TITLE
Guarantee opening an external browser from the internal browser

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -33,9 +33,9 @@ import me.ccrama.redditslide.PostMatch;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
-import me.ccrama.redditslide.Views.NestedWebView;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.AdBlocker;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 
 public class Website extends BaseActivityAnim {
@@ -147,6 +147,7 @@ public class Website extends BaseActivityAnim {
                 return true;
             case R.id.chrome:
                 Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(v.getUrl()));
+                browserIntent.setPackage(LinkUtil.getPackage(browserIntent));
                 startActivity(Intent.createChooser(browserIntent, getDomainName(v.getUrl())));
                 return true;
             case R.id.share:

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -79,6 +79,8 @@ import okhttp3.OkHttpClient;
  * Created by ccrama on 9/17/2015.
  */
 public class Reddit extends MultiDexApplication implements Application.ActivityLifecycleCallbacks {
+    private static Application mApplication;
+
     public static final String EMPTY_STRING = "NOTHING";
 
     public static final long   enter_animation_time_original = 600;
@@ -642,6 +644,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     @Override
     public void onCreate() {
         super.onCreate();
+        mApplication = this;
         //  LeakCanary.install(this);
         if (ProcessPhoenix.isPhoenixProcess(this)) {
             return;
@@ -990,5 +993,9 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
                 return Dns.SYSTEM.lookup(hostname);
             }
         }
+    }
+
+    public static Context getAppContext() {
+        return mApplication.getApplicationContext();
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -36,6 +36,7 @@ import me.ccrama.redditslide.Activities.ReaderMode;
 import me.ccrama.redditslide.Activities.Website;
 import me.ccrama.redditslide.BuildConfig;
 import me.ccrama.redditslide.R;
+import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionViews.PopulateSubmissionViewHolder;
 
@@ -279,5 +280,21 @@ public class LinkUtil {
     public static void crosspost(Submission submission, Activity mContext) {
         Crosspost.toCrosspost = submission;
         mContext.startActivity(new Intent(mContext, Crosspost.class));
+    }
+
+    public static String getPackage(Intent intent) {
+        String packageName = Reddit.getAppContext()
+                .getPackageManager()
+                .resolveActivity(intent,
+                        PackageManager.MATCH_DEFAULT_ONLY).activityInfo.packageName;
+        if (packageName.equals(Reddit.getAppContext().getPackageName())) {
+            // Gets the default app from a URL that is most likely never link handled by another app, hopefully guaranteeing a browser
+            return Reddit.getAppContext()
+                    .getPackageManager()
+                    .resolveActivity(
+                            new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.blank.org")),
+                            PackageManager.MATCH_DEFAULT_ONLY).activityInfo.packageName;
+        }
+        return packageName;
     }
 }


### PR DESCRIPTION
Partial fix on issue [from Reddit](https://www.reddit.com/r/slideforreddit/comments/8cn2ck/slide_locking_up_my_phone/)

When pressing the "open in external browser" button from the internal browser, the url is opened in the default link handler. On links like "https://www.reddit.com/gold/about", this will cause it to infinitely open back in the Slide app, since that's the default link handler, but that url can only be opened in a WebView.

In internal browsers, this is manageable. When Slide is set to open in an external browser, this would likely cause an infinite loop, locking the phone.

This fix only fixes the button in the internal browser now to get your opinion. I added an intent on a URL that will likely never be link handled. This guarantees the returned package is a browser, not another app (or Slide itself). This may not be desired behavior. I could convert it so if the package to be opened is Slide, we open in an external browser, otherwise, let it be link handled.
Whatever we decide, I can try to convert to the other ways Slide opens urls, to fix the infinite loop

Hopefully any of that makes sense.