### PR TITLE
Moved gradle dependencies out of arrays

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,61 +78,56 @@ ext {
     robolectricVersion = '3.3.1'
 }
 dependencies {
-    withGPlayImplementation(
-            'com.google.android.gms:play-services-drive:10.2.0',
-    )
+    withGPlayImplementation 'com.google.android.gms:play-services-drive:10.2.0'
 
-    implementation(
-            'com.github.ccrama:JRAW:b30799fdc8',
-            "com.google.guava:guava:23.0-android",
-            //Updating material-dialogs to any newer version will break all AlertDialogWrapper
-            'com.afollestad.material-dialogs:commons:0.8.6.2',
-            'com.jakewharton:process-phoenix:2.0.0',
-            'org.ligi:snackengage:0.5',
-            "com.android.support:design:$supportLibVersion",
-            "com.android.support:customtabs:$supportLibVersion",
-            "com.android.support:recyclerview-v7:$supportLibVersion",
-            "com.android.support:appcompat-v7:$supportLibVersion",
-            "com.android.support:support-v13:$supportLibVersion",
-            "com.android.support:cardview-v7:$supportLibVersion",
-            'com.android.support:multidex:1.0.2',
-            'com.github.rey5137:material:1.2.4',
-            'com.nostra13.universalimageloader:universal-image-loader:1.9.5',
-            'com.davemorrissey.labs:subsampling-scale-image-view:3.6.0',
-            'com.cocosw:bottomsheet:1.3.0@aar',
-            'com.github.ccrama:AndroidVideoCache:483e44579d',
-            'com.lusfold.androidkeyvaluestore:library:0.1.0@aar',
-            'org.apache.commons:commons-lang3:3.5',
-            'jp.wasabeef:blurry:2.1.0',
-            'com.github.johnkil.android-robototextview:robototextview:4.0.0',
-            'com.makeramen:roundedimageview:2.2.1',
-            'com.getbase:floatingactionbutton:1.10.1',
-            'com.sothree.slidinguppanel:library:3.3.1',
-            'com.github.suckgamony.RapidDecoder:library:7cdfca47fa',
-            'com.github.dasar:shiftcolorpicker:v0.5',
-            'com.squareup.okhttp3:okhttp:3.7.0',
-            'com.google.code.gson:gson:2.8.0',
-            'com.github.ccrama:TedBottomPicker:496623c9b6',
-            'commons-io:commons-io:2.5',
-            'com.github.ozodrukh:CircularReveal:1.3.1',
-            'com.github.ccrama:exomedia:4d4e5a490a',
-            'com.github.ccrama:commonmark-java:07b304b575',
-            'org.jetbrains:annotations-java5:15.0',
-            "com.mikepenz:itemanimators:1.0.0@aar",
-            'com.neovisionaries:nv-websocket-client:1.31',
-            'com.github.ccrama:PeekAndPop:09adee29f1',
-            'com.theartofdev.edmodo:android-image-cropper:2.3.1',
-            'com.github.ccrama:JReadability:bb291880a5',
-            'me.everything:overscroll-decor-android:1.0.4',
-            'com.mikepenz:aboutlibraries:5.8.1',
-            'com.googlecode.mp4parser:isoparser:1.1.21',
-    )
+    implementation 'com.github.ccrama:JRAW:b30799fdc8'
+    implementation "com.google.guava:guava:23.0-android"
+    //Updating material-dialogs to any newer version will break all AlertDialogWrapper
+    //noinspection GradleDependency
+    implementation 'com.afollestad.material-dialogs:commons:0.8.6.2'
+    implementation 'com.jakewharton:process-phoenix:2.0.0'
+    implementation 'org.ligi:snackengage:0.5'
+    implementation "com.android.support:design:$supportLibVersion"
+    implementation "com.android.support:customtabs:$supportLibVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:support-v13:$supportLibVersion"
+    implementation "com.android.support:cardview-v7:$supportLibVersion"
+    implementation 'com.android.support:multidex:1.0.2'
+    implementation 'com.github.rey5137:material:1.2.4'
+    implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.6.0'
+    implementation 'com.cocosw:bottomsheet:1.3.0@aar'
+    implementation 'com.github.ccrama:AndroidVideoCache:483e44579d'
+    implementation 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
+    implementation 'org.apache.commons:commons-lang3:3.5'
+    implementation 'jp.wasabeef:blurry:2.1.0'
+    implementation 'com.github.johnkil.android-robototextview:robototextview:4.0.0'
+    implementation 'com.makeramen:roundedimageview:2.2.1'
+    implementation 'com.getbase:floatingactionbutton:1.10.1'
+    implementation 'com.sothree.slidinguppanel:library:3.3.1'
+    implementation 'com.github.suckgamony.RapidDecoder:library:7cdfca47fa'
+    implementation 'com.github.dasar:shiftcolorpicker:v0.5'
+    implementation 'com.squareup.okhttp3:okhttp:3.7.0'
+    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.github.ccrama:TedBottomPicker:496623c9b6'
+    implementation 'commons-io:commons-io:2.5'
+    implementation 'com.github.ozodrukh:CircularReveal:1.3.1'
+    implementation 'com.github.ccrama:exomedia:4d4e5a490a'
+    implementation 'com.github.ccrama:commonmark-java:07b304b575'
+    implementation 'org.jetbrains:annotations-java5:15.0'
+    implementation "com.mikepenz:itemanimators:1.0.0@aar"
+    implementation 'com.neovisionaries:nv-websocket-client:1.31'
+    implementation 'com.github.ccrama:PeekAndPop:09adee29f1'
+    implementation 'com.theartofdev.edmodo:android-image-cropper:2.3.1'
+    implementation 'com.github.ccrama:JReadability:bb291880a5'
+    implementation 'me.everything:overscroll-decor-android:1.0.4'
+    implementation 'com.mikepenz:aboutlibraries:5.8.1'
+    implementation 'com.googlecode.mp4parser:isoparser:1.1.21'
 
-    testImplementation(
-            'junit:junit:4.12',
-            'org.hamcrest:hamcrest-all:1.3',
-            'org.mockito:mockito-core:1.10.19',
-            "org.robolectric:robolectric:$robolectricVersion",
-            "org.robolectric:shadows-multidex:$robolectricVersion",
-    )
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "org.robolectric:shadows-multidex:$robolectricVersion"
 }


### PR DESCRIPTION
All this change does is moves all of the gradle dependencies out of the arrays.

Originally I added them into arrays, because that made sense. But when inside arrays, gradle won't warn you that there are newer versions of a dependency. It seems like a fault in gradle, but since it's not hard to just not have arrays, I dumped the idea.

Everything else is the same (I DID add `//noinspection GradleDependency` above the `material-dialogs` dependency