### PR TITLE
Make contest mode header use correct font color instead of hardcoded white

### DIFF
--- a/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
+++ b/app/src/main/res/layout/fragment_verticalcontenttoolbar.xml
@@ -130,7 +130,7 @@
                     android:gravity="center"
                     android:padding="8dp"
                     android:text="@string/submission_info_contest"
-                    android:textColor="@color/white"
+                    android:textColor="?attr/fontColor"
                     android:textSize="12sp"/>
 
             <TextView


### PR DESCRIPTION
Fixes #2332 