### PR TITLE
Catch v.redd.it links in content filter

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/ContentType.java
+++ b/app/src/main/java/me/ccrama/redditslide/ContentType.java
@@ -107,7 +107,7 @@ public class ContentType {
             final String host = uri.getHost().toLowerCase(Locale.ENGLISH);
             final String path = uri.getPath().toLowerCase(Locale.ENGLISH);
 
-            return Reddit.videoPlugin && hostContains(host, "youtu.be", "youtube.com",
+            return hostContains(host, "youtu.be", "youtube.com",
                     "youtube.co.uk") && !path.contains("/user/") && !path.contains("/channel/");
 
         } catch (NullPointerException e) {
@@ -189,7 +189,7 @@ public class ContentType {
                     "what-if.xkcd.com")) {
                 return Type.XKCD;
             }
-            if (hostContains(host, "tumblr.com") && uri.getPath().contains("post")) {
+            if (uri.getPath().contains("tumblr.com") && uri.getPath().contains("post")) {
                 return Type.TUMBLR;
             }
             if (hostContains(host, "reddit.com", "redd.it")) {

--- a/app/src/main/java/me/ccrama/redditslide/PostMatch.java
+++ b/app/src/main/java/me/ccrama/redditslide/PostMatch.java
@@ -182,6 +182,8 @@ public class PostMatch {
                 }
                 break;
             case GIF:
+            case VREDDIT_DIRECT:
+            case VREDDIT_REDIRECT:
                 if (gifs) {
                     contentMatch = true;
                 }


### PR DESCRIPTION
Do not require videoPlugin to catch YouTube links in content filter

Fixes https://github.com/ccrama/Slide/issues/2783

v.redd.it links seem to match as gifs in ContentType. If you'd rather these be videos, we should move in both places. For now, I just included it in the GIF block for PostMatch since it matches ContentType

Additionally it seems the lack of the videoPlugin would cause YouTube links to not get caught in the filter.

Additionally additionally I made it so all Tumblr urls are checked, including *.tumblr.com. Before tumblr.com had to be the start of the URL and would get through the filter

EDIT: Seems you specified these are in fact gifs [on Reddit](https://www.reddit.com/r/slideforreddit/comments/8kv0o5/content_filter/dzavdwv)