### PR TITLE
Marked app as unimportant for autofill

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/BaseActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/BaseActivity.java
@@ -1,10 +1,10 @@
 package me.ccrama.redditslide.Activities;
 
+import android.annotation.TargetApi;
 import android.app.ActivityManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.drawable.BitmapDrawable;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
@@ -14,7 +14,6 @@ import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
@@ -132,6 +131,9 @@ public class BaseActivity extends PeekViewActivity
         applyOverrideLanguage();
 
         super.onCreate(savedInstanceState);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            setAutofill();
+        }
 
         /**
          * Enable fullscreen immersive mode if setting is checked
@@ -164,6 +166,12 @@ public class BaseActivity extends PeekViewActivity
             }
         }
 
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    protected void setAutofill() {
+        getWindow().getDecorView()
+                .setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS);
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Login.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Login.java
@@ -1,5 +1,6 @@
 package me.ccrama.redditslide.Activities;
 
+import android.annotation.TargetApi;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
@@ -12,7 +13,6 @@ import android.util.Log;
 import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
-import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -116,6 +116,12 @@ public class Login extends BaseActivityAnim {
         });
 
         webView.loadUrl(authorizationUrl);
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.O)
+    protected void setAutofill() {
+        getWindow().getDecorView().setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_AUTO);
     }
 
     private void doSubStrings(ArrayList<Subreddit> subs) {


### PR DESCRIPTION
Quick and dirty fix for https://github.com/ccrama/Slide/issues/2789

EDIT: I changed how this is implemented so now un-importance is set on the `BaseActivity` and we can override this anywhere up the chain like in `Login` for views that may need to utilize the Autofill API.

Now nothing native should get the Autofill prompt since we're not doing that in the app anywhere natively.