### PR TITLE
Remove screenOrientation setting from CommentsScreen in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -407,7 +407,6 @@
         <activity
                 android:name=".Activities.CommentsScreen"
                 android:alwaysRetainTaskState="true"
-                android:screenOrientation="sensor"
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
                 android:theme="@style/swipeable"
                 android:windowSoftInputMode="adjustResize"/>


### PR DESCRIPTION
Fixes issue https://github.com/ccrama/Slide/issues/2775

I am absolutely floored no one noticed this. This is actually not an Android P issue, but CommentScreen did not respect orientation lock, only the sensor.

Removing this manifest resolved it on all API levels