### PR TITLE
Allow night mode to follow system in Android M and higher

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsThemeFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsThemeFragment.java
@@ -433,96 +433,101 @@ public class SettingsThemeFragment<ActivityType extends BaseActivity & SettingsF
                                     });
                         }
                     }
-                    {
-                        final List<String> timesStart = new ArrayList<String>() {{
-                            add("6pm");
-                            add("7pm");
-                            add("8pm");
-                            add("9pm");
-                            add("10pm");
-                            add("11pm");
-                        }};
-                        final Spinner startSpinner = dialoglayout.findViewById(R.id.start_spinner);
-                        final ArrayAdapter<String> startAdapter =
-                                new ArrayAdapter<>(context,
-                                        android.R.layout.simple_spinner_item, timesStart);
-                        startAdapter.setDropDownViewResource(
-                                android.R.layout.simple_spinner_dropdown_item);
-                        startSpinner.setAdapter(startAdapter);
+                    if (!Reddit.isNightModeAuto) {
+                        {
+                            final List<String> timesStart = new ArrayList<String>() {{
+                                add("6pm");
+                                add("7pm");
+                                add("8pm");
+                                add("9pm");
+                                add("10pm");
+                                add("11pm");
+                            }};
+                            dialoglayout.findViewById(R.id.start_spinner_layout)
+                                    .setVisibility(View.VISIBLE);
+                            final Spinner startSpinner =
+                                    dialoglayout.findViewById(R.id.start_spinner);
+                            final ArrayAdapter<String> startAdapter = new ArrayAdapter<>(context,
+                                    android.R.layout.simple_spinner_item, timesStart);
+                            startAdapter.setDropDownViewResource(
+                                    android.R.layout.simple_spinner_dropdown_item);
+                            startSpinner.setAdapter(startAdapter);
 
-                        //set the currently selected pref
-                        startSpinner.setSelection(startAdapter.getPosition(
-                                Integer.toString(SettingValues.nightStart).concat("pm")));
+                            //set the currently selected pref
+                            startSpinner.setSelection(startAdapter.getPosition(
+                                    Integer.toString(SettingValues.nightStart).concat("pm")));
 
-                        startSpinner.setOnItemSelectedListener(
-                                new AdapterView.OnItemSelectedListener() {
-                                    @Override
-                                    public void onItemSelected(AdapterView<?> parent, View view,
-                                                               int position, long id) {
-                                        //get the time, but remove the "pm" from the string when parsing
-                                        final int time = Integer.parseInt(
-                                                ((String) startSpinner.getItemAtPosition(
-                                                        position)).replaceAll("pm", ""));
+                            startSpinner.setOnItemSelectedListener(
+                                    new AdapterView.OnItemSelectedListener() {
+                                        @Override
+                                        public void onItemSelected(AdapterView<?> parent, View view,
+                                                int position, long id) {
+                                            //get the time, but remove the "pm" from the string when parsing
+                                            final int time = Integer.parseInt(
+                                                    ((String) startSpinner.getItemAtPosition(
+                                                            position)).replaceAll("pm", ""));
 
-                                        SettingValues.nightStart = time;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_START, time)
-                                                .apply();
-                                    }
+                                            SettingValues.nightStart = time;
+                                            SettingValues.prefs.edit()
+                                                    .putInt(SettingValues.PREF_NIGHT_START, time)
+                                                    .apply();
+                                        }
 
-                                    @Override
-                                    public void onNothingSelected(AdapterView<?> parent) {
+                                        @Override
+                                        public void onNothingSelected(AdapterView<?> parent) {
 
-                                    }
-                                });
-                    }
-                    {
-                        final List<String> timesEnd = new ArrayList<String>() {{
-                            add("12am");
-                            add("1am");
-                            add("2am");
-                            add("3am");
-                            add("4am");
-                            add("5am");
-                            add("6am");
-                            add("7am");
-                            add("8am");
-                            add("9am");
-                            add("10am");
-                        }};
-                        final Spinner endSpinner = dialoglayout.findViewById(R.id.end_spinner);
-                        final ArrayAdapter<String> endAdapter =
-                                new ArrayAdapter<>(context,
-                                        android.R.layout.simple_spinner_item, timesEnd);
-                        endAdapter.setDropDownViewResource(
-                                android.R.layout.simple_spinner_dropdown_item);
-                        endSpinner.setAdapter(endAdapter);
+                                        }
+                                    });
+                        }
+                        {
+                            final List<String> timesEnd = new ArrayList<String>() {{
+                                add("12am");
+                                add("1am");
+                                add("2am");
+                                add("3am");
+                                add("4am");
+                                add("5am");
+                                add("6am");
+                                add("7am");
+                                add("8am");
+                                add("9am");
+                                add("10am");
+                            }};
+                            dialoglayout.findViewById(R.id.end_spinner_layout)
+                                    .setVisibility(View.VISIBLE);
+                            final Spinner endSpinner = dialoglayout.findViewById(R.id.end_spinner);
+                            final ArrayAdapter<String> endAdapter = new ArrayAdapter<>(context,
+                                    android.R.layout.simple_spinner_item, timesEnd);
+                            endAdapter.setDropDownViewResource(
+                                    android.R.layout.simple_spinner_dropdown_item);
+                            endSpinner.setAdapter(endAdapter);
 
-                        //set the currently selected pref
-                        endSpinner.setSelection(endAdapter.getPosition(
-                                Integer.toString(SettingValues.nightEnd).concat("am")));
+                            //set the currently selected pref
+                            endSpinner.setSelection(endAdapter.getPosition(
+                                    Integer.toString(SettingValues.nightEnd).concat("am")));
 
-                        endSpinner.setOnItemSelectedListener(
-                                new AdapterView.OnItemSelectedListener() {
-                                    @Override
-                                    public void onItemSelected(AdapterView<?> parent, View view,
-                                                               int position, long id) {
-                                        //get the time, but remove the "am" from the string when parsing
-                                        final int time = Integer.parseInt(
-                                                ((String) endSpinner.getItemAtPosition(
-                                                        position)).replaceAll("am", ""));
+                            endSpinner.setOnItemSelectedListener(
+                                    new AdapterView.OnItemSelectedListener() {
+                                        @Override
+                                        public void onItemSelected(AdapterView<?> parent, View view,
+                                                int position, long id) {
+                                            //get the time, but remove the "am" from the string when parsing
+                                            final int time = Integer.parseInt(
+                                                    ((String) endSpinner.getItemAtPosition(
+                                                            position)).replaceAll("am", ""));
 
-                                        SettingValues.nightEnd = time;
-                                        SettingValues.prefs.edit()
-                                                .putInt(SettingValues.PREF_NIGHT_END, time)
-                                                .apply();
-                                    }
+                                            SettingValues.nightEnd = time;
+                                            SettingValues.prefs.edit()
+                                                    .putInt(SettingValues.PREF_NIGHT_END, time)
+                                                    .apply();
+                                        }
 
-                                    @Override
-                                    public void onNothingSelected(AdapterView<?> parent) {
+                                        @Override
+                                        public void onNothingSelected(AdapterView<?> parent) {
 
-                                    }
-                                });
+                                        }
+                                    });
+                        }
                     }
                     {
                         Button okayButton = dialoglayout.findViewById(R.id.ok);

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -1,10 +1,12 @@
 package me.ccrama.redditslide;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.UiModeManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -16,6 +18,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -115,6 +118,8 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     public        boolean      active;
     private       ImageLoader  defaultImageLoader;
     public static OkHttpClient client;
+
+    public static boolean isNightModeAuto = false;
 
     public static void forceRestart(Context context, boolean forceLoadScreen) {
         if (forceLoadScreen) {
@@ -475,6 +480,10 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
             client = new OkHttpClient();
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            setNightModeAuto();
+        }
+
         overrideLanguage =
                 getSharedPreferences("SETTINGS", 0).getBoolean(SettingValues.PREF_OVERRIDE_LANGUAGE,
                         false);
@@ -680,5 +689,17 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
 
     public static Context getAppContext() {
         return mApplication.getApplicationContext();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static void setNightModeAuto() {
+        UiModeManager uiModeManager =
+                (UiModeManager) getAppContext().getSystemService(Context.UI_MODE_SERVICE);
+        if (uiModeManager != null) {
+            uiModeManager.setNightMode(UiModeManager.MODE_NIGHT_AUTO);
+            isNightModeAuto = true;
+        } else {
+            isNightModeAuto = false;
+        }
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -1,6 +1,7 @@
 package me.ccrama.redditslide;
 
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 
 import net.dean.jraw.models.CommentSort;
 import net.dean.jraw.paginators.Sorting;
@@ -472,8 +473,17 @@ public class SettingValues {
 
 
     public static boolean isNight() {
-        int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-        return (hour >= nightStart + 12 || hour < nightEnd) && tabletUI && nightMode;
+        if (tabletUI && nightMode) {
+            if (Reddit.isNightModeAuto) {
+                return (Reddit.getAppContext().getResources().getConfiguration().uiMode
+                        & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+            } else {
+                int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+                return hour >= nightStart + 12 || hour < nightEnd;
+            }
+        } else {
+            return false;
+        }
     }
 
     public static Sorting getBaseSubmissionSort(String sub) {

--- a/app/src/main/res/layout/nightmode.xml
+++ b/app/src/main/res/layout/nightmode.xml
@@ -117,9 +117,11 @@
 
                 <!--Time selection-->
                 <LinearLayout
+                        android:id="@+id/start_spinner_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp">
+                        android:layout_marginTop="16dp"
+                        android:visibility="gone">
 
                     <TextView
                             android:layout_width="wrap_content"
@@ -138,9 +140,11 @@
                 </LinearLayout>
 
                 <LinearLayout
+                        android:id="@+id/end_spinner_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp">
+                        android:layout_marginTop="16dp"
+                        android:visibility="gone">
 
                     <TextView
                             android:layout_width="wrap_content"


### PR DESCRIPTION
I made night mode follow the system on Android M and higher.
I additionally hide the options to set your own time if you're on M or higher so the system can just do this for us.

If you'd like the options to retain, I can keep them. But this is without. With, I'd have to add another option to this menu, which is not a big deal but I hate adding options.

Let me know either way and I can make the change if desired.