### PR TITLE
Bugfix/prevent slide from opening itself

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
@@ -13,7 +13,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -99,7 +98,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
             finish();
         }
         if (id == R.id.external) {
-            LinkUtil.openExternally(url, this);
+            LinkUtil.openExternally(url);
         }
         if (id == R.id.download) {
             for (final Image elem : images) {
@@ -326,7 +325,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
 
             final PreCachingLayoutManager mLayoutManager;
             mLayoutManager = new PreCachingLayoutManager(getActivity());
-            recyclerView = (RecyclerView) rootView.findViewById(R.id.images);
+            recyclerView = rootView.findViewById(R.id.images);
             recyclerView.setLayoutManager(mLayoutManager);
             ((Album) getActivity()).url =
                     getActivity().getIntent().getExtras().getString(EXTRA_URL, "");
@@ -335,7 +334,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
 
             new LoadIntoRecycler(((Album) getActivity()).url, getActivity()).executeOnExecutor(
                     AsyncTask.THREAD_POOL_EXECUTOR);
-            ((Album) getActivity()).mToolbar = (Toolbar) rootView.findViewById(R.id.toolbar);
+            ((Album) getActivity()).mToolbar = rootView.findViewById(R.id.toolbar);
             ((Album) getActivity()).mToolbar.setTitle(R.string.type_album);
             ToolbarColorizeHelper.colorizeToolbar(((Album) getActivity()).mToolbar, Color.WHITE,
                     (getActivity()));

--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -115,7 +115,7 @@ public class AlbumPager extends FullScreenActivity
             mToolbar.findViewById(R.id.grid).callOnClick();
         }
         if (id == R.id.external) {
-            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""), this);
+            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""));
         }
 
         if (id == R.id.comments) {
@@ -252,7 +252,7 @@ public class AlbumPager extends FullScreenActivity
                     LayoutInflater l = getLayoutInflater();
                     View body = l.inflate(R.layout.album_grid_dialog, null, false);
                     AlertDialogWrapper.Builder b = new AlertDialogWrapper.Builder(AlbumPager.this);
-                    GridView gridview = (GridView) body.findViewById(R.id.images);
+                    GridView gridview = body.findViewById(R.id.images);
                     gridview.setAdapter(new ImageGridAdapter(AlbumPager.this, images));
 
 
@@ -386,7 +386,7 @@ public class AlbumPager extends FullScreenActivity
                 Bundle savedInstanceState) {
             rootView = (ViewGroup) inflater.inflate(R.layout.submission_gifcard_album, container,
                     false);
-            loader = (ProgressBar) rootView.findViewById(R.id.gifprogress);
+            loader = rootView.findViewById(R.id.gifprogress);
 
 
             gif = rootView.findViewById(R.id.gif);
@@ -459,7 +459,7 @@ public class AlbumPager extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(contentUrl, AlbumPager.this);
+                        LinkUtil.openExternally(contentUrl);
                     }
                     break;
                     case (3): {
@@ -594,7 +594,7 @@ public class AlbumPager extends FullScreenActivity
                         ((SpoilerRobotoTextView) rootView.findViewById(R.id.title)).setTypeface(
                                 typeface);
                     }
-                    final SlidingUpPanelLayout l = (SlidingUpPanelLayout) rootView.findViewById(R.id.sliding_layout);
+                    final SlidingUpPanelLayout l = rootView.findViewById(R.id.sliding_layout);
                     rootView.findViewById(R.id.title).setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
@@ -669,13 +669,12 @@ public class AlbumPager extends FullScreenActivity
     }
 
     private static void loadImage(final View rootView, Fragment f, String url, boolean single) {
-        final SubsamplingScaleImageView image =
-                (SubsamplingScaleImageView) rootView.findViewById(R.id.image);
+        final SubsamplingScaleImageView image = rootView.findViewById(R.id.image);
 
         image.setMinimumDpi(70);
         image.setMinimumTileDpi(240);
         ImageView fakeImage = new ImageView(f.getActivity());
-        final TextView size = (TextView) rootView.findViewById(R.id.size);
+        final TextView size = rootView.findViewById(R.id.size);
         fakeImage.setLayoutParams(
                 new LinearLayout.LayoutParams(image.getWidth(), image.getHeight()));
         fakeImage.setScaleType(ImageView.ScaleType.CENTER_CROP);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -269,7 +269,7 @@ public class MediaView extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(contentUrl, MediaView.this);
+                        LinkUtil.openExternally(contentUrl);
                         break;
                     }
                     case (3): {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsAbout.java
@@ -69,7 +69,7 @@ public class SettingsAbout extends BaseActivityAnim {
         report.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                LinkUtil.openExternally("https://github.com/ccrama/Slide/issues", SettingsAbout.this);
+                LinkUtil.openExternally("https://github.com/ccrama/Slide/issues");
             }
         });
         findViewById(R.id.sub).setOnClickListener(new View.OnClickListener() {
@@ -91,7 +91,7 @@ public class SettingsAbout extends BaseActivityAnim {
         changelog.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                LinkUtil.openExternally("https://github.com/ccrama/Slide/blob/master/CHANGELOG.md", SettingsAbout.this);
+                LinkUtil.openExternally("https://github.com/ccrama/Slide/blob/master/CHANGELOG.md");
             }
         });
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
@@ -13,7 +13,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -103,7 +102,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
             finish();
         }
         if (id == R.id.external) {
-            LinkUtil.openExternally(url, this);
+            LinkUtil.openExternally(url);
         }
         if (id == R.id.download) {
             for (final Photo elem : images) {
@@ -327,7 +326,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
 
             final PreCachingLayoutManager mLayoutManager;
             mLayoutManager = new PreCachingLayoutManager(getActivity());
-            recyclerView = (RecyclerView) rootView.findViewById(R.id.images);
+            recyclerView = rootView.findViewById(R.id.images);
             recyclerView.setLayoutManager(mLayoutManager);
             ((Tumblr) getActivity()).url =
                     getActivity().getIntent().getExtras().getString(EXTRA_URL, "");
@@ -336,7 +335,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
 
             new LoadIntoRecycler(((Tumblr) getActivity()).url, getActivity()).executeOnExecutor(
                     AsyncTask.THREAD_POOL_EXECUTOR);
-            ((Tumblr) getActivity()).mToolbar = (Toolbar) rootView.findViewById(R.id.toolbar);
+            ((Tumblr) getActivity()).mToolbar = rootView.findViewById(R.id.toolbar);
             ((Tumblr) getActivity()).mToolbar.setTitle(R.string.type_album);
             ToolbarColorizeHelper.colorizeToolbar(((Tumblr) getActivity()).mToolbar, Color.WHITE,
                     (getActivity()));

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -118,7 +118,7 @@ public class TumblrPager extends FullScreenActivity
             mToolbar.findViewById(R.id.grid).callOnClick();
         }
         if (id == R.id.external) {
-            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""), this);
+            LinkUtil.openExternally(getIntent().getExtras().getString("url", ""));
         }
 
         if (id == R.id.comments) {
@@ -221,7 +221,7 @@ public class TumblrPager extends FullScreenActivity
                     LayoutInflater l = getLayoutInflater();
                     View body = l.inflate(R.layout.album_grid_dialog, null, false);
                     AlertDialogWrapper.Builder b = new AlertDialogWrapper.Builder(TumblrPager.this);
-                    GridView gridview = (GridView) body.findViewById(R.id.images);
+                    GridView gridview = body.findViewById(R.id.images);
                     gridview.setAdapter(new ImageGridAdapterTumblr(TumblrPager.this, images));
 
 
@@ -365,7 +365,7 @@ public class TumblrPager extends FullScreenActivity
                 Bundle savedInstanceState) {
             rootView = (ViewGroup) inflater.inflate(R.layout.submission_gifcard_album, container,
                     false);
-            loader = (ProgressBar) rootView.findViewById(R.id.gifprogress);
+            loader = rootView.findViewById(R.id.gifprogress);
 
 
             gif = rootView.findViewById(R.id.gif);
@@ -438,7 +438,7 @@ public class TumblrPager extends FullScreenActivity
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
                     case (2): {
-                        LinkUtil.openExternally(contentUrl, TumblrPager.this);
+                        LinkUtil.openExternally(contentUrl);
                     }
                     break;
                     case (3): {
@@ -566,8 +566,7 @@ public class TumblrPager extends FullScreenActivity
                     }
                     ((SpoilerRobotoTextView) rootView.findViewById(R.id.title)).setTypeface(typeface);
                 }
-                final SlidingUpPanelLayout l =
-                        (SlidingUpPanelLayout) rootView.findViewById(R.id.sliding_layout);
+                final SlidingUpPanelLayout l = rootView.findViewById(R.id.sliding_layout);
                 rootView.findViewById(R.id.title).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -640,12 +639,11 @@ public class TumblrPager extends FullScreenActivity
     }
 
     private static void loadImage(final View rootView, Fragment f, String url) {
-        final SubsamplingScaleImageView image =
-                (SubsamplingScaleImageView) rootView.findViewById(R.id.image);
+        final SubsamplingScaleImageView image = rootView.findViewById(R.id.image);
         image.setMinimumDpi(70);
         image.setMinimumTileDpi(240);
         ImageView fakeImage = new ImageView(f.getActivity());
-        final TextView size = (TextView) rootView.findViewById(R.id.size);
+        final TextView size = rootView.findViewById(R.id.size);
         fakeImage.setLayoutParams(
                 new LinearLayout.LayoutParams(image.getWidth(), image.getHeight()));
         fakeImage.setScaleType(ImageView.ScaleType.CENTER_CROP);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -1,6 +1,7 @@
 package me.ccrama.redditslide.Activities;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
@@ -33,7 +34,6 @@ import me.ccrama.redditslide.PostMatch;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
-import me.ccrama.redditslide.Views.NestedWebView;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.AdBlocker;
 import me.ccrama.redditslide.util.LogUtil;
@@ -147,6 +147,10 @@ public class Website extends BaseActivityAnim {
                 return true;
             case R.id.chrome:
                 Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(v.getUrl()));
+                // Gets the default app from a URL that is most likely never link handled by another app, hopefully guaranteeing a browser
+                browserIntent.setPackage(getPackageManager().resolveActivity(
+                        new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.blank.org")),
+                        PackageManager.MATCH_DEFAULT_ONLY).activityInfo.packageName);
                 startActivity(Intent.createChooser(browserIntent, getDomainName(v.getUrl())));
                 return true;
             case R.id.share:

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -146,9 +146,7 @@ public class Website extends BaseActivityAnim {
                         });
                 return true;
             case R.id.chrome:
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(v.getUrl()));
-                browserIntent.setPackage(LinkUtil.getPackage(browserIntent));
-                startActivity(Intent.createChooser(browserIntent, getDomainName(v.getUrl())));
+                LinkUtil.openExternally(v.getUrl());
                 return true;
             case R.id.share:
                 Reddit.defaultShareText(v.getTitle(), v.getUrl(), Website.this);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/AlbumView.java
@@ -57,7 +57,7 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                     LayoutInflater l = context.getLayoutInflater();
                     View body = l.inflate(R.layout.album_grid_dialog, null, false);
                     AlertDialogWrapper.Builder b = new AlertDialogWrapper.Builder(context);
-                    GridView gridview = (GridView) body.findViewById(R.id.images);
+                    GridView gridview = body.findViewById(R.id.images);
                     gridview.setAdapter(new ImageGridAdapter(context, users));
 
 
@@ -182,7 +182,7 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         myIntent.putExtra(MediaView.SUBREDDIT, subreddit);
                         main.startActivity(myIntent);
                     } else {
-                        LinkUtil.openExternally(user.getImageUrl(), main);
+                        LinkUtil.openExternally(user.getImageUrl());
                     }
                 }
             };
@@ -234,9 +234,9 @@ public class AlbumView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
         public AlbumViewHolder(View itemView) {
             super(itemView);
-            text = (SpoilerRobotoTextView) itemView.findViewById(R.id.imagetitle);
-            body = (SpoilerRobotoTextView) itemView.findViewById(R.id.imageCaption);
-            image = (ImageView) itemView.findViewById(R.id.image);
+            text = itemView.findViewById(R.id.imagetitle);
+            body = itemView.findViewById(R.id.imageCaption);
+            image = itemView.findViewById(R.id.image);
 
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/GalleryView.java
@@ -167,7 +167,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                             public void onClick(DialogInterface dialog, int which) {
                                 switch (which) {
                                     case R.id.open_link:
-                                        LinkUtil.openExternally(submission.getUrl(), main);
+                                        LinkUtil.openExternally(submission.getUrl());
                                         break;
                                     case R.id.share_link:
                                         Reddit.defaultShareText("", submission.getUrl(), main);
@@ -198,7 +198,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                     myIntent.putExtra(MediaView.EXTRA_URL, submission.getUrl());
                                     main.startActivity(myIntent);
                                 } else {
-                                    LinkUtil.openExternally(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl());
                                 }
                                 break;
                             case IMGUR:
@@ -213,7 +213,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    LinkUtil.openExternally(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl());
                                 }
                                 break;
                             case REDDIT:
@@ -236,7 +236,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    LinkUtil.openExternally(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl());
 
                                 }
                                 break;
@@ -254,7 +254,7 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(i);
                                     }
                                 } else {
-                                    LinkUtil.openExternally(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl());
 
                                 }
                                 break;
@@ -280,15 +280,15 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                                         main.startActivity(sharingIntent);
 
                                     } catch (Exception e) {
-                                        LinkUtil.openExternally(submission.getUrl(), main);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                 } else {
-                                    LinkUtil.openExternally(submission.getUrl(), main);
+                                    LinkUtil.openExternally(submission.getUrl());
                                 }
                                 break;
                         }
                     } else {
-                        LinkUtil.openExternally(submission.getUrl(), main);
+                        LinkUtil.openExternally(submission.getUrl());
                     }
                 }
             });
@@ -315,8 +315,8 @@ public class GalleryView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         public AlbumViewHolder(View itemView) {
             super(itemView);
             comments = itemView.findViewById(R.id.comments);
-            image = (ImageView) itemView.findViewById(R.id.image);
-            type = (ImageView) itemView.findViewById(R.id.type);
+            image = itemView.findViewById(R.id.image);
+            type = itemView.findViewById(R.id.type);
         }
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/TumblrView.java
@@ -60,7 +60,7 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                     LayoutInflater l = context.getLayoutInflater();
                     View body = l.inflate(R.layout.album_grid_dialog, null, false);
                     AlertDialogWrapper.Builder b = new AlertDialogWrapper.Builder(context);
-                    GridView gridview = (GridView) body.findViewById(R.id.images);
+                    GridView gridview = body.findViewById(R.id.images);
                     gridview.setAdapter(new ImageGridAdapterTumblr(context, users));
 
 
@@ -173,7 +173,7 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         myIntent.putExtra(MediaView.EXTRA_URL, user.getOriginalSize().getUrl());
                         main.startActivity(myIntent);
                     } else {
-                        LinkUtil.openExternally(user.getOriginalSize().getUrl(), main);
+                        LinkUtil.openExternally(user.getOriginalSize().getUrl());
                     }
                 }
             };
@@ -229,9 +229,9 @@ public class TumblrView extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
         public AlbumViewHolder(View itemView) {
             super(itemView);
-            text = (SpoilerRobotoTextView) itemView.findViewById(R.id.imagetitle);
-            body = (SpoilerRobotoTextView) itemView.findViewById(R.id.imageCaption);
-            image = (ImageView) itemView.findViewById(R.id.image);
+            text = itemView.findViewById(R.id.imagetitle);
+            body = itemView.findViewById(R.id.imageCaption);
+            image = itemView.findViewById(R.id.image);
 
 
         }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -309,17 +309,17 @@ public class CommentPage extends Fragment {
         LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
         v = localInflater.inflate(R.layout.fragment_verticalcontenttoolbar, container, false);
 
-        rv = (RecyclerView) v.findViewById(R.id.vertical_content);
+        rv = v.findViewById(R.id.vertical_content);
         rv.setLayoutManager(mLayoutManager);
         rv.getLayoutManager().scrollToPosition(0);
 
-        toolbar = (Toolbar) v.findViewById(R.id.toolbar);
+        toolbar = v.findViewById(R.id.toolbar);
         toolbar.setPopupTheme(new ColorPreferences(getActivity()).getFontStyle().getBaseId());
 
         if (!SettingValues.fabComments) {
             v.findViewById(R.id.comment_floating_action_button).setVisibility(View.GONE);
         } else {
-            fab = (FloatingActionButton) v.findViewById(R.id.comment_floating_action_button);
+            fab = v.findViewById(R.id.comment_floating_action_button);
             if (SettingValues.fastscroll) {
                 FrameLayout.LayoutParams fabs = (FrameLayout.LayoutParams) fab.getLayoutParams();
                 fabs.setMargins(fabs.leftMargin, fabs.topMargin, fabs.rightMargin,
@@ -335,7 +335,7 @@ public class CommentPage extends Fragment {
                     final AlertDialogWrapper.Builder builder =
                             new AlertDialogWrapper.Builder(getActivity());
 
-                    final EditText e = (EditText) dialoglayout.findViewById(R.id.entry);
+                    final EditText e = dialoglayout.findViewById(R.id.entry);
 
                     //Tint the replyLine appropriately if the base theme is Light or Sepia
                     if (SettingValues.currentTheme == 1 || SettingValues.currentTheme == 5) {
@@ -477,12 +477,10 @@ public class CommentPage extends Fragment {
                                                         new AlertDialogWrapper.Builder(
                                                                 getActivity());
                                                 final Slider landscape =
-                                                        (Slider) dialoglayout.findViewById(
-                                                                R.id.landscape);
+                                                        dialoglayout.findViewById(R.id.landscape);
 
                                                 final TextView since =
-                                                        (TextView) dialoglayout.findViewById(
-                                                                R.id.time_string);
+                                                        dialoglayout.findViewById(R.id.time_string);
                                                 landscape.setValueRange(60, 18000, false);
                                                 landscape.setOnPositionChangeListener(
                                                         new Slider.OnPositionChangeListener() {
@@ -617,8 +615,7 @@ public class CommentPage extends Fragment {
 
         toolbar.setBackgroundColor(Palette.getColor(subreddit));
 
-        mSwipeRefreshLayout =
-                (SwipeRefreshLayout) v.findViewById(R.id.activity_main_swipe_refresh_layout);
+        mSwipeRefreshLayout = v.findViewById(R.id.activity_main_swipe_refresh_layout);
         mSwipeRefreshLayout.setColorSchemeColors(Palette.getColors(subreddit, getActivity()));
 
         mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
@@ -784,8 +781,7 @@ public class CommentPage extends Fragment {
                                             getActivity().startActivity(myIntent);
 
                                         } else {
-                                            LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                    getActivity());
+                                            LinkUtil.openExternally(adapter.submission.getUrl());
                                         }
                                         break;
                                     case IMGUR:
@@ -827,8 +823,7 @@ public class CommentPage extends Fragment {
                                                 getActivity().startActivity(i);
                                             }
                                         } else {
-                                            LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                    getActivity());
+                                            LinkUtil.openExternally(adapter.submission.getUrl());
                                         }
                                         break;
                                     case REDDIT:
@@ -848,7 +843,7 @@ public class CommentPage extends Fragment {
                                                     Snackbar.make(rv, R.string.submission_nocontent,
                                                             Snackbar.LENGTH_SHORT);
                                             View view = s.getView();
-                                            TextView tv = (TextView) view.findViewById(
+                                            TextView tv = view.findViewById(
                                                     android.support.design.R.id.snackbar_text);
                                             tv.setTextColor(Color.WHITE);
                                             s.show();
@@ -894,8 +889,7 @@ public class CommentPage extends Fragment {
                                                         R.anim.slideright, R.anim.fade_out);
                                             }
                                         } else {
-                                            LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                    getActivity());
+                                            LinkUtil.openExternally(adapter.submission.getUrl());
 
                                         }
                                         break;
@@ -920,8 +914,7 @@ public class CommentPage extends Fragment {
                                                         R.anim.slideright, R.anim.fade_out);
                                             }
                                         } else {
-                                            LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                    getActivity());
+                                            LinkUtil.openExternally(adapter.submission.getUrl());
 
                                         }
                                         break;
@@ -948,17 +941,16 @@ public class CommentPage extends Fragment {
                                                 getActivity().startActivity(sharingIntent);
 
                                             } catch (Exception e) {
-                                                LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                        getActivity());
+                                                LinkUtil.openExternally(
+                                                        adapter.submission.getUrl());
                                             }
                                         } else {
-                                            LinkUtil.openExternally(adapter.submission.getUrl(),
-                                                    getActivity());
+                                            LinkUtil.openExternally(adapter.submission.getUrl());
                                         }
 
                                 }
                             } else {
-                                LinkUtil.openExternally(adapter.submission.getUrl(), getActivity());
+                                LinkUtil.openExternally(adapter.submission.getUrl());
                             }
                         }
                     }
@@ -1227,9 +1219,8 @@ public class CommentPage extends Fragment {
                             final String text =
                                     baseSub.getDataNode().get("description_html").asText();
                             final SpoilerRobotoTextView body =
-                                    (SpoilerRobotoTextView) sidebar.findViewById(R.id.sidebar_text);
-                            CommentOverflow overflow =
-                                    (CommentOverflow) sidebar.findViewById(R.id.commentOverflow);
+                                    sidebar.findViewById(R.id.sidebar_text);
+                            CommentOverflow overflow = sidebar.findViewById(R.id.commentOverflow);
                             setViews(text, baseSub.getDisplayName(), body, overflow);
                         } else {
                             sidebar.findViewById(R.id.sidebar_text).setVisibility(View.GONE);
@@ -1363,8 +1354,7 @@ public class CommentPage extends Fragment {
                         }
 
                         {
-                            final TextView subscribe =
-                                    (TextView) sidebar.findViewById(R.id.subscribe);
+                            final TextView subscribe = sidebar.findViewById(R.id.subscribe);
 
                             currentlySubbed = (!Authentication.isLoggedIn
                                     && UserSubscriptions.getSubscriptions(getActivity())
@@ -1418,7 +1408,7 @@ public class CommentPage extends Fragment {
                                                                                                             s.getView();
                                                                                                     TextView
                                                                                                             tv =
-                                                                                                            (TextView) view
+                                                                                                            view
                                                                                                                     .findViewById(
                                                                                                                             android.support.design.R.id.snackbar_text);
                                                                                                     tv.setTextColor(
@@ -1476,9 +1466,8 @@ public class CommentPage extends Fragment {
                                                                         R.string.sub_added,
                                                                         Snackbar.LENGTH_SHORT);
                                                                 View view = s.getView();
-                                                                TextView tv =
-                                                                        (TextView) view.findViewById(
-                                                                                android.support.design.R.id.snackbar_text);
+                                                                TextView tv = view.findViewById(
+                                                                        android.support.design.R.id.snackbar_text);
                                                                 tv.setTextColor(Color.WHITE);
                                                                 s.show();
                                                             }
@@ -1545,7 +1534,7 @@ public class CommentPage extends Fragment {
                                                                                                             s.getView();
                                                                                                     TextView
                                                                                                             tv =
-                                                                                                            (TextView) view
+                                                                                                            view
                                                                                                                     .findViewById(
                                                                                                                             android.support.design.R.id.snackbar_text);
                                                                                                     tv.setTextColor(
@@ -1602,9 +1591,8 @@ public class CommentPage extends Fragment {
                                                                         R.string.misc_unsubscribed,
                                                                         Snackbar.LENGTH_SHORT);
                                                                 View view = s.getView();
-                                                                TextView tv =
-                                                                        (TextView) view.findViewById(
-                                                                                android.support.design.R.id.snackbar_text);
+                                                                TextView tv = view.findViewById(
+                                                                        android.support.design.R.id.snackbar_text);
                                                                 tv.setTextColor(Color.WHITE);
                                                                 s.show();
                                                             }
@@ -2257,7 +2245,7 @@ public class CommentPage extends Fragment {
         Snackbar s = Snackbar.make(toolbar, isChecked ? getString(R.string.misc_subscribed)
                 : getString(R.string.misc_unsubscribed), Snackbar.LENGTH_SHORT);
         View view = s.getView();
-        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+        TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
         tv.setTextColor(Color.WHITE);
         s.show();
     }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
@@ -146,11 +146,10 @@ public class MediaFragment extends Fragment {
 
         (rootView.findViewById(R.id.thumbimage2)).setVisibility(View.GONE);
 
-        ImageView typeImage = (ImageView) rootView.findViewById(R.id.type);
+        ImageView typeImage = rootView.findViewById(R.id.type);
         typeImage.setVisibility(View.VISIBLE);
         SubsamplingScaleImageView img = rootView.findViewById(R.id.submission_image);
-        final SlidingUpPanelLayout slideLayout =
-                ((SlidingUpPanelLayout) rootView.findViewById(R.id.sliding_layout));
+        final SlidingUpPanelLayout slideLayout = rootView.findViewById(R.id.sliding_layout);
         ContentType.Type type = ContentType.getContentType(s);
 
         if (type == ContentType.Type.VREDDIT_REDIRECT || type == ContentType.Type.VREDDIT_DIRECT) {
@@ -348,13 +347,13 @@ public class MediaFragment extends Fragment {
                                 contextActivity.startActivity(myIntent);
 
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
 
                         case EMBEDDED:
 
                             if (SettingValues.video) {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                                 String data = submission.getDataNode()
                                         .get("media_embed")
                                         .get("content")
@@ -365,7 +364,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
                             break;
                         case REDDIT:
@@ -398,7 +397,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
                             break;
                         case TUMBLR:
@@ -416,7 +415,7 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(i);
                                 }
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
                             break;
                         case DEVIANTART:
@@ -441,10 +440,10 @@ public class MediaFragment extends Fragment {
                                     contextActivity.startActivity(sharingIntent);
 
                                 } catch (Exception e) {
-                                    LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                    LinkUtil.openExternally(submission.getUrl());
                                 }
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
                     }
                 }
@@ -454,11 +453,11 @@ public class MediaFragment extends Fragment {
 
     public void doLoadGif(final Submission s) {
         isGif = true;
-        videoView = (MediaVideoView) rootView.findViewById(R.id.gif);
+        videoView = rootView.findViewById(R.id.gif);
         videoView.clearFocus();
         rootView.findViewById(R.id.gifarea).setVisibility(View.VISIBLE);
         rootView.findViewById(R.id.submission_image).setVisibility(View.GONE);
-        final ProgressBar loader = (ProgressBar) rootView.findViewById(R.id.gifprogress);
+        final ProgressBar loader = rootView.findViewById(R.id.gifprogress);
         gif = new GifUtils.AsyncLoadGif(getActivity(),
                 (MediaVideoView) rootView.findViewById(R.id.gif), loader,
                 rootView.findViewById(R.id.placeholder), false, false,
@@ -527,11 +526,11 @@ public class MediaFragment extends Fragment {
 
     public void doLoadGifDirect(final String s) {
         isGif = true;
-        videoView = (MediaVideoView) rootView.findViewById(R.id.gif);
+        videoView = rootView.findViewById(R.id.gif);
         videoView.clearFocus();
         rootView.findViewById(R.id.gifarea).setVisibility(View.VISIBLE);
         rootView.findViewById(R.id.submission_image).setVisibility(View.GONE);
-        final ProgressBar loader = (ProgressBar) rootView.findViewById(R.id.gifprogress);
+        final ProgressBar loader = rootView.findViewById(R.id.gifprogress);
         gif = new GifUtils.AsyncLoadGif(getActivity(),
                 (MediaVideoView) rootView.findViewById(R.id.gif), loader,
                 rootView.findViewById(R.id.placeholder), false, false,
@@ -802,12 +801,11 @@ public class MediaFragment extends Fragment {
 
         if (!imageShown) {
             actuallyLoaded = url;
-            final SubsamplingScaleImageView i =
-                    (SubsamplingScaleImageView) rootView.findViewById(R.id.submission_image);
+            final SubsamplingScaleImageView i = rootView.findViewById(R.id.submission_image);
 
             i.setMinimumDpi(70);
             i.setMinimumTileDpi(240);
-            final ProgressBar bar = (ProgressBar) rootView.findViewById(R.id.progress);
+            final ProgressBar bar = rootView.findViewById(R.id.progress);
             bar.setIndeterminate(false);
             LogUtil.v("Displaying image " + url);
             bar.setProgress(0);

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
@@ -123,8 +123,7 @@ public class MediaFragmentComment extends Fragment {
         if (savedInstanceState != null && savedInstanceState.containsKey("position")) {
             stopPosition = savedInstanceState.getLong("position");
         }
-        final SlidingUpPanelLayout slideLayout =
-                ((SlidingUpPanelLayout) rootView.findViewById(R.id.sliding_layout));
+        final SlidingUpPanelLayout slideLayout = rootView.findViewById(R.id.sliding_layout);
 
         PopulateShadowboxInfo.doActionbar(s.comment, rootView, getActivity(), true);
         (rootView.findViewById(R.id.thumbimage2)).setVisibility(View.GONE);
@@ -319,7 +318,7 @@ public class MediaFragmentComment extends Fragment {
 
                                 contextActivity.startActivity(myIntent);
                             } else {
-                                LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                LinkUtil.openExternally(submission.getUrl());
                             }
 
                             break;
@@ -332,11 +331,11 @@ public class MediaFragmentComment extends Fragment {
 
     public void doLoadGif(final String dat) {
         isGif = true;
-        videoView = (MediaVideoView) rootView.findViewById(R.id.gif);
+        videoView = rootView.findViewById(R.id.gif);
         videoView.clearFocus();
         rootView.findViewById(R.id.gifarea).setVisibility(View.VISIBLE);
         rootView.findViewById(R.id.submission_image).setVisibility(View.GONE);
-        final ProgressBar loader = (ProgressBar) rootView.findViewById(R.id.gifprogress);
+        final ProgressBar loader = rootView.findViewById(R.id.gifprogress);
         rootView.findViewById(R.id.progress).setVisibility(View.GONE);
         gif = new GifUtils.AsyncLoadGif(getActivity(),
                 (MediaVideoView) rootView.findViewById(R.id.gif), loader,
@@ -537,12 +536,11 @@ public class MediaFragmentComment extends Fragment {
     public void displayImage(final String url) {
         if (!imageShown) {
             actuallyLoaded = url;
-            final SubsamplingScaleImageView i =
-                    (SubsamplingScaleImageView) rootView.findViewById(R.id.submission_image);
+            final SubsamplingScaleImageView i = rootView.findViewById(R.id.submission_image);
 
             i.setMinimumDpi(70);
             i.setMinimumTileDpi(240);
-            final ProgressBar bar = (ProgressBar) rootView.findViewById(R.id.progress);
+            final ProgressBar bar = rootView.findViewById(R.id.progress);
             bar.setIndeterminate(false);
             bar.setProgress(0);
 

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -39,7 +39,7 @@ public class OpenRedditLink {
         LogUtil.v("Link is " + url);
         url = formatRedditUrl(url);
         if (url.isEmpty()) {
-            LinkUtil.openExternally(oldUrl, context);
+            LinkUtil.openExternally(oldUrl);
             return false;
         } else if (url.startsWith("np")) {
             np = true;

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -49,17 +49,13 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import me.ccrama.redditslide.Activities.Album;
 import me.ccrama.redditslide.Activities.AlbumPager;
-import me.ccrama.redditslide.Activities.CommentsScreenSingle;
 import me.ccrama.redditslide.Activities.MediaView;
 import me.ccrama.redditslide.Activities.TumblrPager;
 import me.ccrama.redditslide.ForceTouch.PeekView;
@@ -420,7 +416,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                         intent2.putExtra(MediaView.SUBREDDIT, subreddit);
                         activity.startActivity(intent2);
                     } else {
-                        LinkUtil.openExternally(url, activity);
+                        LinkUtil.openExternally(url);
                     }
                     break;
                 case REDDIT:
@@ -450,7 +446,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(i);
                         }
                     } else {
-                        LinkUtil.openExternally(url, activity);
+                        LinkUtil.openExternally(url);
                     }
                     break;
                 case TUMBLR:
@@ -465,7 +461,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(i);
                         }
                     } else {
-                        LinkUtil.openExternally(url, activity);
+                        LinkUtil.openExternally(url);
                     }
                     break;
                 case IMAGE:
@@ -490,21 +486,21 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                             activity.startActivity(sharingIntent);
 
                         } catch (Exception e) {
-                            LinkUtil.openExternally(url, activity);
+                            LinkUtil.openExternally(url);
                         }
                     } else {
-                        LinkUtil.openExternally(url, activity);
+                        LinkUtil.openExternally(url);
                     }
                 case SPOILER:
                     spoilerClicked = true;
                     setOrRemoveSpoilerSpans(xOffset, span);
                     break;
                 case EXTERNAL:
-                    LinkUtil.openExternally(url, activity);
+                    LinkUtil.openExternally(url);
                     break;
             }
         } else {
-            LinkUtil.openExternally(url, context);
+            LinkUtil.openExternally(url);
         }
     }
 
@@ -546,7 +542,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                     @Override
                     public void onInflated(final PeekView peekView, final View rootView) {
                         //do stuff
-                        TextView text = ((TextView) rootView.findViewById(R.id.title));
+                        TextView text = rootView.findViewById(R.id.title);
                         text.setText(url);
                         text.setTextColor(Color.WHITE);
                         ((PeekMediaView) rootView.findViewById(R.id.peek)).setUrl(url);
@@ -588,7 +584,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                         peekView.addButton((R.id.external), new OnButtonUp() {
                             @Override
                             public void onButtonUp() {
-                                LinkUtil.openExternally(url, context);
+                                LinkUtil.openExternally(url);
                             }
                         });
                         peekView.setOnPop(new OnPop() {
@@ -627,7 +623,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                     public void onClick(DialogInterface dialog, int which) {
                         switch (which) {
                             case R.id.open_link:
-                                LinkUtil.openExternally(url, context);
+                                LinkUtil.openExternally(url);
                                 break;
                             case R.id.share_link:
                                 Reddit.defaultShareText("", url, finalActivity);
@@ -659,7 +655,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
                 getContext().startActivity(myIntent);
             }
         } else {
-            LinkUtil.openExternally(url, getContext());
+            LinkUtil.openExternally(url);
         }
     }
 
@@ -672,7 +668,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
             getContext().startActivity(myIntent);
 
         } else {
-            LinkUtil.openExternally(url, getContext());
+            LinkUtil.openExternally(url);
         }
     }
 
@@ -683,7 +679,7 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
             myIntent.putExtra(MediaView.SUBREDDIT, subreddit);
             getContext().startActivity(myIntent);
         } else {
-            LinkUtil.openExternally(submission, getContext());
+            LinkUtil.openExternally(submission);
         }
 
     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/HeaderImageLinkView.java
@@ -479,7 +479,7 @@ public class HeaderImageLinkView extends RelativeLayout {
 
 
             if (SettingValues.smallTag && !full && !news) {
-                title = (TextView) findViewById(R.id.tag);
+                title = findViewById(R.id.tag);
                 findViewById(R.id.tag).setVisibility(View.VISIBLE);
                 info = null;
             } else {
@@ -548,7 +548,7 @@ public class HeaderImageLinkView extends RelativeLayout {
                     @Override
                     public void onInflated(final PeekView peekView, final View rootView) {
                         //do stuff
-                        TextView text = ((TextView) rootView.findViewById(R.id.title));
+                        TextView text = rootView.findViewById(R.id.title);
                         text.setText(url);
                         text.setTextColor(Color.WHITE);
                         ((PeekMediaView) rootView.findViewById(R.id.peek)).setUrl(url);
@@ -619,7 +619,7 @@ public class HeaderImageLinkView extends RelativeLayout {
                     public void onClick(DialogInterface dialog, int which) {
                         switch (which) {
                             case R.id.open_link:
-                                LinkUtil.openExternally(url, context);
+                                LinkUtil.openExternally(url);
                                 break;
                             case R.id.share_link:
                                 Reddit.defaultShareText("", url, finalActivity);
@@ -762,8 +762,8 @@ public class HeaderImageLinkView extends RelativeLayout {
 
     private void init() {
         inflate(getContext(), R.layout.header_image_title_view, this);
-        this.title = (TextView) findViewById(R.id.textimage);
-        this.info = (TextView) findViewById(R.id.subtextimage);
-        this.backdrop = (ImageView) findViewById(R.id.leadimage);
+        this.title = findViewById(R.id.textimage);
+        this.info = findViewById(R.id.subtextimage);
+        this.backdrop = findViewById(R.id.leadimage);
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
@@ -136,7 +136,7 @@ public class PopulateNewsViewHolder {
                                         myIntent.putExtra(MediaView.EXTRA_URL, submission.getUrl());
                                         contextActivity.startActivity(myIntent);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                                 case IMGUR:
@@ -156,7 +156,7 @@ public class PopulateNewsViewHolder {
                                             contextActivity.startActivity(i);
                                         }
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                                 case REDDIT:
@@ -194,7 +194,7 @@ public class PopulateNewsViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
 
                                     }
                                     break;
@@ -218,7 +218,7 @@ public class PopulateNewsViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
 
                                     }
                                     break;
@@ -248,16 +248,15 @@ public class PopulateNewsViewHolder {
                                             contextActivity.startActivity(sharingIntent);
 
                                         } catch (Exception e) {
-                                            LinkUtil.openExternally(submission.getUrl(),
-                                                    contextActivity);
+                                            LinkUtil.openExternally(submission.getUrl());
                                         }
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                             }
                         } else {
-                            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                            LinkUtil.openExternally(submission.getUrl());
                         }
                     }
                 } else {
@@ -267,7 +266,7 @@ public class PopulateNewsViewHolder {
                         Snackbar s = Snackbar.make(holder.itemView, R.string.go_online_view_content,
                                 Snackbar.LENGTH_SHORT);
                         View view = s.getView();
-                        TextView tv = (TextView) view.findViewById(
+                        TextView tv = view.findViewById(
                                 android.support.design.R.id.snackbar_text);
                         tv.setTextColor(Color.WHITE);
                         s.show();
@@ -325,7 +324,7 @@ public class PopulateNewsViewHolder {
             contextActivity.startActivity(myIntent);
 
         } else {
-            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl());
         }
 
     }
@@ -409,7 +408,7 @@ public class PopulateNewsViewHolder {
             addAdaptorPosition(myIntent, submission, adapterPosition);
             contextActivity.startActivity(myIntent);
         } else {
-            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl());
         }
 
     }
@@ -592,7 +591,6 @@ public class PopulateNewsViewHolder {
                                     mContext.getString(R.string.filter_posts_flair, flair, baseSub)
                             };
                         }
-                        ;
                         chosen = new boolean[]{
                                 Arrays.asList(
                                         SettingValues.subredditFilters.toLowerCase(Locale.ENGLISH)
@@ -795,7 +793,7 @@ public class PopulateNewsViewHolder {
                     }
                     break;
                     case 7:
-                        LinkUtil.openExternally(submission.getUrl(), mContext);
+                        LinkUtil.openExternally(submission.getUrl());
                         if (submission.isNsfw() && !SettingValues.storeNSFWHistory) {
                             //Do nothing if the post is NSFW and storeNSFWHistory is not enabled
                         } else if (SettingValues.storeHistory) {
@@ -808,7 +806,7 @@ public class PopulateNewsViewHolder {
                             Snackbar s = Snackbar.make(holder.itemView, "Added to read later!",
                                     Snackbar.LENGTH_SHORT);
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(
+                            TextView tv = view.findViewById(
                                     android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.setAction(R.string.btn_undo, new View.OnClickListener() {
@@ -818,7 +816,7 @@ public class PopulateNewsViewHolder {
                                     Snackbar s2 = Snackbar.make(holder.itemView,
                                             "Removed from read later", Snackbar.LENGTH_SHORT);
                                     View view2 = s2.getView();
-                                    TextView tv2 = (TextView) view2.findViewById(
+                                    TextView tv2 = view2.findViewById(
                                             android.support.design.R.id.snackbar_text);
                                     tv2.setTextColor(Color.WHITE);
                                     s2.show();
@@ -844,7 +842,7 @@ public class PopulateNewsViewHolder {
                                         Snackbar.make(holder.itemView, "Removed from read later",
                                                 Snackbar.LENGTH_SHORT);
                                 View view2 = s2.getView();
-                                TextView tv2 = (TextView) view2.findViewById(
+                                TextView tv2 = view2.findViewById(
                                         android.support.design.R.id.snackbar_text);
                                 tv2.setTextColor(Color.WHITE);
                                 s2.setAction(R.string.btn_undo, new View.OnClickListener() {
@@ -859,7 +857,7 @@ public class PopulateNewsViewHolder {
                                         Snackbar.make(holder.itemView, "Removed from read later",
                                                 Snackbar.LENGTH_SHORT);
                                 View view2 = s2.getView();
-                                TextView tv2 = (TextView) view2.findViewById(
+                                TextView tv2 = view2.findViewById(
                                         android.support.design.R.id.snackbar_text);
                                 s2.show();
                             }
@@ -915,7 +913,7 @@ public class PopulateNewsViewHolder {
                                                                 R.string.msg_report_sent,
                                                                 Snackbar.LENGTH_SHORT);
                                                         View view = s.getView();
-                                                        TextView tv = (TextView) view.findViewById(
+                                                        TextView tv = view.findViewById(
                                                                 android.support.design.R.id.snackbar_text);
                                                         tv.setTextColor(Color.WHITE);
                                                         s.show();
@@ -1032,8 +1030,7 @@ public class PopulateNewsViewHolder {
                 Snackbar snack = Snackbar.make(recyclerview, R.string.submission_info_unhidden,
                         Snackbar.LENGTH_LONG);
                 View view = snack.getView();
-                TextView tv =
-                        (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                 tv.setTextColor(Color.WHITE);
                 snack.show();
             } else {
@@ -1072,8 +1069,7 @@ public class PopulateNewsViewHolder {
                             }
                         });
                 View view = snack.getView();
-                TextView tv =
-                        (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                 tv.setTextColor(Color.WHITE);
                 snack.show();
             }
@@ -1136,7 +1132,7 @@ public class PopulateNewsViewHolder {
                                 + "%)" : "";
 
         if (!scoreRatio.isEmpty()) {
-            TextView percent = ((TextView) holder.itemView.findViewById(R.id.percent));
+            TextView percent = holder.itemView.findViewById(R.id.percent);
             percent.setVisibility(View.VISIBLE);
             percent.setText(scoreRatio);
 
@@ -1162,7 +1158,7 @@ public class PopulateNewsViewHolder {
 
         //Save the score so we can use it in the OnClickListeners for the vote buttons
 
-        ImageView thumbImage2 = ((ImageView) holder.thumbnail);
+        ImageView thumbImage2 = holder.thumbnail;
 
         if (holder.leadImage.thumbImage2 == null) {
             holder.leadImage.setThumbnail(thumbImage2);
@@ -1194,8 +1190,7 @@ public class PopulateNewsViewHolder {
                             Snackbar.make(holder.itemView, mContext.getString(R.string.offline_msg),
                                     Snackbar.LENGTH_SHORT);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateShadowboxInfo.java
@@ -62,8 +62,8 @@ import me.ccrama.redditslide.util.LinkUtil;
  */
 public class PopulateShadowboxInfo {
     public static void doActionbar(final Submission s, final View rootView, final Activity c, boolean extras) {
-        TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView desc = (TextView) rootView.findViewById(R.id.desc);
+        TextView title = rootView.findViewById(R.id.title);
+        TextView desc = rootView.findViewById(R.id.desc);
         String distingush = "";
         if(s != null) {
             if (s.getDistinguishedStatus() == DistinguishedStatus.MODERATOR)
@@ -95,8 +95,8 @@ public class PopulateShadowboxInfo {
             ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
 
             if (extras) {
-                final ImageView downvotebutton = (ImageView) rootView.findViewById(R.id.downvote);
-                final ImageView upvotebutton = (ImageView) rootView.findViewById(R.id.upvote);
+                final ImageView downvotebutton = rootView.findViewById(R.id.downvote);
+                final ImageView upvotebutton = rootView.findViewById(R.id.upvote);
 
                 if (s.isArchived() || s.isLocked()) {
                     downvotebutton.setVisibility(View.GONE);
@@ -185,8 +185,8 @@ public class PopulateShadowboxInfo {
                     rootView.findViewById(R.id.save).setVisibility(View.GONE);
                 }
                 try {
-                    final TextView points = ((TextView) rootView.findViewById(R.id.score));
-                    final TextView comments = ((TextView) rootView.findViewById(R.id.comments));
+                    final TextView points = rootView.findViewById(R.id.score);
+                    final TextView comments = rootView.findViewById(R.id.comments);
                     if (Authentication.isLoggedIn && Authentication.didOnline) {
                         {
 
@@ -275,8 +275,8 @@ public class PopulateShadowboxInfo {
 
     public static void doActionbar(final CommentNode node, final View rootView, final Activity c, boolean extras) {
         final Comment s = node.getComment();
-        TitleTextView title = (TitleTextView) rootView.findViewById(R.id.title);
-        TextView desc = (TextView) rootView.findViewById(R.id.desc);
+        TitleTextView title = rootView.findViewById(R.id.title);
+        TextView desc = rootView.findViewById(R.id.desc);
         String distingush = "";
         if(s != null) {
             if (s.getDistinguishedStatus() == DistinguishedStatus.MODERATOR)
@@ -320,8 +320,8 @@ public class PopulateShadowboxInfo {
             ((TextView) rootView.findViewById(R.id.score)).setText(String.format(Locale.getDefault(), "%d", s.getScore()));
 
             if (extras) {
-                final ImageView downvotebutton = (ImageView) rootView.findViewById(R.id.downvote);
-                final ImageView upvotebutton = (ImageView) rootView.findViewById(R.id.upvote);
+                final ImageView downvotebutton = rootView.findViewById(R.id.downvote);
+                final ImageView upvotebutton = rootView.findViewById(R.id.upvote);
 
                 if (s.isArchived()) {
                     downvotebutton.setVisibility(View.GONE);
@@ -410,8 +410,8 @@ public class PopulateShadowboxInfo {
                     rootView.findViewById(R.id.save).setVisibility(View.GONE);
                 }
                 try {
-                    final TextView points = ((TextView) rootView.findViewById(R.id.score));
-                    final TextView comments = ((TextView) rootView.findViewById(R.id.comments));
+                    final TextView points = rootView.findViewById(R.id.score);
+                    final TextView comments = rootView.findViewById(R.id.comments);
                     if (Authentication.isLoggedIn && Authentication.didOnline) {
                         {
 
@@ -537,7 +537,7 @@ public class PopulateShadowboxInfo {
                             }
                             break;
                             case 7:
-                                LinkUtil.openExternally(submission.getUrl(), mContext);
+                                LinkUtil.openExternally(submission.getUrl());
                                 break;
                             case 4:
                                 Reddit.defaultShareText(submission.getTitle(), submission.getUrl(), mContext);
@@ -575,7 +575,8 @@ public class PopulateShadowboxInfo {
                                                     protected void onPostExecute(Void aVoid) {
                                                         Snackbar s = Snackbar.make(rootView, R.string.msg_report_sent, Snackbar.LENGTH_SHORT);
                                                         View view = s.getView();
-                                                        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                                                        TextView tv = view.findViewById(
+                                                                android.support.design.R.id.snackbar_text);
                                                         tv.setTextColor(Color.WHITE);
                                                         s.show();
                                                     }

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -166,8 +166,7 @@ public class PopulateSubmissionViewHolder {
                                                 holder.getAdapterPosition());
                                         contextActivity.startActivity(myIntent);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(),
-                                                contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                                 case IMGUR:
@@ -187,8 +186,7 @@ public class PopulateSubmissionViewHolder {
                                             contextActivity.startActivity(i);
                                         }
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(),
-                                                contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                                 case REDDIT:
@@ -226,8 +224,7 @@ public class PopulateSubmissionViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(),
-                                                contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
 
                                     }
                                     break;
@@ -251,8 +248,7 @@ public class PopulateSubmissionViewHolder {
                                         contextActivity.overridePendingTransition(R.anim.slideright,
                                                 R.anim.fade_out);
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(),
-                                                contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
 
                                     }
                                     break;
@@ -284,17 +280,15 @@ public class PopulateSubmissionViewHolder {
                                             contextActivity.startActivity(sharingIntent);
 
                                         } catch (Exception e) {
-                                            LinkUtil.openExternally(submission.getUrl(),
-                                                    contextActivity);
+                                            LinkUtil.openExternally(submission.getUrl());
                                         }
                                     } else {
-                                        LinkUtil.openExternally(submission.getUrl(),
-                                                contextActivity);
+                                        LinkUtil.openExternally(submission.getUrl());
                                     }
                                     break;
                             }
                         } else {
-                            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+                            LinkUtil.openExternally(submission.getUrl());
                         }
                     }
                 } else {
@@ -362,7 +356,7 @@ public class PopulateSubmissionViewHolder {
             contextActivity.startActivity(myIntent);
 
         } else {
-            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl());
         }
 
     }
@@ -475,7 +469,7 @@ public class PopulateSubmissionViewHolder {
             addAdaptorPosition(myIntent, submission, adapterPosition);
             contextActivity.startActivity(myIntent);
         } else {
-            LinkUtil.openExternally(submission.getUrl(), contextActivity);
+            LinkUtil.openExternally(submission.getUrl());
         }
 
     }
@@ -867,7 +861,7 @@ public class PopulateSubmissionViewHolder {
                     }
                     break;
                     case 7:
-                        LinkUtil.openExternally(submission.getUrl(), mContext);
+                        LinkUtil.openExternally(submission.getUrl());
                         if (submission.isNsfw() && !SettingValues.storeNSFWHistory) {
                             //Do nothing if the post is NSFW and storeNSFWHistory is not enabled
                         } else if (SettingValues.storeHistory) {

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -34,7 +34,6 @@ import me.ccrama.redditslide.Activities.Crosspost;
 import me.ccrama.redditslide.Activities.MakeExternal;
 import me.ccrama.redditslide.Activities.ReaderMode;
 import me.ccrama.redditslide.Activities.Website;
-import me.ccrama.redditslide.BuildConfig;
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
@@ -100,7 +99,7 @@ public class LinkUtil {
                     formatURL(StringEscapeUtils.unescapeHtml4(url)));
         } catch (ActivityNotFoundException anfe) {
             Log.w(LogUtil.getTag(), "Unknown url: " + anfe);
-            openExternally(url, contextActivity);
+            openExternally(url);
         }
     }
 
@@ -108,7 +107,7 @@ public class LinkUtil {
             int adapterPosition, Submission submission) {
         if (!SettingValues.web) {
             // External browser
-            openExternally(url, contextActivity);
+            openExternally(url);
             return;
         }
 
@@ -187,7 +186,7 @@ public class LinkUtil {
     public static void openUrl(@NonNull String url, int color, @NonNull Activity contextActivity) {
         if (!SettingValues.web) {
             // External browser
-            openExternally(url, contextActivity);
+            openExternally(url);
             return;
         }
 
@@ -227,31 +226,17 @@ public class LinkUtil {
      * Opens the {@code uri} externally or shows an application chooser if it is set to open in this
      * application
      *
-     * @param uri     URI to open
-     * @param context Current context
+     * @param url     URL to open
      */
-    public static void openExternally(String url, Context context) {
+    public static void openExternally(String url) {
         url = StringEscapeUtils.unescapeHtml4(Html.fromHtml(url).toString());
         Uri uri = formatURL(url);
 
-        final String id = BuildConfig.APPLICATION_ID;
         final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        final PackageManager packageManager = context.getPackageManager();
-        String resolvedName;
-        try {
-            resolvedName = intent.resolveActivity(packageManager).getPackageName();
-        } catch (Exception e) {
-            resolvedName = context.getPackageName();
-        }
-        if (resolvedName == null) return;
-
-        if (resolvedName.matches(id)) {
-            context.startActivity(
-                    Intent.createChooser(intent, context.getString(R.string.misc_link_chooser)));
-            return;
-        }
-
-        context.startActivity(intent);
+        intent.setPackage(getPackage(intent));
+        Reddit.getAppContext()
+                .startActivity(Intent.createChooser(intent,
+                        Reddit.getAppContext().getString(R.string.misc_link_chooser)));
     }
 
     public static CustomTabsSession getSession() {


### PR DESCRIPTION
This is the addition on the internal browser link handling.
This will prevent the app from attempting to open itself when clicking a link, causing an infinite loop of attempting to open itself.

This change did three things:

- Gets the package from the new helper method (I do not know what those try catches were doing?)
- Uses static application context in the LinkUtil.openExternally method (we were already affecting everything anyways, so yolo)
- Use the LinkUtil.openExternally method when clicking to open externally from the internal browser