### PR TITLE
Added options to hide drawer items

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -149,6 +149,7 @@ import me.ccrama.redditslide.Constants;
 import me.ccrama.redditslide.ContentType;
 import me.ccrama.redditslide.FDroid;
 import me.ccrama.redditslide.Fragments.CommentPage;
+import me.ccrama.redditslide.Fragments.DrawerItemsDialog;
 import me.ccrama.redditslide.Fragments.SettingsGeneralFragment;
 import me.ccrama.redditslide.Fragments.SettingsThemeFragment;
 import me.ccrama.redditslide.Fragments.SubmissionsView;
@@ -1490,24 +1491,20 @@ public class MainActivity extends BaseActivity
                 public boolean onLongClick(View v) {
                     new MaterialDialog.Builder(MainActivity.this).inputRange(3, 20)
                             .alwaysCallInputCallback()
-                            .input(getString(R.string.user_enter), null,
-                                    new MaterialDialog.InputCallback() {
-                                        @Override
-                                        public void onInput(@NonNull MaterialDialog dialog,
-                                                CharSequence input) {
-                                            final EditText editText = dialog.getInputEditText();
-                                            EditTextValidator.validateUsername(editText);
-                                            if (input.length() >= 3 && input.length() <= 20) {
-                                                dialog.getActionButton(DialogAction.POSITIVE)
-                                                        .setEnabled(true);
-                                            }
-                                        }
-                                    })
+                            .input(getString(R.string.user_enter), null, new MaterialDialog.InputCallback() {
+                                @Override
+                                public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                                    final EditText editText = dialog.getInputEditText();
+                                    EditTextValidator.validateUsername(editText);
+                                    if (input.length() >= 3 && input.length() <= 20) {
+                                        dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                                    }
+                                }
+                            })
                             .positiveText(R.string.user_btn_gotomultis)
                             .onPositive(new MaterialDialog.SingleButtonCallback() {
                                 @Override
-                                public void onClick(@NonNull MaterialDialog dialog,
-                                        @NonNull DialogAction which) {
+                                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                                     if (runAfterLoad == null) {
                                         Intent inte = new Intent(MainActivity.this,
                                                 MultiredditOverview.class);
@@ -1617,8 +1614,7 @@ public class MainActivity extends BaseActivity
                 }
             });
 
-            for (String s : Authentication.authentication.getStringSet("accounts",
-                    new HashSet<String>())) {
+            for (String s : Authentication.authentication.getStringSet("accounts", new HashSet<String>())) {
                 if (s.contains(":")) {
                     accounts.put(s.split(":")[0], s.split(":")[1]);
                 } else {
@@ -1642,94 +1638,79 @@ public class MainActivity extends BaseActivity
                         @Override
                         public void onClick(View v) {
 
-                            new AlertDialogWrapper.Builder(MainActivity.this).setTitle(
-                                    R.string.profile_remove)
+                            new AlertDialogWrapper.Builder(MainActivity.this).setTitle(R.string.profile_remove)
                                     .setMessage(R.string.profile_remove_account)
-                                    .setNegativeButton(R.string.btn_delete,
-                                            new DialogInterface.OnClickListener() {
-                                                @Override
-                                                public void onClick(DialogInterface dialog2,
-                                                        int which2) {
-                                                    Set<String> accounts2 =
-                                                            Authentication.authentication.getStringSet(
-                                                                    "accounts",
-                                                                    new HashSet<String>());
-                                                    Set<String> done = new HashSet<>();
-                                                    for (String s : accounts2) {
-                                                        if (!s.contains(accName)) {
-                                                            done.add(s);
+                                    .setNegativeButton(R.string.btn_delete, new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog2, int which2) {
+                                            Set<String> accounts2 = Authentication.authentication.getStringSet(
+                                                    "accounts", new HashSet<String>());
+                                            Set<String> done = new HashSet<>();
+                                            for (String s : accounts2) {
+                                                if (!s.contains(accName)) {
+                                                    done.add(s);
+                                                }
+                                            }
+                                            Authentication.authentication.edit()
+                                                    .putStringSet("accounts", done)
+                                                    .commit();
+                                            dialog2.dismiss();
+                                            accountList.removeView(t);
+                                            if (accName.equalsIgnoreCase(Authentication.name)) {
+
+                                                boolean d = false;
+                                                for (String s : keys) {
+
+                                                    if (!s.equalsIgnoreCase(accName)) {
+                                                        d = true;
+                                                        LogUtil.v("Switching to " + s);
+                                                        for(Map.Entry<String, String> e : accounts.entrySet()){
+                                                            LogUtil.v(e.getKey() + ":" + e.getValue());
                                                         }
-                                                    }
-                                                    Authentication.authentication.edit()
-                                                            .putStringSet("accounts", done)
-                                                            .commit();
-                                                    dialog2.dismiss();
-                                                    accountList.removeView(t);
-                                                    if (accName.equalsIgnoreCase(
-                                                            Authentication.name)) {
-
-                                                        boolean d = false;
-                                                        for (String s : keys) {
-
-                                                            if (!s.equalsIgnoreCase(accName)) {
-                                                                d = true;
-                                                                LogUtil.v("Switching to " + s);
-                                                                for(Map.Entry<String, String> e : accounts.entrySet()){
-                                                                    LogUtil.v(e.getKey() + ":" + e.getValue());
-                                                                }
-                                                                if (accounts.containsKey(s)
-                                                                        && !accounts.get(s)
-                                                                        .isEmpty()) {
-                                                                    Authentication.authentication.edit()
-                                                                            .putString("lasttoken",
-                                                                                    accounts.get(s))
-                                                                            .remove("backedCreds")
-                                                                            .commit();
-                                                                } else {
-                                                                    ArrayList<String> tokens =
-                                                                            new ArrayList<>(
-                                                                                    Authentication.authentication
-                                                                                            .getStringSet(
-                                                                                                    "tokens",
-                                                                                                    new HashSet<String>()));
-                                                                    int index = keys.indexOf(s);
-                                                                    if (keys.indexOf(s)
-                                                                            > tokens.size()) {
-                                                                        index -= 1;
-                                                                    }
-                                                                    Authentication.authentication.edit()
-                                                                            .putString("lasttoken",
-                                                                                    tokens.get(
-                                                                                            index))
-                                                                            .remove("backedCreds")
-                                                                            .commit();
-                                                                }
-                                                                Authentication.name = s;
-                                                                UserSubscriptions.switchAccounts();
-                                                                Reddit.forceRestart(
-                                                                        MainActivity.this, true);
-                                                                break;
-                                                            }
-
-                                                        }
-                                                        if (!d) {
-                                                            Authentication.name = "LOGGEDOUT";
-                                                            Authentication.isLoggedIn = false;
+                                                        if (accounts.containsKey(s) && !accounts.get(s)
+                                                                .isEmpty()) {
                                                             Authentication.authentication.edit()
-                                                                    .remove("lasttoken")
+                                                                    .putString("lasttoken", accounts.get(s))
                                                                     .remove("backedCreds")
                                                                     .commit();
-                                                            UserSubscriptions.switchAccounts();
-                                                            Reddit.forceRestart(MainActivity.this,
-                                                                    true);
+                                                        } else {
+                                                            ArrayList<String> tokens = new ArrayList<>(
+                                                                    Authentication.authentication.getStringSet(
+                                                                            "tokens", new HashSet<String>()));
+                                                            int index = keys.indexOf(s);
+                                                            if (keys.indexOf(s) > tokens.size()) {
+                                                                index -= 1;
+                                                            }
+                                                            Authentication.authentication.edit()
+                                                                    .putString("lasttoken",
+                                                                            tokens.get(index))
+                                                                    .remove("backedCreds")
+                                                                    .commit();
                                                         }
-
-                                                    } else {
-                                                        accounts.remove(accName);
-                                                        keys.remove(accName);
+                                                        Authentication.name = s;
+                                                        UserSubscriptions.switchAccounts();
+                                                        Reddit.forceRestart(MainActivity.this, true);
+                                                        break;
                                                     }
+
                                                 }
-                                            })
+                                                if (!d) {
+                                                    Authentication.name = "LOGGEDOUT";
+                                                    Authentication.isLoggedIn = false;
+                                                    Authentication.authentication.edit()
+                                                            .remove("lasttoken")
+                                                            .remove("backedCreds")
+                                                            .commit();
+                                                    UserSubscriptions.switchAccounts();
+                                                    Reddit.forceRestart(MainActivity.this, true);
+                                                }
+
+                                            } else {
+                                                accounts.remove(accName);
+                                                keys.remove(accName);
+                                            }
+                                        }
+                                    })
                                     .setPositiveButton(R.string.btn_cancel, null)
                                     .show();
 
@@ -1755,11 +1736,9 @@ public class MainActivity extends BaseActivity
                                             .apply();
                                 } else {
                                     ArrayList<String> tokens = new ArrayList<>(
-                                            Authentication.authentication.getStringSet("tokens",
-                                                    new HashSet<String>()));
+                                            Authentication.authentication.getStringSet("tokens", new HashSet<String>()));
                                     Authentication.authentication.edit()
-                                            .putString("lasttoken",
-                                                    tokens.get(keys.indexOf(accName)))
+                                            .putString("lasttoken", tokens.get(keys.indexOf(accName)))
                                             .remove("backedCreds")
                                             .apply();
                                 }
@@ -1849,8 +1828,7 @@ public class MainActivity extends BaseActivity
             });
             final HashMap<String, String> accounts = new HashMap<>();
 
-            for (String s : Authentication.authentication.getStringSet("accounts",
-                    new HashSet<String>())) {
+            for (String s : Authentication.authentication.getStringSet("accounts", new HashSet<String>())) {
                 if (s.contains(":")) {
                     accounts.put(s.split(":")[0], s.split(":")[1]);
                 } else {
@@ -1873,82 +1851,68 @@ public class MainActivity extends BaseActivity
                         @Override
                         public void onClick(View v) {
 
-                            new AlertDialogWrapper.Builder(MainActivity.this).setTitle(
-                                    R.string.profile_remove)
+                            new AlertDialogWrapper.Builder(MainActivity.this).setTitle(R.string.profile_remove)
                                     .setMessage(R.string.profile_remove_account)
-                                    .setNegativeButton(R.string.btn_delete,
-                                            new DialogInterface.OnClickListener() {
-                                                @Override
-                                                public void onClick(DialogInterface dialog2,
-                                                        int which2) {
-                                                    Set<String> accounts2 =
-                                                            Authentication.authentication.getStringSet(
-                                                                    "accounts",
-                                                                    new HashSet<String>());
-                                                    Set<String> done = new HashSet<>();
-                                                    for (String s : accounts2) {
-                                                        if (!s.contains(accName)) {
-                                                            done.add(s);
-                                                        }
-                                                    }
-                                                    Authentication.authentication.edit()
-                                                            .putStringSet("accounts", done)
-                                                            .commit();
-                                                    dialog2.dismiss();
-                                                    accountList.removeView(t);
+                                    .setNegativeButton(R.string.btn_delete, new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog2, int which2) {
+                                            Set<String> accounts2 = Authentication.authentication.getStringSet(
+                                                    "accounts", new HashSet<String>());
+                                            Set<String> done = new HashSet<>();
+                                            for (String s : accounts2) {
+                                                if (!s.contains(accName)) {
+                                                    done.add(s);
+                                                }
+                                            }
+                                            Authentication.authentication.edit()
+                                                    .putStringSet("accounts", done)
+                                                    .commit();
+                                            dialog2.dismiss();
+                                            accountList.removeView(t);
 
-                                                    if (accName.equalsIgnoreCase(
-                                                            Authentication.name)) {
-                                                        boolean d = false;
-                                                        for (String s : keys) {
-                                                            if (!s.equalsIgnoreCase(accName)) {
-                                                                d = true;
-                                                                LogUtil.v("Switching to " + s);
-                                                                if (!accounts.get(s).isEmpty()) {
-                                                                    Authentication.authentication.edit()
-                                                                            .putString("lasttoken",
-                                                                                    accounts.get(s))
-                                                                            .remove("backedCreds")
-                                                                            .commit();
-
-                                                                } else {
-                                                                    ArrayList<String> tokens =
-                                                                            new ArrayList<>(
-                                                                                    Authentication.authentication
-                                                                                            .getStringSet(
-                                                                                                    "tokens",
-                                                                                                    new HashSet<String>()));
-                                                                    Authentication.authentication.edit()
-                                                                            .putString("lasttoken",
-                                                                                    tokens.get(
-                                                                                            keys.indexOf(
-                                                                                                    s)))
-                                                                            .remove("backedCreds")
-                                                                            .commit();
-                                                                }
-                                                                Authentication.name = s;
-                                                                UserSubscriptions.switchAccounts();
-                                                                Reddit.forceRestart(
-                                                                        MainActivity.this, true);
-                                                            }
-                                                        }
-                                                        if (!d) {
-                                                            Authentication.name = "LOGGEDOUT";
-                                                            Authentication.isLoggedIn = false;
+                                            if (accName.equalsIgnoreCase(Authentication.name)) {
+                                                boolean d = false;
+                                                for (String s : keys) {
+                                                    if (!s.equalsIgnoreCase(accName)) {
+                                                        d = true;
+                                                        LogUtil.v("Switching to " + s);
+                                                        if (!accounts.get(s).isEmpty()) {
                                                             Authentication.authentication.edit()
-                                                                    .remove("lasttoken")
+                                                                    .putString("lasttoken", accounts.get(s))
                                                                     .remove("backedCreds")
                                                                     .commit();
-                                                            UserSubscriptions.switchAccounts();
-                                                            Reddit.forceRestart(MainActivity.this,
-                                                                    true);
+
+                                                        } else {
+                                                            ArrayList<String> tokens = new ArrayList<>(
+                                                                    Authentication.authentication.getStringSet(
+                                                                            "tokens", new HashSet<String>()));
+                                                            Authentication.authentication.edit()
+                                                                    .putString("lasttoken", tokens.get(
+                                                                            keys.indexOf(s)))
+                                                                    .remove("backedCreds")
+                                                                    .commit();
                                                         }
-                                                    } else {
-                                                        accounts.remove(accName);
-                                                        keys.remove(accName);
+                                                        Authentication.name = s;
+                                                        UserSubscriptions.switchAccounts();
+                                                        Reddit.forceRestart(MainActivity.this, true);
                                                     }
                                                 }
-                                            })
+                                                if (!d) {
+                                                    Authentication.name = "LOGGEDOUT";
+                                                    Authentication.isLoggedIn = false;
+                                                    Authentication.authentication.edit()
+                                                            .remove("lasttoken")
+                                                            .remove("backedCreds")
+                                                            .commit();
+                                                    UserSubscriptions.switchAccounts();
+                                                    Reddit.forceRestart(MainActivity.this, true);
+                                                }
+                                            } else {
+                                                accounts.remove(accName);
+                                                keys.remove(accName);
+                                            }
+                                        }
+                                    })
                                     .setPositiveButton(R.string.btn_cancel, null)
                                     .show();
                         }
@@ -1959,8 +1923,7 @@ public class MainActivity extends BaseActivity
                 t.setOnClickListener(new OnSingleClickListener() {
                     @Override
                     public void onSingleClick(View v) {
-                        if (!accName.equalsIgnoreCase(Authentication.name) && !accName.equals(
-                                guest)) {
+                        if (!accName.equalsIgnoreCase(Authentication.name) && !accName.equals(guest)) {
                             if (!accounts.get(accName).isEmpty()) {
                                 Authentication.authentication.edit()
                                         .putString("lasttoken", accounts.get(accName))
@@ -1968,8 +1931,7 @@ public class MainActivity extends BaseActivity
                                         .commit();
                             } else {
                                 ArrayList<String> tokens = new ArrayList<>(
-                                        Authentication.authentication.getStringSet("tokens",
-                                                new HashSet<String>()));
+                                        Authentication.authentication.getStringSet("tokens", new HashSet<String>()));
                                 Authentication.authentication.edit()
                                         .putString("lasttoken", tokens.get(keys.indexOf(accName)))
                                         .remove("backedCreds")
@@ -2007,24 +1969,20 @@ public class MainActivity extends BaseActivity
                 public void onClick(View view) {
                     new MaterialDialog.Builder(MainActivity.this).inputRange(3, 20)
                             .alwaysCallInputCallback()
-                            .input(getString(R.string.user_enter), null,
-                                    new MaterialDialog.InputCallback() {
-                                        @Override
-                                        public void onInput(@NonNull MaterialDialog dialog,
-                                                CharSequence input) {
-                                            final EditText editText = dialog.getInputEditText();
-                                            EditTextValidator.validateUsername(editText);
-                                            if (input.length() >= 3 && input.length() <= 20) {
-                                                dialog.getActionButton(DialogAction.POSITIVE)
-                                                        .setEnabled(true);
-                                            }
-                                        }
-                                    })
+                            .input(getString(R.string.user_enter), null, new MaterialDialog.InputCallback() {
+                                @Override
+                                public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                                    final EditText editText = dialog.getInputEditText();
+                                    EditTextValidator.validateUsername(editText);
+                                    if (input.length() >= 3 && input.length() <= 20) {
+                                        dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                                    }
+                                }
+                            })
                             .positiveText(R.string.user_btn_gotomultis)
                             .onPositive(new MaterialDialog.SingleButtonCallback() {
                                 @Override
-                                public void onClick(@NonNull MaterialDialog dialog,
-                                        @NonNull DialogAction which) {
+                                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                                     if (runAfterLoad == null) {
                                         Intent inte = new Intent(MainActivity.this,
                                                 MultiredditOverview.class);
@@ -2070,34 +2028,25 @@ public class MainActivity extends BaseActivity
                 header.findViewById(R.id.support).setOnClickListener(new OnSingleClickListener() {
                     @Override
                     public void onSingleClick(View view) {
-                        new AlertDialogWrapper.Builder(MainActivity.this).setTitle(
-                                R.string.settings_support_slide)
+                        new AlertDialogWrapper.Builder(MainActivity.this).setTitle(R.string.settings_support_slide)
                                 .setMessage(R.string.pro_upgrade_msg)
-                                .setPositiveButton(R.string.btn_yes_exclaim,
-                                        new DialogInterface.OnClickListener() {
-                                            public void onClick(DialogInterface dialog,
-                                                    int whichButton) {
-                                                try {
-                                                    startActivity(new Intent(Intent.ACTION_VIEW,
-                                                            Uri.parse("market://details?id="
-                                                                    + getString(
-                                                                    R.string.ui_unlock_package))));
-                                                } catch (ActivityNotFoundException e) {
-                                                    startActivity(new Intent(Intent.ACTION_VIEW,
-                                                            Uri.parse(
-                                                                    "http://play.google.com/store/apps/details?id="
-                                                                            + getString(
-                                                                            R.string.ui_unlock_package))));
-                                                }
-                                            }
-                                        })
-                                .setNegativeButton(R.string.btn_no_danks,
-                                        new DialogInterface.OnClickListener() {
-                                            public void onClick(DialogInterface dialog,
-                                                    int whichButton) {
-                                                dialog.dismiss();
-                                            }
-                                        })
+                                .setPositiveButton(R.string.btn_yes_exclaim, new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int whichButton) {
+                                        try {
+                                            startActivity(new Intent(Intent.ACTION_VIEW,
+                                                    Uri.parse("market://details?id=" + getString(R.string.ui_unlock_package))));
+                                        } catch (ActivityNotFoundException e) {
+                                            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(
+                                                    "http://play.google.com/store/apps/details?id="
+                                                            + getString(R.string.ui_unlock_package))));
+                                        }
+                                    }
+                                })
+                                .setNegativeButton(R.string.btn_no_danks, new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int whichButton) {
+                                        dialog.dismiss();
+                                    }
+                                })
                                 .show();
                     }
                 });
@@ -2107,24 +2056,20 @@ public class MainActivity extends BaseActivity
                 public void onClick(View view) {
                     new MaterialDialog.Builder(MainActivity.this).inputRange(3, 20)
                             .alwaysCallInputCallback()
-                            .input(getString(R.string.user_enter), null,
-                                    new MaterialDialog.InputCallback() {
-                                        @Override
-                                        public void onInput(@NonNull MaterialDialog dialog,
-                                                CharSequence input) {
-                                            final EditText editText = dialog.getInputEditText();
-                                            EditTextValidator.validateUsername(editText);
-                                            if (input.length() >= 3 && input.length() <= 20) {
-                                                dialog.getActionButton(DialogAction.POSITIVE)
-                                                        .setEnabled(true);
-                                            }
-                                        }
-                                    })
+                            .input(getString(R.string.user_enter), null, new MaterialDialog.InputCallback() {
+                                @Override
+                                public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                                    final EditText editText = dialog.getInputEditText();
+                                    EditTextValidator.validateUsername(editText);
+                                    if (input.length() >= 3 && input.length() <= 20) {
+                                        dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                                    }
+                                }
+                            })
                             .positiveText(R.string.user_btn_goto)
                             .onPositive(new MaterialDialog.SingleButtonCallback() {
                                 @Override
-                                public void onClick(@NonNull MaterialDialog dialog,
-                                        @NonNull DialogAction which) {
+                                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                                     Intent inte = new Intent(MainActivity.this, Profile.class);
                                     //noinspection ConstantConditions
                                     inte.putExtra(Profile.EXTRA_PROFILE,
@@ -2160,8 +2105,7 @@ public class MainActivity extends BaseActivity
         final Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
 
         final ActionBarDrawerToggle actionBarDrawerToggle =
-                new ActionBarDrawerToggle(MainActivity.this, drawerLayout, toolbar,
-                        R.string.btn_open, R.string.btn_close) {
+                new ActionBarDrawerToggle(MainActivity.this, drawerLayout, toolbar, R.string.btn_open, R.string.btn_close) {
                     @Override
                     public void onDrawerSlide(View drawerView, float slideOffset) {
                         super.onDrawerSlide(drawerView, 0); // this disables the animation
@@ -2177,15 +2121,12 @@ public class MainActivity extends BaseActivity
                                 current -= 1;
                             }
                             String compare = usedArray.get(current);
-                            if (compare.equals("random")
-                                    || compare.equals("myrandom")
-                                    || compare.equals("randnsfw")) {
+                            if (compare.equals("random") || compare.equals("myrandom") || compare.equals("randnsfw")) {
                                 if (adapter != null
                                         && adapter.getCurrentFragment() != null
                                         && ((SubmissionsView) adapter.getCurrentFragment()).adapter.dataSet.subredditRandom
                                         != null) {
-                                    String sub =
-                                            ((SubmissionsView) adapter.getCurrentFragment()).adapter.dataSet.subredditRandom;
+                                    String sub = ((SubmissionsView) adapter.getCurrentFragment()).adapter.dataSet.subredditRandom;
                                     doSubSidebarNoLoad(sub);
                                     doSubSidebar(sub);
                                 }
@@ -2198,8 +2139,7 @@ public class MainActivity extends BaseActivity
                     @Override
                     public void onDrawerClosed(View view) {
                         super.onDrawerClosed(view);
-                        InputMethodManager imm =
-                                (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
                         imm.hideSoftInputFromWindow(drawerLayout.getWindowToken(), 0);
                     }
                 };
@@ -2215,6 +2155,19 @@ public class MainActivity extends BaseActivity
 
 
         setDrawerSubList();
+        hideDrawerItems();
+    }
+
+    public void hideDrawerItems() {
+        for (DrawerItemsDialog.SettingsDrawerEnum settingDrawerItem : DrawerItemsDialog.SettingsDrawerEnum
+                .values()) {
+            View drawerItem = drawerSubList.findViewById(settingDrawerItem.drawerId);
+            if (drawerItem != null
+                    && drawerItem.getVisibility() == View.VISIBLE
+                    && (SettingValues.selectedDrawerItems & settingDrawerItem.value) == 0) {
+                drawerItem.setVisibility(View.GONE);
+            }
+        }
     }
 
     public void doForcePrefs() {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/DrawerItemsDialog.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/DrawerItemsDialog.java
@@ -1,0 +1,110 @@
+package me.ccrama.redditslide.Fragments;
+
+import android.os.Bundle;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.CheckBox;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
+
+import me.ccrama.redditslide.R;
+import me.ccrama.redditslide.SettingValues;
+
+public class DrawerItemsDialog extends MaterialDialog {
+    public DrawerItemsDialog(final Builder builder) {
+        super(builder.customView(R.layout.dialog_drawer_items, false)
+                .title(R.string.settings_general_title_drawer_items)
+                .positiveText(android.R.string.ok)
+                .canceledOnTouchOutside(false)
+                .onPositive(new SingleButtonCallback() {
+                    @Override
+                    public void onClick(@NonNull MaterialDialog dialog,
+                            @NonNull DialogAction which) {
+                        if (SettingsThemeFragment.changed) {
+                            SettingValues.prefs.edit()
+                                    .putLong(SettingValues.PREF_SELECTED_DRAWER_ITEMS,
+                                            SettingValues.selectedDrawerItems)
+                                    .apply();
+                        }
+                    }
+                }));
+
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (SettingValues.selectedDrawerItems == -1) {
+            SettingValues.selectedDrawerItems = 0;
+            for (final SettingsDrawerEnum settingDrawerItem : SettingsDrawerEnum.values()) {
+                SettingValues.selectedDrawerItems += settingDrawerItem.value;
+            }
+            SettingValues.prefs.edit()
+                    .putLong(SettingValues.PREF_SELECTED_DRAWER_ITEMS,
+                            SettingValues.selectedDrawerItems)
+                    .apply();
+        }
+
+        setupViews();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        SettingValues.prefs.edit()
+                .putLong(SettingValues.PREF_SELECTED_DRAWER_ITEMS,
+                        SettingValues.selectedDrawerItems)
+                .apply();
+    }
+
+    private void setupViews() {
+        for (final SettingsDrawerEnum settingDrawerItem : SettingsDrawerEnum.values()) {
+            findViewById(settingDrawerItem.layoutId).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    CheckBox checkBox = (CheckBox) findViewById(settingDrawerItem.checkboxId);
+                    if (checkBox.isChecked()) {
+                        SettingValues.selectedDrawerItems -= settingDrawerItem.value;
+                    } else {
+                        SettingValues.selectedDrawerItems += settingDrawerItem.value;
+                    }
+                    checkBox.setChecked(!checkBox.isChecked());
+                }
+            });
+            SettingsThemeFragment.changed = true;
+            ((CheckBox) findViewById(settingDrawerItem.checkboxId)).setChecked(
+                    (SettingValues.selectedDrawerItems & settingDrawerItem.value) != 0);
+        }
+    }
+
+    public enum SettingsDrawerEnum {
+        PROFILE(1, R.id.settings_drawer_profile, R.id.settings_drawer_profile_checkbox,
+                R.id.prof_click),
+        INBOX(1 << 1, R.id.settings_drawer_inbox, R.id.settings_drawer_inbox_checkbox, R.id.inbox),
+        MULTIREDDITS(1 << 2, R.id.settings_drawer_multireddits,
+                R.id.settings_drawer_multireddits_checkbox, R.id.multi),
+        GOTO_PROFILE(1 << 3, R.id.settings_drawer_goto_profile,
+                R.id.settings_drawer_goto_profile_checkbox, R.id.prof),
+        DISCOVER(1 << 4, R.id.settings_drawer_discover, R.id.settings_drawer_discover_checkbox,
+                R.id.discover);
+
+        public long value;
+        @IdRes
+        public int  layoutId;
+        @IdRes
+        public int  checkboxId;
+        @IdRes
+        public int  drawerId;
+
+        SettingsDrawerEnum(long value, @IdRes int layoutId, @IdRes int checkboxId,
+                @IdRes int drawerId) {
+            this.value = value;
+            this.layoutId = layoutId;
+            this.checkboxId = checkboxId;
+            this.drawerId = drawerId;
+        }
+    }
+}

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
@@ -193,6 +193,14 @@ public class SettingsGeneralFragment<ActivityType extends AppCompatActivity & Fo
 
     /* Allow SettingsGeneral and Settings Activity classes to use the same XML functionality */
     public void Bind() {
+        context.findViewById(R.id.settings_general_drawer_items)
+                .setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        new DrawerItemsDialog(new MaterialDialog.Builder(context)).show();
+                    }
+                });
+
         {
             SwitchCompat single = context.findViewById(R.id.settings_general_immersivemode);
 

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -512,7 +512,9 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         doLanguages();
         lastPosition = new ArrayList<>();
 
-        new SetupIAB().execute();
+        if (BuildConfig.FLAVOR == "withGPlay") {
+            new SetupIAB().execute();
+        }
 
         if (!appRestart.contains("startScreen")) {
             Authentication.isLoggedIn = appRestart.getBoolean("loggedin", false);

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -105,21 +105,22 @@ public class SettingValues {
     public static final String PREF_SELFTEXT_IMAGE_COMMENT = "selftextImageComment";
     public static final String SYNCCIT_AUTH                = "SYNCCIT_AUTH";
     public static final String SYNCCIT_NAME                = "SYNCCIT_NAME";
-    public static final String PREF_BLUR                 = "blur";
-    public static final String PREF_ALBUM_SWIPE          = "albumswipe";
-    public static final String PREF_COMMENT_NAV          = "commentVolumeNav";
-    public static final String PREF_COLOR_COMMENT_DEPTH  = "colorCommentDepth";
-    public static final String COMMENT_DEPTH             = "commentDepth";
-    public static final String COMMENT_COUNT             = "commentcount";
-    public static final String PREF_USER_FILTERS         = "userFilters";
-    public static final String PREF_COLOR_ICON           = "colorIcon";
-    public static final String PREF_PEEK                 = "peek";
-    public static final String PREF_LARGE_LINKS          = "largeLinks";
-    public static final String PREF_LARGE_DEPTH          = "largeDepth";
-    public static final String PREF_TITLE_TOP            = "titleTop";
-    public static final String PREF_HIGHLIGHT_COMMENT_OP = "commentOP";
-    public static final String PREF_LONG_LINK            = "shareLongLink";
-    public static final String PREF_SELECTED_BROWSER     = "selectedBrowser";
+    public static final String PREF_BLUR                   = "blur";
+    public static final String PREF_ALBUM_SWIPE            = "albumswipe";
+    public static final String PREF_COMMENT_NAV            = "commentVolumeNav";
+    public static final String PREF_COLOR_COMMENT_DEPTH    = "colorCommentDepth";
+    public static final String COMMENT_DEPTH               = "commentDepth";
+    public static final String COMMENT_COUNT               = "commentcount";
+    public static final String PREF_USER_FILTERS           = "userFilters";
+    public static final String PREF_COLOR_ICON             = "colorIcon";
+    public static final String PREF_PEEK                   = "peek";
+    public static final String PREF_LARGE_LINKS            = "largeLinks";
+    public static final String PREF_LARGE_DEPTH            = "largeDepth";
+    public static final String PREF_TITLE_TOP              = "titleTop";
+    public static final String PREF_HIGHLIGHT_COMMENT_OP   = "commentOP";
+    public static final String PREF_LONG_LINK              = "shareLongLink";
+    public static final String PREF_SELECTED_BROWSER       = "selectedBrowser";
+    public static final String PREF_SELECTED_DRAWER_ITEMS  = "selectedDrawerItems";
 
     public static CreateCardView.CardEnum defaultCardView;
     public static Sorting                 defaultSorting;
@@ -240,6 +241,7 @@ public class SettingValues {
     public static boolean highlightCommentOP;
     public static boolean highlightTime;
     public static String  selectedBrowser;
+    public static long    selectedDrawerItems;
 
     public static void setAllValues(SharedPreferences settings) {
         prefs = settings;
@@ -390,6 +392,7 @@ public class SettingValues {
         colorIcon = prefs.getBoolean(PREF_COLOR_ICON, false);
         peek = prefs.getBoolean(PREF_PEEK, false);
         selectedBrowser = prefs.getString(PREF_SELECTED_BROWSER, "");
+        selectedDrawerItems = prefs.getLong(PREF_SELECTED_DRAWER_ITEMS, -1);
     }
 
     public static void setPicsEnabled(String sub, boolean checked) {

--- a/app/src/main/res/layout/activity_settings_general_child.xml
+++ b/app/src/main/res/layout/activity_settings_general_child.xml
@@ -541,6 +541,31 @@
         android:tag="label"
         android:textColor="?attr/colorAccent" />
 
+    <LinearLayout
+            android:id="@+id/settings_general_drawer_items"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_general_title_drawer_items"
+                android:textColor="?attr/fontColor"
+                android:textSize="14sp"/>
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha=".86"
+                android:text="@string/settings_general_subtitle_drawer_items"
+                android:textColor="?attr/fontColor"
+                android:textSize="13sp"/>
+    </LinearLayout>
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="56dp"

--- a/app/src/main/res/layout/dialog_drawer_items.xml
+++ b/app/src/main/res/layout/dialog_drawer_items.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:background="?attr/activity_background">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+        <LinearLayout
+                android:id="@+id/settings_drawer_profile"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal">
+
+            <CheckBox
+                    android:id="@+id/settings_drawer_profile_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:clickable="false"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:text="@string/drawer_profile"/>
+        </LinearLayout>
+
+        <LinearLayout
+                android:id="@+id/settings_drawer_inbox"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal">
+
+            <CheckBox
+                    android:id="@+id/settings_drawer_inbox_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:clickable="false"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:text="@string/title_inbox"/>
+        </LinearLayout>
+
+        <LinearLayout
+                android:id="@+id/settings_drawer_multireddits"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal">
+
+            <CheckBox
+                    android:id="@+id/settings_drawer_multireddits_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:clickable="false"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:text="@string/title_multireddits"/>
+        </LinearLayout>
+
+        <LinearLayout
+                android:id="@+id/settings_drawer_goto_profile"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal">
+
+            <CheckBox
+                    android:id="@+id/settings_drawer_goto_profile_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:clickable="false"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:text="@string/drawer_goto_profile"/>
+        </LinearLayout>
+
+        <LinearLayout
+                android:id="@+id/settings_drawer_discover"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="?android:selectableItemBackground"
+                android:orientation="horizontal">
+
+            <CheckBox
+                    android:id="@+id/settings_drawer_discover_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:clickable="false"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    android:text="@string/discover_title"/>
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -594,6 +594,8 @@
     <string name="settings_set_image_location">Images will be saved to %s</string>
     <string name="settings_general_immersive_mode">Immersive fullscreen mode</string>
     <string name="settings_general_immersive_mode_desc">Hide the status and navigation bars (experimental)</string>
+    <string name="settings_general_title_drawer_items">Drawer Items</string>
+    <string name="settings_general_subtitle_drawer_items">Select which drawer items to display</string>
 
 
     <!-- Settings titles displayed in settings activity-->


### PR DESCRIPTION
Request from here https://github.com/ccrama/Slide/issues/2764

This change adds a setting to General Settings that shows a dialog to let you turn buttons in the slide out menu on and off. These values are stored as a bitmasked (byte masked? Bite Masqued) long in settings we can read out of from a single source.

This will let you hide a subset of the options (You, Inbox, Multireddits, Go to profile, Discover). All of these are handled in a single `for-loop` for hiding

The `enum` in `DialogItemsDialog` sort of just stores everything needed to pull this off without too much linkage between classes.

Current users upgrading to this should just have everything enabled since I default the value to -1 **but please check this personally if possible**
I am pretty sure this will "just work" as is though. Testing proved it to be true at least.