### PR TITLE
adds button to bottom nav bar to expand/collapse comments

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsComments.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsComments.java
@@ -24,14 +24,19 @@ public class SettingsComments extends BaseActivityAnim {
                     SettingValues.fastscroll = isChecked;
                     SettingValues.prefs.edit().putBoolean(SettingValues.PREF_FASTSCROLL, isChecked).apply();
 
-                    //Disable autohidenav if commentNav isn't checked
+                    //Disable autohidenav and showcollapseexpand if commentNav isn't checked
                     if (!isChecked) {
                         findViewById(R.id.autohidenav).setEnabled(false);
                         ((SwitchCompat) findViewById(R.id.autohidenav)).setChecked(SettingValues.commentAutoHide);
                         findViewById(R.id.auto_hide_the_comment_nav_bar_text).setAlpha(0.25f);
+                        findViewById(R.id.showcollapseexpand).setEnabled(false);
+                        ((SwitchCompat) findViewById(R.id.showcollapseexpand)).setChecked(SettingValues.commentAutoHide);
+                        findViewById(R.id.show_collapse_expand_nav_bar).setAlpha(0.25f);
                     } else {
                         findViewById(R.id.autohidenav).setEnabled(true);
                         findViewById(R.id.auto_hide_the_comment_nav_bar_text).setAlpha(1f);
+                        findViewById(R.id.showcollapseexpand).setEnabled(true);
+                        findViewById(R.id.show_collapse_expand_nav_bar).setAlpha(1f);
                     }
                 }
             });
@@ -117,6 +122,23 @@ public class SettingsComments extends BaseActivityAnim {
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                     SettingValues.commentAutoHide = isChecked;
                     SettingValues.prefs.edit().putBoolean(SettingValues.PREF_AUTOHIDE_COMMENTS, isChecked).apply();
+                }
+            });
+        }
+        {
+            SwitchCompat single = (SwitchCompat) findViewById(R.id.showcollapseexpand);
+            single.setChecked(SettingValues.showCollapseExpand);
+
+            if (!((SwitchCompat) findViewById(R.id.commentnav)).isChecked()) {
+                single.setEnabled(false);
+                findViewById(R.id.show_collapse_expand_nav_bar).setAlpha(0.25f);
+            }
+
+            single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    SettingValues.showCollapseExpand = isChecked;
+                    SettingValues.prefs.edit().putBoolean(SettingValues.PREF_SHOW_COLLAPSE_EXPAND, isChecked).apply();
                 }
             });
         }

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapter.java
@@ -240,6 +240,20 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
     }
 
+    public void expandAll() {
+        if (currentComments == null) return;
+        for (CommentObject o : currentComments) {
+            if (o.comment.isTopLevel()) {
+                if (hiddenPersons.contains(o.comment.getComment().getFullName())) {
+                    hiddenPersons.remove(o.comment.getComment().getFullName());
+                }
+                unhideAll(o.comment);
+            }
+        }
+        notifyItemChanged(2);
+    }
+
+
     public void collapseAll() {
         if (currentComments == null) return;
         for (CommentObject o : currentComments) {
@@ -1907,6 +1921,17 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             }
         } catch (Exception ignored) {
 
+        }
+    }
+
+    public void unhideAll(CommentNode n) {
+        unhideNumber(n, 0);
+        if (SettingValues.collapseComments) {
+            listView.setItemAnimator(null);
+            notifyDataSetChanged();
+        } else {
+            listView.setItemAnimator(new AlphaInAnimator());
+            notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -384,20 +384,25 @@ public class CommentPage extends Fragment {
         if (!SettingValues.fastscroll) {
             fastScroll.setVisibility(View.GONE);
         } else {
-            v.findViewById(R.id.collapse_expand).setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (adapter != null) {
-                        if (collapsed) {
-                            adapter.expandAll();
-                            collapsed = !collapsed;
-                        } else {
-                            adapter.collapseAll();
-                            collapsed = !collapsed;
+            if (!SettingValues.showCollapseExpand) {
+                v.findViewById(R.id.collapse_expand).setVisibility(View.GONE);
+            } else {
+                v.findViewById(R.id.collapse_expand).setVisibility(View.VISIBLE);
+                v.findViewById(R.id.collapse_expand).setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (adapter != null) {
+                            if (collapsed) {
+                                adapter.expandAll();
+                                collapsed = !collapsed;
+                            } else {
+                                adapter.collapseAll();
+                                collapsed = !collapsed;
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
             v.findViewById(R.id.down).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/CommentPage.java
@@ -143,6 +143,7 @@ public class CommentPage extends Fragment {
     private boolean upvoted   = false;
     private boolean downvoted = false;
     private boolean currentlySubbed;
+    private boolean collapsed = SettingValues.collapseCommentsDefault;
 
 
     public void doResult(Intent data) {
@@ -383,6 +384,20 @@ public class CommentPage extends Fragment {
         if (!SettingValues.fastscroll) {
             fastScroll.setVisibility(View.GONE);
         } else {
+            v.findViewById(R.id.collapse_expand).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (adapter != null) {
+                        if (collapsed) {
+                            adapter.expandAll();
+                            collapsed = !collapsed;
+                        } else {
+                            adapter.collapseAll();
+                            collapsed = !collapsed;
+                        }
+                    }
+                }
+            });
             v.findViewById(R.id.down).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -26,6 +26,7 @@ public class SettingValues {
     public static final String PREF_NIGHT_THEME               = "nightTheme";
     public static final String PREF_TYPE_IN_TEXT              = "typeInText";
     public static final String PREF_AUTOHIDE_COMMENTS         = "autohideComments";
+    public static final String PREF_SHOW_COLLAPSE_EXPAND      = "showCollapseExpand";
     public static final String PREF_NO_IMAGES                 = "noImages";
     public static final String PREF_AUTOTHEME                 = "autotime";
     public static final String PREVIEWS_LEFT                  = "previewsLeft";
@@ -147,6 +148,7 @@ public class SettingValues {
     public static boolean                 actionbarVisible;
     public static boolean                 actionbarTap;
     public static boolean                 commentAutoHide;
+    public static boolean                 showCollapseExpand;
     public static boolean                 fullCommentOverride;
     public static boolean                 lowResAlways;
     public static boolean                 noImages;
@@ -302,6 +304,7 @@ public class SettingValues {
         collapseCommentsDefault = prefs.getBoolean(PREF_COLLAPSE_COMMENTS_DEFAULT, false);
         rightHandedCommentMenu = prefs.getBoolean(PREF_RIGHT_HANDED_COMMENT_MENU, false);
         commentAutoHide = prefs.getBoolean(PREF_AUTOHIDE_COMMENTS, false);
+        showCollapseExpand = prefs.getBoolean(PREF_SHOW_COLLAPSE_EXPAND, false);
         highlightCommentOP = prefs.getBoolean(PREF_HIGHLIGHT_COMMENT_OP, true);
 
         typeInfoLine = prefs.getBoolean(PREF_TYPE_INFO_LINE, false);

--- a/app/src/main/res/layout/activity_settings_comments.xml
+++ b/app/src/main/res/layout/activity_settings_comments.xml
@@ -491,6 +491,49 @@
                     android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/show_collapse_expand_nav_bar"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/show_collapse_expand_nav_bar"
+                        android:textColor="?attr/fontColor"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/showcollapseexpand"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:paddingEnd="16dp"
+                    android:backgroundTint="?attr/tintColor"
+                    android:button="@null"
+                    android:buttonTint="?attr/tintColor"
+                    android:hapticFeedbackEnabled="true"
+                    android:textColor="?attr/fontColor"
+                    android:textColorHint="?attr/fontColor" />
+            </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:background="?attr/tintColor"
+                android:alpha=".25"
+                android:layout_height="0.25dp"/>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:background="?android:selectableItemBackground"
+                android:paddingStart="16dp">
+
+                <LinearLayout
+                    android:layout_marginEnd="64dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:orientation="vertical">
+
+                    <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/settings_volume_nav_comments"

--- a/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
+++ b/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
@@ -42,6 +42,13 @@
                 android:layout_height="36dp"
                 android:padding="8dp"
                 app:srcCompat="@drawable/nav"/>
+        <ImageView
+            android:id="@+id/collapse_expand"
+            style="@style/Ripple.List"
+            android:layout_width="48dp"
+            android:layout_height="36dp"
+            android:padding="8dp"
+            app:srcCompat="@drawable/comment"/>
 
         <ImageView
                 android:id="@+id/down"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1189,5 +1189,6 @@
     <string name="settings_shortlink_description">Links will be shared as \'https://redd.it/\'</string>
     <string name="settings_shortlink">Share Reddit shortlink where possible</string>
     <string name="firefox">Firefox</string>
+    <string name="show_collapse_expand_nav_bar">Show collapse/expand button in the comment navigation bar</string>
 
 </resources>


### PR DESCRIPTION
This PR adds another icon to the bottom nav bar which when clicked, will either collapse or expand all comments.

I'm not 100% sure if the bottom nav bar is the best place for this, but I couldn't think of where else it could go.

This feature might not be a good idea at all, just thought I would throw it out there to see if it makes sense