### PR TITLE
Added all dark themes to Night Mode options

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -62,6 +62,7 @@ import android.text.Editable;
 import android.text.Spannable;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -178,7 +179,6 @@ import me.ccrama.redditslide.util.NetworkUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
 
-import static android.content.pm.PackageManager.MATCH_ALL;
 import static me.ccrama.redditslide.UserSubscriptions.modOf;
 
 
@@ -619,195 +619,32 @@ public class MainActivity extends BaseActivity
                 if (SettingValues.isNight()) {
                     dialoglayout.findViewById(R.id.nightmsg).setVisibility(View.VISIBLE);
                 }
-                dialoglayout.findViewById(R.id.black)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 2) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
+
+                for (final Pair<Integer, Integer> pair : ColorPreferences.themePairList) {
+                    dialoglayout.findViewById(pair.first)
+                            .setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    String[] names =
+                                            new ColorPreferences(MainActivity.this).getFontStyle()
+                                                    .getTitle()
+                                                    .split("_");
+                                    String name = names[names.length - 1];
+                                    final String newName = name.replace("(", "");
+                                    for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
+                                        if (theme.toString().contains(newName)
+                                                && theme.getThemeType() == pair.second) {
+                                            back = theme.getThemeType();
+                                            new ColorPreferences(MainActivity.this).setFontStyle(
+                                                    theme);
+                                            d.dismiss();
+                                            restartTheme();
+                                            break;
+                                        }
                                     }
                                 }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.blacklighter)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 4) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.deep)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 8) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.sepia)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 5) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.pixel)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 7) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.red).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        String[] names = new ColorPreferences(MainActivity.this).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 6) {
-                                back = theme.getThemeType();
-                                new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                d.dismiss();
-                                restartTheme();
-                                break;
-                            }
-                        }
-                    }
-                });
-                dialoglayout.findViewById(R.id.light)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                String[] names =
-                                        new ColorPreferences(MainActivity.this).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 1) {
-                                        new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                        back = theme.getThemeType();
-                                        d.dismiss();
-                                        restartTheme();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.dark).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        String[] names = new ColorPreferences(MainActivity.this).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 0) {
-                                new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                back = theme.getThemeType();
-                                d.dismiss();
-                                restartTheme();
-                                break;
-                            }
-                        }
-                    }
-                });
-                dialoglayout.findViewById(R.id.blue).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        String[] names = new ColorPreferences(MainActivity.this).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 3) {
-                                new ColorPreferences(MainActivity.this).setFontStyle(theme);
-                                back = theme.getThemeType();
-                                d.dismiss();
-                                restartTheme();
-                                break;
-                            }
-                        }
-                    }
-                });
+                            });
+                }
             }
             return true;
             case R.id.action_refresh:

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tutorial.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tutorial.java
@@ -11,6 +11,7 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -58,7 +59,7 @@ public class Tutorial extends AppCompatActivity {
 
 
         // Instantiate a ViewPager and a PagerAdapter.
-        mPager = (ViewPager) findViewById(R.id.vp);
+        mPager = findViewById(R.id.vp);
         /*
       The pager adapter, which provides the pages to the view pager widget.
      */
@@ -142,12 +143,12 @@ public class Tutorial extends AppCompatActivity {
                     LayoutInflater inflater = getActivity().getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.choosemain, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getContext());
-                    final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                    final TextView title = dialoglayout.findViewById(R.id.title);
                     title.setBackgroundColor(Palette.getDefaultColor());
 
 
-                    LineColorPicker colorPicker = (LineColorPicker) dialoglayout.findViewById(R.id.picker);
-                    final LineColorPicker colorPicker2 = (LineColorPicker) dialoglayout.findViewById(R.id.picker2);
+                    LineColorPicker colorPicker = dialoglayout.findViewById(R.id.picker);
+                    final LineColorPicker colorPicker2 = dialoglayout.findViewById(R.id.picker2);
 
                     colorPicker.setColors(ColorPreferences.getBaseColors(getContext()));
                     int currentColor = Palette.getDefaultColor();
@@ -215,15 +216,16 @@ public class Tutorial extends AppCompatActivity {
                     LayoutInflater inflater = getActivity().getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.chooseaccent, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
-                    final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                    final TextView title = dialoglayout.findViewById(R.id.title);
                     title.setBackgroundColor(Palette.getDefaultColor());
 
-                    final LineColorPicker colorPicker = (LineColorPicker) dialoglayout.findViewById(R.id.picker3);
+                    final LineColorPicker colorPicker = dialoglayout.findViewById(R.id.picker3);
 
                     int[] arrs = new int[ColorPreferences.getNumColorsFromThemeType(0)];
                     int i = 0;
                     for (ColorPreferences.Theme type : ColorPreferences.Theme.values()) {
-                        if (type.getThemeType() == 0) {
+                        if (type.getThemeType()
+                                == ColorPreferences.ColorThemeOptions.Dark.getValue()) {
                             arrs[i] = ContextCompat.getColor(getActivity(), type.getColor());
 
                             i++;
@@ -273,259 +275,44 @@ public class Tutorial extends AppCompatActivity {
                     LayoutInflater inflater = getActivity().getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.choosethemesmall, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
-                    final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                    final TextView title = dialoglayout.findViewById(R.id.title);
                     title.setBackgroundColor(Palette.getDefaultColor());
 
-                    dialoglayout.findViewById(R.id.black).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 2) {
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
+                    for (final Pair<Integer, Integer> pair : ColorPreferences.themePairList) {
+                        dialoglayout.findViewById(pair.first)
+                                .setOnClickListener(new View.OnClickListener() {
+                                    @Override
+                                    public void onClick(View v) {
+                                        String[] names =
+                                                new ColorPreferences(getActivity()).getFontStyle()
+                                                        .getTitle()
+                                                        .split("_");
+                                        String name = names[names.length - 1];
+                                        final String newName = name.replace("(", "");
+                                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
+                                            if (theme.toString().contains(newName)
+                                                    && theme.getThemeType() == pair.second) {
+                                                ((Tutorial) getActivity()).back =
+                                                        theme.getThemeType();
+                                                new ColorPreferences(getActivity()).setFontStyle(
+                                                        theme);
 
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
+                                                Intent i =
+                                                        new Intent(getActivity(), Tutorial.class);
+                                                i.putExtra("page", 1);
+                                                i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                                                startActivity(i);
+                                                getActivity().overridePendingTransition(0, 0);
 
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
+                                                getActivity().finish();
+                                                getActivity().overridePendingTransition(0, 0);
 
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.light).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 1) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.dark).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 0) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.blacklighter).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 4) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.deep).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 8) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.pixel).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 7) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.sepia).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 5) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.pixel).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 7) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-
-                    dialoglayout.findViewById(R.id.red).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 6) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                    dialoglayout.findViewById(R.id.blue).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            String[] names = new ColorPreferences(getActivity()).getFontStyle().getTitle().split("_");
-                            String name = names[names.length - 1];
-                            final String newName = name.replace("(", "");
-                            for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                if (theme.toString().contains(newName) && theme.getThemeType() == 3) {
-                                    new ColorPreferences(getActivity()).setFontStyle(theme);
-                                    ((Tutorial)getActivity()).back = theme.getThemeType();
-
-                                    Intent i = new Intent(getActivity(), Tutorial.class);
-                                    i.putExtra("page", 1);
-                                    i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                                    startActivity(i);
-                                    getActivity().overridePendingTransition(0, 0);
-
-                                    getActivity().finish();
-                                    getActivity().overridePendingTransition(0, 0);
-                                    break;
-                                }
-                            }
-                        }
-                    });
+                                                break;
+                                            }
+                                        }
+                                    }
+                                });
+                    }
 
                     builder.setView(dialoglayout);
                     builder.show();

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SettingsSubAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SettingsSubAdapter.java
@@ -1,7 +1,6 @@
 package me.ccrama.redditslide.Adapters;
 
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.PorterDuff;
@@ -12,7 +11,6 @@ import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
@@ -54,8 +52,7 @@ public class SettingsSubAdapter extends RecyclerView.Adapter<SettingsSubAdapter.
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
         View convertView = holder.itemView;
-        final TextView t =
-                ((TextView) convertView.findViewById(R.id.name));
+        final TextView t = convertView.findViewById(R.id.name);
         t.setText(objects.get(position));
 
         final String subreddit = objects.get(position);
@@ -132,8 +129,8 @@ public class SettingsSubAdapter extends RecyclerView.Adapter<SettingsSubAdapter.
 
         final ColorPreferences colorPrefs = new ColorPreferences(context);
         final String subreddit = multipleSubs ? null : subreddits.get(0);
-        final SwitchCompat bigPics = (SwitchCompat) dialoglayout.findViewById(R.id.bigpics);
-        final SwitchCompat selftext = (SwitchCompat) dialoglayout.findViewById(R.id.selftext);
+        final SwitchCompat bigPics = dialoglayout.findViewById(R.id.bigpics);
+        final SwitchCompat selftext = dialoglayout.findViewById(R.id.selftext);
 
         //Selected multiple subreddits
         if (multipleSubs) {
@@ -186,7 +183,7 @@ public class SettingsSubAdapter extends RecyclerView.Adapter<SettingsSubAdapter.
 
         AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(context);
 
-        final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+        final TextView title = dialoglayout.findViewById(R.id.title);
         title.setBackgroundColor(currentColor);
 
         if (multipleSubs) {
@@ -218,9 +215,10 @@ public class SettingsSubAdapter extends RecyclerView.Adapter<SettingsSubAdapter.
 
         {
             //Primary color pickers
-            final LineColorPicker colorPickerPrimary = (LineColorPicker) dialoglayout.findViewById(R.id.picker);
+            final LineColorPicker colorPickerPrimary = dialoglayout.findViewById(R.id.picker);
             //shades of primary colors
-            final LineColorPicker colorPickerPrimaryShades = (LineColorPicker) dialoglayout.findViewById(R.id.picker2);
+            final LineColorPicker colorPickerPrimaryShades =
+                    dialoglayout.findViewById(R.id.picker2);
 
             colorPickerPrimary.setColors(ColorPreferences.getBaseColors(context));
 
@@ -302,14 +300,14 @@ public class SettingsSubAdapter extends RecyclerView.Adapter<SettingsSubAdapter.
             }
 
             //Accent color picker
-            final LineColorPicker colorPickerAcc = (LineColorPicker) dialoglayout.findViewById(R.id.picker3);
+            final LineColorPicker colorPickerAcc = dialoglayout.findViewById(R.id.picker3);
 
             {
                 //Get all possible accent colors (for day theme)
                 int[] arrs = new int[ColorPreferences.getNumColorsFromThemeType(0)];
                 int i = 0;
                 for (ColorPreferences.Theme type : ColorPreferences.Theme.values()) {
-                    if (type.getThemeType() == 0) {
+                    if (type.getThemeType() == ColorPreferences.ColorThemeOptions.Dark.getValue()) {
                         arrs[i] = ContextCompat.getColor(context, type.getColor());
                         i++;
                     }

--- a/app/src/main/java/me/ccrama/redditslide/ColorPreferences.java
+++ b/app/src/main/java/me/ccrama/redditslide/ColorPreferences.java
@@ -4,9 +4,13 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
+import android.util.Pair;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 import me.ccrama.redditslide.Activities.Slide;
@@ -625,130 +629,207 @@ public class ColorPreferences {
     }
 
     public enum Theme {
-        dark_white(R.style.white_dark, "dark_white", R.color.md_blue_grey_200, 0),
-        light_white(R.style.white_light, "light_white", R.color.md_blue_grey_200, 1),
-        amoled_white(R.style.white_amoled, "amoled_white", R.color.md_blue_grey_200, 2),
-        blue_white(R.style.white_blue, "blue_white", R.color.md_blue_grey_200, 3),
-        amoled_light_white(R.style.white_AMOLED_lighter, "amoled_light_white", R.color.md_blue_grey_200, 4),
+        dark_white(R.style.white_dark, "dark_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.Dark.getValue()), light_white(R.style.white_light, "light_white",
+                R.color.md_blue_grey_200, ColorThemeOptions.Light.getValue()), amoled_white(
+                R.style.white_amoled, "amoled_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.AMOLED.getValue()), blue_white(R.style.white_blue, "blue_white",
+                R.color.md_blue_grey_200,
+                ColorThemeOptions.DarkBlue.getValue()), amoled_light_white(
+                R.style.white_AMOLED_lighter, "amoled_light_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_pink(R.style.pink_dark, "dark_pink", R.color.md_pink_A200, 0),
-        light_pink(R.style.pink_light, "light_pink", R.color.md_pink_A200, 1),
-        amoled_pink(R.style.pink_amoled, "amoled_pink", R.color.md_pink_A200, 2),
-        blue_pink(R.style.pink_blue, "blue_pink", R.color.md_pink_A200, 3),
-        amoled_light_pink(R.style.pink_AMOLED_lighter, "amoled_light_pink", R.color.md_pink_A200, 4),
+        dark_pink(R.style.pink_dark, "dark_pink", R.color.md_pink_A200,
+                ColorThemeOptions.Dark.getValue()), light_pink(R.style.pink_light, "light_pink",
+                R.color.md_pink_A200, ColorThemeOptions.Light.getValue()), amoled_pink(
+                R.style.pink_amoled, "amoled_pink", R.color.md_pink_A200,
+                ColorThemeOptions.AMOLED.getValue()), blue_pink(R.style.pink_blue, "blue_pink",
+                R.color.md_pink_A200, ColorThemeOptions.DarkBlue.getValue()), amoled_light_pink(
+                R.style.pink_AMOLED_lighter, "amoled_light_pink", R.color.md_pink_A200,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_deeporange(R.style.deeporange_dark, "dark_deeporange", R.color.md_deep_orange_A400, 0),
-        light_deeporange(R.style.deeporange_LIGHT, "light_deeporange", R.color.md_deep_orange_A400, 1),
-        amoled_deeporange(R.style.deeporange_AMOLED, "amoled_deeporange", R.color.md_deep_orange_A400, 2),
-        blue_deeporange(R.style.deeporange_blue, "blue_deeporange", R.color.md_deep_orange_A400, 3),
-        amoled_light_deeporange(R.style.deeporange_AMOLED_lighter, "amoled_light_deeporange", R.color.md_deep_orange_A400, 4),
+        dark_deeporange(R.style.deeporange_dark, "dark_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.Dark.getValue()), light_deeporange(R.style.deeporange_LIGHT,
+                "light_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.Light.getValue()), amoled_deeporange(R.style.deeporange_AMOLED,
+                "amoled_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_deeporange(R.style.deeporange_blue,
+                "blue_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.DarkBlue.getValue()), amoled_light_deeporange(
+                R.style.deeporange_AMOLED_lighter, "amoled_light_deeporange",
+                R.color.md_deep_orange_A400, ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_amber(R.style.amber_dark, "dark_amber", R.color.md_amber_A400, 0),
-        light_amber(R.style.amber_LIGHT, "light_amber", R.color.md_amber_A400, 1),
-        amoled_amber(R.style.amber_AMOLED, "amoled_amber", R.color.md_amber_A400, 2),
-        blue_amber(R.style.amber_blue, "blue_amber", R.color.md_amber_A400, 3),
-        amoled_light_amber(R.style.amber_AMOLED_lighter, "amoled_light_amber", R.color.md_amber_A400, 4),
+        dark_amber(R.style.amber_dark, "dark_amber", R.color.md_amber_A400,
+                ColorThemeOptions.Dark.getValue()), light_amber(R.style.amber_LIGHT, "light_amber",
+                R.color.md_amber_A400, ColorThemeOptions.Light.getValue()), amoled_amber(
+                R.style.amber_AMOLED, "amoled_amber", R.color.md_amber_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_amber(R.style.amber_blue, "blue_amber",
+                R.color.md_amber_A400, ColorThemeOptions.DarkBlue.getValue()), amoled_light_amber(
+                R.style.amber_AMOLED_lighter, "amoled_light_amber", R.color.md_amber_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_yellow(R.style.yellow_dark, "dark_yellow", R.color.md_yellow_A400, 0),
-        light_yellow(R.style.yellow_LIGHT, "light_yellow", R.color.md_yellow_A400, 1),
-        amoled_yellow(R.style.yellow_AMOLED, "amoled_yellow", R.color.md_yellow_A400, 2),
-        blue_yellow(R.style.yellow_blue, "blue_yellow", R.color.md_yellow_A400, 3),
-        amoled_light_yellow(R.style.yellow_AMOLED_lighter, "amoled_light_yellow", R.color.md_yellow_A400, 4),
+        dark_yellow(R.style.yellow_dark, "dark_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.Dark.getValue()), light_yellow(R.style.yellow_LIGHT,
+                "light_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.Light.getValue()), amoled_yellow(R.style.yellow_AMOLED,
+                "amoled_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_yellow(R.style.yellow_blue,
+                "blue_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.DarkBlue.getValue()), amoled_light_yellow(
+                R.style.yellow_AMOLED_lighter, "amoled_light_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_lime(R.style.lime_dark, "dark_lime", R.color.md_lime_A400, 0),
-        light_lime(R.style.lime_LIGHT, "light_lime", R.color.md_lime_A400, 1),
-        amoled_lime(R.style.lime_AMOLED, "amoled_lime", R.color.md_lime_A400, 2),
-        blue_lime(R.style.lime_blue, "blue_lime", R.color.md_lime_A400, 3),
-        amoled_light_lime(R.style.lime_AMOLED_lighter, "amoled_light_lime", R.color.md_lime_A400, 4),
+        dark_lime(R.style.lime_dark, "dark_lime", R.color.md_lime_A400,
+                ColorThemeOptions.Dark.getValue()), light_lime(R.style.lime_LIGHT, "light_lime",
+                R.color.md_lime_A400, ColorThemeOptions.Light.getValue()), amoled_lime(
+                R.style.lime_AMOLED, "amoled_lime", R.color.md_lime_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_lime(R.style.lime_blue, "blue_lime",
+                R.color.md_lime_A400, ColorThemeOptions.DarkBlue.getValue()), amoled_light_lime(
+                R.style.lime_AMOLED_lighter, "amoled_light_lime", R.color.md_lime_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_green(R.style.green_dark, "dark_green", R.color.md_green_A400, 0),
-        light_green(R.style.green_LIGHT, "light_green", R.color.md_green_A400, 1),
-        amoled_green(R.style.green_AMOLED, "amoled_green", R.color.md_green_A400, 2),
-        blue_green(R.style.green_blue, "blue_green", R.color.md_green_A400, 3),
-        amoled_light_green(R.style.green_AMOLED_lighter, "amoled_light_green", R.color.md_green_A400, 4),
+        dark_green(R.style.green_dark, "dark_green", R.color.md_green_A400,
+                ColorThemeOptions.Dark.getValue()), light_green(R.style.green_LIGHT, "light_green",
+                R.color.md_green_A400, ColorThemeOptions.Light.getValue()), amoled_green(
+                R.style.green_AMOLED, "amoled_green", R.color.md_green_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_green(R.style.green_blue, "blue_green",
+                R.color.md_green_A400, ColorThemeOptions.DarkBlue.getValue()), amoled_light_green(
+                R.style.green_AMOLED_lighter, "amoled_light_green", R.color.md_green_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_teal(R.style.teal_dark, "dark_teal", R.color.md_teal_A700, 0),
-        light_teal(R.style.teal_light, "light_teal", R.color.md_teal_A700, 1),
-        amoled_teal(R.style.teal_amoled, "amoled_teal", R.color.md_teal_A700, 2),
-        blue_teal(R.style.teal_blue, "blue_teal", R.color.md_teal_A700, 3),
-        amoled_light_teal(R.style.teal_AMOLED_lighter, "amoled_light_teal", R.color.md_teal_A700, 4),
+        dark_teal(R.style.teal_dark, "dark_teal", R.color.md_teal_A700,
+                ColorThemeOptions.Dark.getValue()), light_teal(R.style.teal_light, "light_teal",
+                R.color.md_teal_A700, ColorThemeOptions.Light.getValue()), amoled_teal(
+                R.style.teal_amoled, "amoled_teal", R.color.md_teal_A700,
+                ColorThemeOptions.AMOLED.getValue()), blue_teal(R.style.teal_blue, "blue_teal",
+                R.color.md_teal_A700, ColorThemeOptions.DarkBlue.getValue()), amoled_light_teal(
+                R.style.teal_AMOLED_lighter, "amoled_light_teal", R.color.md_teal_A700,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_cyan(R.style.cyan_dark, "dark_cyan", R.color.md_cyan_A400, 0),
-        light_cyan(R.style.cyan_LIGHT, "light_cyan", R.color.md_cyan_A400, 1),
-        amoled_cyan(R.style.cyan_AMOLED, "amoled_cyan", R.color.md_cyan_A400, 2),
-        blue_cyan(R.style.cyan_blue, "blue_cyan", R.color.md_cyan_A400, 3),
-        amoled_light_cyan(R.style.cyan_AMOLED_lighter, "amoled_light_cyan", R.color.md_cyan_A400, 4),
+        dark_cyan(R.style.cyan_dark, "dark_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.Dark.getValue()), light_cyan(R.style.cyan_LIGHT, "light_cyan",
+                R.color.md_cyan_A400, ColorThemeOptions.Light.getValue()), amoled_cyan(
+                R.style.cyan_AMOLED, "amoled_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_cyan(R.style.cyan_blue, "blue_cyan",
+                R.color.md_cyan_A400, ColorThemeOptions.DarkBlue.getValue()), amoled_light_cyan(
+                R.style.cyan_AMOLED_lighter, "amoled_light_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_lightblue(R.style.lightblue_dark, "dark_lightblue", R.color.md_light_blue_A400, 0),
-        light_lightblue(R.style.lightblue_LIGHT, "light_lightblue", R.color.md_light_blue_A400, 1),
-        amoled_lightblue(R.style.lightblue_AMOLED, "amoled_lightblue", R.color.md_light_blue_A400, 2),
-        blue_lightblue(R.style.lightblue_blue, "blue_lightblue", R.color.md_light_blue_A400, 3),
-        amoled_light_lightblue(R.style.lightblue_AMOLED_lighter, "amoled_light_lightblue", R.color.md_light_blue_A400, 4),
+        dark_lightblue(R.style.lightblue_dark, "dark_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.Dark.getValue()), light_lightblue(R.style.lightblue_LIGHT,
+                "light_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.Light.getValue()), amoled_lightblue(R.style.lightblue_AMOLED,
+                "amoled_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_lightblue(R.style.lightblue_blue,
+                "blue_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.DarkBlue.getValue()), amoled_light_lightblue(
+                R.style.lightblue_AMOLED_lighter, "amoled_light_lightblue",
+                R.color.md_light_blue_A400, ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_blue(R.style.blue_dark, "dark_blue", R.color.md_blue_A400, 0),
-        light_blue(R.style.blue_LIGHT, "light_blue", R.color.md_blue_A400, 1),
-        amoled_blue(R.style.blue_AMOLED, "amoled_blue", R.color.md_blue_A400, 2),
-        blue_blue(R.style.blue_blue, "blue_blue", R.color.md_blue_A400, 3),
-        amoled_light_blue(R.style.blue_AMOLED_lighter, "amoled_light_blue", R.color.md_blue_A400, 4),
+        dark_blue(R.style.blue_dark, "dark_blue", R.color.md_blue_A400,
+                ColorThemeOptions.Dark.getValue()), light_blue(R.style.blue_LIGHT, "light_blue",
+                R.color.md_blue_A400, ColorThemeOptions.Light.getValue()), amoled_blue(
+                R.style.blue_AMOLED, "amoled_blue", R.color.md_blue_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_blue(R.style.blue_blue, "blue_blue",
+                R.color.md_blue_A400, ColorThemeOptions.DarkBlue.getValue()), amoled_light_blue(
+                R.style.blue_AMOLED_lighter, "amoled_light_blue", R.color.md_blue_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
-        dark_indigo(R.style.indigo_dark, "dark_indigo", R.color.md_indigo_A400, 0),
-        light_indigo(R.style.indigo_LIGHT, "light_indigo", R.color.md_indigo_A400, 1),
-        amoled_indigo(R.style.indigo_AMOLED, "amoled_indigo", R.color.md_indigo_A400, 2),
-        blue_indigo(R.style.indigo_blue, "blue_indigo", R.color.md_indigo_A400, 3),
-        amoled_light_indigo(R.style.indigo_AMOLED_lighter, "amoled_light_indigo", R.color.md_indigo_A400, 4),
+        dark_indigo(R.style.indigo_dark, "dark_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.Dark.getValue()), light_indigo(R.style.indigo_LIGHT,
+                "light_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.Light.getValue()), amoled_indigo(R.style.indigo_AMOLED,
+                "amoled_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.AMOLED.getValue()), blue_indigo(R.style.indigo_blue,
+                "blue_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.DarkBlue.getValue()), amoled_light_indigo(
+                R.style.indigo_AMOLED_lighter, "amoled_light_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.AMOLEDContrast.getValue()),
 
 
-        sepia_white(R.style.white_sepia, "sepia_white", R.color.md_blue_grey_200, 5),
-        sepia_pink(R.style.pink_sepia, "sepia_pink", R.color.md_pink_A200, 5),
-        sepia_deeporange(R.style.deeporange_sepia, "sepia_deeporange", R.color.md_deep_orange_A400, 5),
-        sepia_amber(R.style.amber_sepia, "sepia_amber", R.color.md_amber_A400, 5),
-        sepia_yellow(R.style.yellow_sepia, "sepia_yellow", R.color.md_yellow_A400, 5),
-        sepia_lime(R.style.lime_sepia, "sepia_lime", R.color.md_lime_A400, 5),
-        sepia_green(R.style.green_sepia, "sepia_green", R.color.md_green_A400, 5),
-        sepia_teal(R.style.teal_sepia, "sepia_teal", R.color.md_teal_A700, 5),
-        sepia_cyan(R.style.cyan_sepia, "sepia_cyan", R.color.md_cyan_A400, 5),
-        sepia_lightblue(R.style.lightblue_sepia, "sepia_lightblue", R.color.md_light_blue_A400, 5),
-        sepia_blue(R.style.blue_sepia, "sepia_blue", R.color.md_blue_A400, 5),
-        sepia_indigo(R.style.indigo_sepia, "sepia_indigo", R.color.md_indigo_A400, 5),
+        sepia_white(R.style.white_sepia, "sepia_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.Sepia.getValue()), sepia_pink(R.style.pink_sepia, "sepia_pink",
+                R.color.md_pink_A200, ColorThemeOptions.Sepia.getValue()), sepia_deeporange(
+                R.style.deeporange_sepia, "sepia_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.Sepia.getValue()), sepia_amber(R.style.amber_sepia, "sepia_amber",
+                R.color.md_amber_A400, ColorThemeOptions.Sepia.getValue()), sepia_yellow(
+                R.style.yellow_sepia, "sepia_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.Sepia.getValue()), sepia_lime(R.style.lime_sepia, "sepia_lime",
+                R.color.md_lime_A400, ColorThemeOptions.Sepia.getValue()), sepia_green(
+                R.style.green_sepia, "sepia_green", R.color.md_green_A400,
+                ColorThemeOptions.Sepia.getValue()), sepia_teal(R.style.teal_sepia, "sepia_teal",
+                R.color.md_teal_A700, ColorThemeOptions.Sepia.getValue()), sepia_cyan(
+                R.style.cyan_sepia, "sepia_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.Sepia.getValue()), sepia_lightblue(R.style.lightblue_sepia,
+                "sepia_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.Sepia.getValue()), sepia_blue(R.style.blue_sepia, "sepia_blue",
+                R.color.md_blue_A400, ColorThemeOptions.Sepia.getValue()), sepia_indigo(
+                R.style.indigo_sepia, "sepia_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.Sepia.getValue()),
 
-        night_red_white(R.style.white_night_red, "night_red_white", R.color.md_blue_grey_200, 6),
-        night_red_pink(R.style.pink_night_red, "night_red_pink", R.color.md_pink_A200, 6),
-        night_red_deeporange(R.style.deeporange_night_red, "night_red_deeporange", R.color.md_deep_orange_A400, 6),
-        night_red_amber(R.style.amber_night_red, "night_red_amber", R.color.md_amber_A400, 6),
-        night_red_yellow(R.style.yellow_night_red, "night_red_yellow", R.color.md_yellow_A400, 6),
-        night_red_lime(R.style.lime_night_red, "night_red_lime", R.color.md_lime_A400, 6),
-        night_red_green(R.style.green_night_red, "night_red_green", R.color.md_green_A400, 6),
-        night_red_teal(R.style.teal_night_red, "night_red_teal", R.color.md_teal_A700, 6),
-        night_red_cyan(R.style.cyan_night_red, "night_red_cyan", R.color.md_cyan_A400, 6),
-        night_red_lightblue(R.style.lightblue_night_red, "night_red_lightblue", R.color.md_light_blue_A400, 6),
-        night_red_blue(R.style.blue_night_red, "night_red_blue", R.color.md_blue_A400, 6),
-        night_red_indigo(R.style.indigo_night_red, "night_red_indigo", R.color.md_indigo_A400, 6),
+        night_red_white(R.style.white_night_red, "night_red_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.RedShift.getValue()), night_red_pink(R.style.pink_night_red,
+                "night_red_pink", R.color.md_pink_A200,
+                ColorThemeOptions.RedShift.getValue()), night_red_deeporange(
+                R.style.deeporange_night_red, "night_red_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_amber(R.style.amber_night_red,
+                "night_red_amber", R.color.md_amber_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_yellow(R.style.yellow_night_red,
+                "night_red_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_lime(R.style.lime_night_red,
+                "night_red_lime", R.color.md_lime_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_green(R.style.green_night_red,
+                "night_red_green", R.color.md_green_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_teal(R.style.teal_night_red,
+                "night_red_teal", R.color.md_teal_A700,
+                ColorThemeOptions.RedShift.getValue()), night_red_cyan(R.style.cyan_night_red,
+                "night_red_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_lightblue(
+                R.style.lightblue_night_red, "night_red_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_blue(R.style.blue_night_red,
+                "night_red_blue", R.color.md_blue_A400,
+                ColorThemeOptions.RedShift.getValue()), night_red_indigo(R.style.indigo_night_red,
+                "night_red_indigo", R.color.md_indigo_A400, ColorThemeOptions.RedShift.getValue()),
 
-        pixel_white(R.style.white_pixel, "pixel_white", R.color.md_blue_grey_200, 7),
-        pixel_pink(R.style.pink_pixel, "pixel_pink", R.color.md_pink_A200, 7),
-        pixel_deeporange(R.style.deeporange_pixel, "pixel_deeporange", R.color.md_deep_orange_A400, 7),
-        pixel_amber(R.style.amber_pixel, "pixel_amber", R.color.md_amber_A400, 7),
-        pixel_yellow(R.style.yellow_pixel, "pixel_yellow", R.color.md_yellow_A400, 7),
-        pixel_lime(R.style.lime_pixel, "pixel_lime", R.color.md_lime_A400, 7),
-        pixel_green(R.style.green_pixel, "pixel_green", R.color.md_green_A400, 7),
-        pixel_teal(R.style.teal_pixel, "pixel_teal", R.color.md_teal_A700, 7),
-        pixel_cyan(R.style.cyan_pixel, "pixel_cyan", R.color.md_cyan_A400, 7),
-        pixel_lightblue(R.style.lightblue_pixel, "pixel_lightblue", R.color.md_light_blue_A400, 7),
-        pixel_blue(R.style.blue_pixel, "pixel_blue", R.color.md_blue_A400, 7),
-        pixel_indigo(R.style.indigo_pixel, "pixel_indigo", R.color.md_indigo_A400, 7),
+        pixel_white(R.style.white_pixel, "pixel_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.Pixel.getValue()), pixel_pink(R.style.pink_pixel, "pixel_pink",
+                R.color.md_pink_A200, ColorThemeOptions.Pixel.getValue()), pixel_deeporange(
+                R.style.deeporange_pixel, "pixel_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.Pixel.getValue()), pixel_amber(R.style.amber_pixel, "pixel_amber",
+                R.color.md_amber_A400, ColorThemeOptions.Pixel.getValue()), pixel_yellow(
+                R.style.yellow_pixel, "pixel_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.Pixel.getValue()), pixel_lime(R.style.lime_pixel, "pixel_lime",
+                R.color.md_lime_A400, ColorThemeOptions.Pixel.getValue()), pixel_green(
+                R.style.green_pixel, "pixel_green", R.color.md_green_A400,
+                ColorThemeOptions.Pixel.getValue()), pixel_teal(R.style.teal_pixel, "pixel_teal",
+                R.color.md_teal_A700, ColorThemeOptions.Pixel.getValue()), pixel_cyan(
+                R.style.cyan_pixel, "pixel_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.Pixel.getValue()), pixel_lightblue(R.style.lightblue_pixel,
+                "pixel_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.Pixel.getValue()), pixel_blue(R.style.blue_pixel, "pixel_blue",
+                R.color.md_blue_A400, ColorThemeOptions.Pixel.getValue()), pixel_indigo(
+                R.style.indigo_pixel, "pixel_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.Pixel.getValue()),
 
-        deep_white(R.style.white_deep, "deep_white", R.color.md_blue_grey_200, 8),
-        deep_pink(R.style.pink_deep, "deep_pink", R.color.md_pink_A200, 8),
-        deep_deeporange(R.style.deeporange_deep, "deep_deeporange", R.color.md_deep_orange_A400, 8),
-        deep_amber(R.style.amber_deep, "deep_amber", R.color.md_amber_A400, 8),
-        deep_yellow(R.style.yellow_deep, "deep_yellow", R.color.md_yellow_A400, 8),
-        deep_lime(R.style.lime_deep, "deep_lime", R.color.md_lime_A400, 8),
-        deep_green(R.style.green_deep, "deep_green", R.color.md_green_A400, 8),
-        deep_teal(R.style.teal_deep, "deep_teal", R.color.md_teal_A700, 8),
-        deep_cyan(R.style.cyan_deep, "deep_cyan", R.color.md_cyan_A400, 8),
-        deep_lightblue(R.style.lightblue_deep, "deep_lightblue", R.color.md_light_blue_A400, 8),
-        deep_blue(R.style.blue_deep, "deep_blue", R.color.md_blue_A400, 8),
-        deep_indigo(R.style.indigo_deep, "deep_indigo", R.color.md_indigo_A400, 8);
+        deep_white(R.style.white_deep, "deep_white", R.color.md_blue_grey_200,
+                ColorThemeOptions.Deep.getValue()), deep_pink(R.style.pink_deep, "deep_pink",
+                R.color.md_pink_A200, ColorThemeOptions.Deep.getValue()), deep_deeporange(
+                R.style.deeporange_deep, "deep_deeporange", R.color.md_deep_orange_A400,
+                ColorThemeOptions.Deep.getValue()), deep_amber(R.style.amber_deep, "deep_amber",
+                R.color.md_amber_A400, ColorThemeOptions.Deep.getValue()), deep_yellow(
+                R.style.yellow_deep, "deep_yellow", R.color.md_yellow_A400,
+                ColorThemeOptions.Deep.getValue()), deep_lime(R.style.lime_deep, "deep_lime",
+                R.color.md_lime_A400, ColorThemeOptions.Deep.getValue()), deep_green(
+                R.style.green_deep, "deep_green", R.color.md_green_A400,
+                ColorThemeOptions.Deep.getValue()), deep_teal(R.style.teal_deep, "deep_teal",
+                R.color.md_teal_A700, ColorThemeOptions.Deep.getValue()), deep_cyan(
+                R.style.cyan_deep, "deep_cyan", R.color.md_cyan_A400,
+                ColorThemeOptions.Deep.getValue()), deep_lightblue(R.style.lightblue_deep,
+                "deep_lightblue", R.color.md_light_blue_A400,
+                ColorThemeOptions.Deep.getValue()), deep_blue(R.style.blue_deep, "deep_blue",
+                R.color.md_blue_A400, ColorThemeOptions.Deep.getValue()), deep_indigo(
+                R.style.indigo_deep, "deep_indigo", R.color.md_indigo_A400,
+                ColorThemeOptions.Deep.getValue());
 
         private int baseId;
         private String title;
@@ -776,6 +857,33 @@ public class ColorPreferences {
 
         public int getColor() {
             return color;
+        }
+    }
+
+    public static List<Pair<Integer, Integer>> themePairList = new ArrayList<>(
+            Arrays.asList(new Pair<>(R.id.dark, ColorPreferences.ColorThemeOptions.Dark.getValue()),
+                    new Pair<>(R.id.light, ColorPreferences.ColorThemeOptions.Light.getValue()),
+                    new Pair<>(R.id.amoled, ColorPreferences.ColorThemeOptions.AMOLED.getValue()),
+                    new Pair<>(R.id.blue, ColorPreferences.ColorThemeOptions.DarkBlue.getValue()),
+                    new Pair<>(R.id.amoled_contrast,
+                            ColorPreferences.ColorThemeOptions.AMOLEDContrast.getValue()),
+                    new Pair<>(R.id.sepia, ColorPreferences.ColorThemeOptions.Sepia.getValue()),
+                    new Pair<>(R.id.red, ColorPreferences.ColorThemeOptions.RedShift.getValue()),
+                    new Pair<>(R.id.pixel, ColorPreferences.ColorThemeOptions.Pixel.getValue()),
+                    new Pair<>(R.id.deep, ColorPreferences.ColorThemeOptions.Deep.getValue())));
+
+    public enum ColorThemeOptions {
+        Dark(0), Light(1), AMOLED(2), DarkBlue(3), AMOLEDContrast(4), Sepia(5), RedShift(6), Pixel(
+                7), Deep(8);
+
+        private final int mValue;
+
+        ColorThemeOptions(int value) {
+            mValue = value;
+        }
+
+        public int getValue() {
+            return mValue;
         }
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsThemeFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsThemeFragment.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.SwitchCompat;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -63,16 +64,15 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                 final View dialoglayout = inflater.inflate(R.layout.chooseaccent, null);
                 AlertDialogWrapper.Builder builder =
                         new AlertDialogWrapper.Builder(context);
-                final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                final TextView title = dialoglayout.findViewById(R.id.title);
                 title.setBackgroundColor(Palette.getDefaultColor());
 
-                final LineColorPicker colorPicker =
-                        (LineColorPicker) dialoglayout.findViewById(R.id.picker3);
+                final LineColorPicker colorPicker = dialoglayout.findViewById(R.id.picker3);
 
                 int[] arrs = new int[ColorPreferences.getNumColorsFromThemeType(0)];
                 int i = 0;
                 for (ColorPreferences.Theme type : ColorPreferences.Theme.values()) {
-                    if (type.getThemeType() == 0) {
+                    if (type.getThemeType() == ColorPreferences.ColorThemeOptions.Dark.getValue()) {
                         arrs[i] = ContextCompat.getColor(context, type.getColor());
                         i++;
                     }
@@ -113,199 +113,36 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                 final View dialoglayout = inflater.inflate(R.layout.choosethemesmall, null);
                 AlertDialogWrapper.Builder builder =
                         new AlertDialogWrapper.Builder(context);
-                final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                final TextView title = dialoglayout.findViewById(R.id.title);
                 title.setBackgroundColor(Palette.getDefaultColor());
 
                 if (SettingValues.isNight()) {
                     dialoglayout.findViewById(R.id.nightmsg).setVisibility(View.VISIBLE);
                 }
 
-                dialoglayout.findViewById(R.id.black)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                SettingsThemeFragment.changed = true;
-                                String[] names =
-                                        new ColorPreferences(context).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 2) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(context).setFontStyle(theme);
-                                        context.restartActivity();
-                                        break;
+                for (final Pair<Integer, Integer> pair : ColorPreferences.themePairList) {
+                    dialoglayout.findViewById(pair.first)
+                            .setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    SettingsThemeFragment.changed = true;
+                                    String[] names = new ColorPreferences(context).getFontStyle()
+                                            .getTitle()
+                                            .split("_");
+                                    String name = names[names.length - 1];
+                                    final String newName = name.replace("(", "");
+                                    for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
+                                        if (theme.toString().contains(newName)
+                                                && theme.getThemeType() == pair.second) {
+                                            back = theme.getThemeType();
+                                            new ColorPreferences(context).setFontStyle(theme);
+                                            context.restartActivity();
+                                            break;
+                                        }
                                     }
                                 }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.light)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                SettingsThemeFragment.changed = true;
-                                String[] names =
-                                        new ColorPreferences(context).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 1) {
-                                        new ColorPreferences(context).setFontStyle(theme);
-                                        back = theme.getThemeType();
-                                        context.restartActivity();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.pixel).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        SettingsThemeFragment.changed = true;
-                        String[] names = new ColorPreferences(context).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 7) {
-                                new ColorPreferences(context).setFontStyle(theme);
-                                back = theme.getThemeType();
-                                context.restartActivity();
-                                break;
-                            }
-                        }
-                    }
-                });
-                dialoglayout.findViewById(R.id.dark).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        SettingsThemeFragment.changed = true;
-                        String[] names = new ColorPreferences(context).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 0) {
-                                new ColorPreferences(context).setFontStyle(theme);
-                                back = theme.getThemeType();
-                                context.restartActivity();
-                                break;
-                            }
-                        }
-                    }
-                });
-                dialoglayout.findViewById(R.id.blacklighter)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                SettingsThemeFragment.changed = true;
-                                String[] names =
-                                        new ColorPreferences(context).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 4) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(context).setFontStyle(theme);
-                                        context.restartActivity();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.deep)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                SettingsThemeFragment.changed = true;
-                                String[] names =
-                                        new ColorPreferences(context).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 8) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(context).setFontStyle(theme);
-                                        context.restartActivity();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.sepia)
-                        .setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                SettingsThemeFragment.changed = true;
-                                String[] names =
-                                        new ColorPreferences(context).getFontStyle()
-                                                .getTitle()
-                                                .split("_");
-                                String name = names[names.length - 1];
-                                final String newName = name.replace("(", "");
-                                for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                                    if (theme.toString().contains(newName)
-                                            && theme.getThemeType() == 5) {
-                                        back = theme.getThemeType();
-                                        new ColorPreferences(context).setFontStyle(theme);
-                                        context.restartActivity();
-                                        break;
-                                    }
-                                }
-                            }
-                        });
-                dialoglayout.findViewById(R.id.red).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        SettingsThemeFragment.changed = true;
-                        String[] names = new ColorPreferences(context).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 6) {
-                                back = theme.getThemeType();
-                                new ColorPreferences(context).setFontStyle(theme);
-                                context.restartActivity();
-                                break;
-                            }
-                        }
-                    }
-                });
-                dialoglayout.findViewById(R.id.blue).setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        SettingsThemeFragment.changed = true;
-                        String[] names = new ColorPreferences(context).getFontStyle()
-                                .getTitle()
-                                .split("_");
-                        String name = names[names.length - 1];
-                        final String newName = name.replace("(", "");
-                        for (ColorPreferences.Theme theme : ColorPreferences.Theme.values()) {
-                            if (theme.toString().contains(newName) && theme.getThemeType() == 3) {
-                                new ColorPreferences(context).setFontStyle(theme);
-                                back = theme.getThemeType();
-                                context.restartActivity();
-                                break;
-                            }
-                        }
-                    }
-                });
+                            });
+                }
 
                 builder.setView(dialoglayout);
                 builder.show();
@@ -320,13 +157,11 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                 final LinearLayout dialoglayout = (LinearLayout) inflater.inflate(R.layout.choosemain, null);
                 final AlertDialogWrapper.Builder builder =
                         new AlertDialogWrapper.Builder(context);
-                final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                final TextView title = dialoglayout.findViewById(R.id.title);
                 title.setBackgroundColor(Palette.getDefaultColor());
 
-                final LineColorPicker colorPicker =
-                        (LineColorPicker) dialoglayout.findViewById(R.id.picker);
-                final LineColorPicker colorPicker2 =
-                        (LineColorPicker) dialoglayout.findViewById(R.id.picker2);
+                final LineColorPicker colorPicker = dialoglayout.findViewById(R.id.picker);
+                final LineColorPicker colorPicker2 = dialoglayout.findViewById(R.id.picker2);
 
                 colorPicker.setColors(ColorPreferences.getBaseColors(context));
                 int currentColor = Palette.getDefaultColor();
@@ -563,7 +398,7 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                             //todo save
                         }
                     });
-                    SwitchCompat s = (SwitchCompat) dialog.findViewById(R.id.enabled);
+                    SwitchCompat s = dialog.findViewById(R.id.enabled);
                     s.setChecked(SettingValues.nightMode);
                     s.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                         @Override
@@ -575,100 +410,29 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                             SettingsThemeFragment.changed = true;
                         }
                     });
-                    switch (SettingValues.nightTheme) {
-                        case 0:
-                            ((RadioButton) dialoglayout.findViewById(R.id.dark)).setChecked(true);
-                            break;
-                        case 2:
-                            ((RadioButton) dialoglayout.findViewById(R.id.amoled)).setChecked(true);
-                            break;
-                        case 3:
-                            ((RadioButton) dialoglayout.findViewById(R.id.blue)).setChecked(true);
-                            break;
-                        case 6:
-                            ((RadioButton) dialoglayout.findViewById(R.id.red)).setChecked(true);
-                            break;
-                        case 4:
-                            ((RadioButton) dialoglayout.findViewById(
-                                    R.id.amoled_contrast)).setChecked(true);
-                            break;
-                        default:
-                            ((RadioButton) dialoglayout.findViewById(R.id.dark)).setChecked(true);
-                            break;
-
+                    for (final Pair<Integer, Integer> pair : ColorPreferences.themePairList) {
+                        RadioButton radioButton = dialoglayout.findViewById(pair.first);
+                        if (radioButton != null) {
+                            if (SettingValues.nightTheme == pair.second) {
+                                radioButton.setChecked(true);
+                            }
+                            radioButton.setOnCheckedChangeListener(
+                                    new CompoundButton.OnCheckedChangeListener() {
+                                        @Override
+                                        public void onCheckedChanged(CompoundButton buttonView,
+                                                boolean isChecked) {
+                                            if (isChecked) {
+                                                SettingsThemeFragment.changed = true;
+                                                SettingValues.nightTheme = pair.second;
+                                                SettingValues.prefs.edit()
+                                                        .putInt(SettingValues.PREF_NIGHT_THEME,
+                                                                pair.second)
+                                                        .apply();
+                                            }
+                                        }
+                                    });
+                        }
                     }
-                    ((RadioButton) dialoglayout.findViewById(R.id.dark)).setOnCheckedChangeListener(
-                            new CompoundButton.OnCheckedChangeListener() {
-                                @Override
-                                public void onCheckedChanged(CompoundButton buttonView,
-                                                             boolean isChecked) {
-                                    if (isChecked) {
-                                        SettingsThemeFragment.changed = true;
-                                        SettingValues.nightTheme = 0;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_THEME, 0)
-                                                .apply();
-                                    }
-                                }
-                            });
-                    ((RadioButton) dialoglayout.findViewById(
-                            R.id.amoled)).setOnCheckedChangeListener(
-                            new CompoundButton.OnCheckedChangeListener() {
-                                @Override
-                                public void onCheckedChanged(CompoundButton buttonView,
-                                                             boolean isChecked) {
-                                    if (isChecked) {
-                                        SettingsThemeFragment.changed = true;
-                                        SettingValues.nightTheme = 2;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_THEME, 2)
-                                                .apply();
-                                    }
-                                }
-                            });
-                    ((RadioButton) dialoglayout.findViewById(R.id.red)).setOnCheckedChangeListener(
-                            new CompoundButton.OnCheckedChangeListener() {
-                                @Override
-                                public void onCheckedChanged(CompoundButton buttonView,
-                                                             boolean isChecked) {
-                                    if (isChecked) {
-                                        SettingsThemeFragment.changed = true;
-                                        SettingValues.nightTheme = 6;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_THEME, 6)
-                                                .apply();
-                                    }
-                                }
-                            });
-                    ((RadioButton) dialoglayout.findViewById(R.id.blue)).setOnCheckedChangeListener(
-                            new CompoundButton.OnCheckedChangeListener() {
-                                @Override
-                                public void onCheckedChanged(CompoundButton buttonView,
-                                                             boolean isChecked) {
-                                    if (isChecked) {
-                                        SettingsThemeFragment.changed = true;
-                                        SettingValues.nightTheme = 3;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_THEME, 3)
-                                                .apply();
-                                    }
-                                }
-                            });
-                    ((RadioButton) dialoglayout.findViewById(
-                            R.id.amoled_contrast)).setOnCheckedChangeListener(
-                            new CompoundButton.OnCheckedChangeListener() {
-                                @Override
-                                public void onCheckedChanged(CompoundButton buttonView,
-                                                             boolean isChecked) {
-                                    if (isChecked) {
-                                        SettingsThemeFragment.changed = true;
-                                        SettingValues.nightTheme = 4;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_THEME, 4)
-                                                .apply();
-                                    }
-                                }
-                            });
                     {
                         final List<String> timesStart = new ArrayList<String>() {{
                             add("6pm");
@@ -678,8 +442,7 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                             add("10pm");
                             add("11pm");
                         }};
-                        final Spinner startSpinner =
-                                (Spinner) dialoglayout.findViewById(R.id.start_spinner);
+                        final Spinner startSpinner = dialoglayout.findViewById(R.id.start_spinner);
                         final ArrayAdapter<String> startAdapter =
                                 new ArrayAdapter<>(context,
                                         android.R.layout.simple_spinner_item, timesStart);
@@ -727,8 +490,7 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                             add("9am");
                             add("10am");
                         }};
-                        final Spinner endSpinner =
-                                (Spinner) dialoglayout.findViewById(R.id.end_spinner);
+                        final Spinner endSpinner = dialoglayout.findViewById(R.id.end_spinner);
                         final ArrayAdapter<String> endAdapter =
                                 new ArrayAdapter<>(context,
                                         android.R.layout.simple_spinner_item, timesEnd);
@@ -763,7 +525,7 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                                 });
                     }
                     {
-                        Button okayButton = (Button) dialoglayout.findViewById(R.id.ok);
+                        Button okayButton = dialoglayout.findViewById(R.id.ok);
                         okayButton.setOnClickListener(new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {

--- a/app/src/main/res/layout/choosethemesmall.xml
+++ b/app/src/main/res/layout/choosethemesmall.xml
@@ -237,13 +237,13 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/blacklighter"
-                        android:layout_width="match_parent"
-                        android:layout_height="48dp"
-                        android:background="#121212"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:paddingEnd="16dp">
+                            android:id="@+id/amoled_contrast"
+                            android:layout_width="match_parent"
+                            android:layout_height="48dp"
+                            android:background="#121212"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal"
+                            android:paddingEnd="16dp">
 
                         <ImageView
                             android:layout_width="56dp"
@@ -263,14 +263,14 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:id="@+id/black"
-                        android:layout_width="match_parent"
-                        android:layout_height="48dp"
-                        android:background="#0e0e0e"
-                        android:gravity="center_vertical"
+                            android:id="@+id/amoled"
+                            android:layout_width="match_parent"
+                            android:layout_height="48dp"
+                            android:background="#0e0e0e"
+                            android:gravity="center_vertical"
 
-                        android:orientation="horizontal"
-                        android:paddingEnd="16dp">
+                            android:orientation="horizontal"
+                            android:paddingEnd="16dp">
 
                         <ImageView
                             android:layout_width="56dp"

--- a/app/src/main/res/layout/nightmode.xml
+++ b/app/src/main/res/layout/nightmode.xml
@@ -59,6 +59,14 @@
                         android:orientation="vertical">
 
                     <RadioButton
+                            android:id="@+id/blue"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?android:selectableItemBackground"
+                            android:text="@string/theme_dark_blue"
+                            android:textColor="?attr/fontColor"/>
+
+                    <RadioButton
                             android:id="@+id/dark"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
@@ -67,11 +75,27 @@
                             android:textColor="?attr/fontColor"/>
 
                     <RadioButton
-                            android:id="@+id/blue"
+                            android:id="@+id/pixel"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:background="?android:selectableItemBackground"
-                            android:text="@string/theme_dark_blue"
+                            android:text="@string/theme_pixel"
+                            android:textColor="?attr/fontColor"/>
+
+                    <RadioButton
+                            android:id="@+id/deep"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?android:selectableItemBackground"
+                            android:text="@string/theme_deep"
+                            android:textColor="?attr/fontColor"/>
+
+                    <RadioButton
+                            android:id="@+id/amoled_contrast"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="?android:selectableItemBackground"
+                            android:text="@string/theme_amoled_contrast"
                             android:textColor="?attr/fontColor"/>
 
                     <RadioButton
@@ -82,13 +106,6 @@
                             android:text="@string/theme_black"
                             android:textColor="?attr/fontColor"/>
 
-                    <RadioButton
-                            android:id="@+id/amoled_contrast"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:background="?android:selectableItemBackground"
-                            android:text="@string/theme_amoled_contrast"
-                            android:textColor="?attr/fontColor"/>
                     <RadioButton
                             android:id="@+id/red"
                             android:layout_width="match_parent"


### PR DESCRIPTION
Refactored theme selection simplify logic and force consistency
[Request from Reddit](https://www.reddit.com/r/slideforreddit/comments/8gbpo6/i_would_love_to_get_the_deep_base_theme_as_a/)

I added all non-light color theme options to the "Night Mode" menu. This includes adding the new "Deep" theme as an option.

Additionally I tried my best to clean up a lot of the logic. I added an enum to `ColorPreferences` to hold all the int values per base-theme type. These values are used in both the Theme enum and the new themePairList list used to link theme `resIds` to themeType `ints`

Entire blocks have been condensed into single for-loops around this new themePairList. The logic behaves the exact same and I seem to not be missing anything crucial. Testing it out makes it seem fine (Did not test whatever happens in Tutorial?)

Let me know what you think.