### PR TITLE
Fixed reader mode and custom tabs not being respected

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
@@ -382,7 +382,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
                                                             int which) {
                                                         Intent i = new Intent(getActivity(),
                                                                 Website.class);
-                                                        i.putExtra(Website.EXTRA_URL, url);
+                                                        i.putExtra(LinkUtil.EXTRA_URL, url);
                                                         startActivity(i);
                                                         getActivity().finish();
                                                     }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -217,7 +217,7 @@ public class AlbumPager extends FullScreenActivity
                                             public void onClick(DialogInterface dialog, int which) {
                                                 Intent i =
                                                         new Intent(AlbumPager.this, Website.class);
-                                                i.putExtra(Website.EXTRA_URL, url);
+                                                i.putExtra(LinkUtil.EXTRA_URL, url);
                                                 startActivity(i);
                                                 finish();
                                             }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/LiveThread.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/LiveThread.java
@@ -22,7 +22,6 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
@@ -60,6 +59,7 @@ import me.ccrama.redditslide.Views.CommentOverflow;
 import me.ccrama.redditslide.Views.SidebarLayout;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.HttpUtil;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.SubmissionParser;
 import me.ccrama.redditslide.util.TwitterObject;
@@ -203,62 +203,85 @@ public class LiveThread extends BaseActivityAnim {
                         com.neovisionaries.ws.client.WebSocket ws = new WebSocketFactory().createSocket(thread.getWebsocketUrl());
                         ws.addListener(new WebSocketListener() {
                             @Override
-                            public void onStateChanged(com.neovisionaries.ws.client.WebSocket websocket, WebSocketState newState) throws Exception {
+                            public void onStateChanged(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketState newState) {
 
                             }
 
                             @Override
-                            public void onConnected(com.neovisionaries.ws.client.WebSocket websocket, Map<String, List<String>> headers) throws Exception {
+                            public void onConnected(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    Map<String, List<String>> headers) {
 
                             }
 
                             @Override
-                            public void onConnectError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause) throws Exception {
+                            public void onConnectError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause) {
 
                             }
 
                             @Override
-                            public void onDisconnected(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer) throws Exception {
+                            public void onDisconnected(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame serverCloseFrame,
+                                    WebSocketFrame clientCloseFrame, boolean closedByServer) {
 
                             }
 
                             @Override
-                            public void onFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onFrame(com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onContinuationFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onContinuationFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onTextFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onTextFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onBinaryFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onBinaryFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onCloseFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onCloseFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onPingFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onPingFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onPongFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onPongFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onTextMessage(com.neovisionaries.ws.client.WebSocket websocket, String s) throws Exception {
+                            public void onTextMessage(
+                                    com.neovisionaries.ws.client.WebSocket websocket, String s) {
                                 LogUtil.v("Recieved" + s);
                                 if (s.contains("\"type\": \"update\"")) {
                                     try {
@@ -299,67 +322,92 @@ public class LiveThread extends BaseActivityAnim {
                             }
 
                             @Override
-                            public void onBinaryMessage(com.neovisionaries.ws.client.WebSocket websocket, byte[] binary) throws Exception {
+                            public void onBinaryMessage(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    byte[] binary) {
 
                             }
 
                             @Override
-                            public void onSendingFrame(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onSendingFrame(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onFrameSent(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onFrameSent(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onFrameUnsent(com.neovisionaries.ws.client.WebSocket websocket, WebSocketFrame frame) throws Exception {
+                            public void onFrameUnsent(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause) throws Exception {
+                            public void onError(com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause) {
 
                             }
 
                             @Override
-                            public void onFrameError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause, WebSocketFrame frame) throws Exception {
+                            public void onFrameError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause, WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onMessageError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause, List<WebSocketFrame> frames) throws Exception {
+                            public void onMessageError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause, List<WebSocketFrame> frames) {
 
                             }
 
                             @Override
-                            public void onMessageDecompressionError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause, byte[] compressed) throws Exception {
+                            public void onMessageDecompressionError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause, byte[] compressed) {
 
                             }
 
                             @Override
-                            public void onTextMessageError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause, byte[] data) throws Exception {
+                            public void onTextMessageError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause, byte[] data) {
 
                             }
 
                             @Override
-                            public void onSendError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause, WebSocketFrame frame) throws Exception {
+                            public void onSendError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause, WebSocketFrame frame) {
 
                             }
 
                             @Override
-                            public void onUnexpectedError(com.neovisionaries.ws.client.WebSocket websocket, WebSocketException cause) throws Exception {
+                            public void onUnexpectedError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    WebSocketException cause) {
 
                             }
 
                             @Override
-                            public void handleCallbackError(com.neovisionaries.ws.client.WebSocket websocket, Throwable cause) throws Exception {
+                            public void handleCallbackError(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    Throwable cause) {
 
                             }
 
                             @Override
-                            public void onSendingHandshake(com.neovisionaries.ws.client.WebSocket websocket, String requestLine, List<String[]> headers) throws Exception {
+                            public void onSendingHandshake(
+                                    com.neovisionaries.ws.client.WebSocket websocket,
+                                    String requestLine, List<String[]> headers) {
 
                             }
                         });
@@ -421,7 +469,7 @@ public class LiveThread extends BaseActivityAnim {
                     @Override
                     public void onClick(View v) {
                         Intent i = new Intent(LiveThread.this, Website.class);
-                        i.putExtra(Website.EXTRA_URL, url);
+                        i.putExtra(LinkUtil.EXTRA_URL, url);
                         startActivity(i);
                     }
                 });
@@ -505,11 +553,11 @@ public class LiveThread extends BaseActivityAnim {
 
             public ItemHolder(View itemView) {
                 super(itemView);
-                title = (TextView) itemView.findViewById(R.id.title);
-                info = (SpoilerRobotoTextView) itemView.findViewById(R.id.body);
+                title = itemView.findViewById(R.id.title);
+                info = itemView.findViewById(R.id.body);
                 go = itemView.findViewById(R.id.go);
-                imageArea = (ImageView) itemView.findViewById(R.id.image_area);
-                twitterArea = (WebView) itemView.findViewById(R.id.twitter_area);
+                imageArea = itemView.findViewById(R.id.image_area);
+                twitterArea = itemView.findViewById(R.id.twitter_area);
                 twitterArea.setWebChromeClient(new WebChromeClient());
                 twitterArea.getSettings().setJavaScriptEnabled(true);
                 twitterArea.setBackgroundColor(Color.TRANSPARENT);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -845,7 +845,7 @@ public class MediaView extends FullScreenActivity
                         } catch (Exception e2) {
                             e2.printStackTrace();
                             Intent i = new Intent(MediaView.this, Website.class);
-                            i.putExtra(Website.EXTRA_URL, finalUrl);
+                            i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                             MediaView.this.startActivity(i);
                             finish();
                         }
@@ -900,14 +900,14 @@ public class MediaView extends FullScreenActivity
                                         });
                             } else {
                                 Intent i = new Intent(MediaView.this, Website.class);
-                                i.putExtra(Website.EXTRA_URL, finalUrl);
+                                i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                                 MediaView.this.startActivity(i);
                                 finish();
                             }
                         } catch (Exception e2) {
                             e2.printStackTrace();
                             Intent i = new Intent(MediaView.this, Website.class);
-                            i.putExtra(Website.EXTRA_URL, finalUrl);
+                            i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                             MediaView.this.startActivity(i);
                             finish();
                         }
@@ -941,7 +941,7 @@ public class MediaView extends FullScreenActivity
                     doLoadImage(url);
                 } else {
                     Intent i = new Intent(MediaView.this, Website.class);
-                    i.putExtra(Website.EXTRA_URL, contentUrl);
+                    i.putExtra(LinkUtil.EXTRA_URL, contentUrl);
                     MediaView.this.startActivity(i);
                     finish();
                 }
@@ -1000,7 +1000,7 @@ public class MediaView extends FullScreenActivity
                                     actuallyLoaded = finalUrl2;
                                 } else if (!imageShown) {
                                     Intent i = new Intent(MediaView.this, Website.class);
-                                    i.putExtra(Website.EXTRA_URL, finalUrl2);
+                                    i.putExtra(LinkUtil.EXTRA_URL, finalUrl2);
                                     MediaView.this.startActivity(i);
                                     finish();
                                 }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ReaderMode.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ReaderMode.java
@@ -31,14 +31,13 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.LinkUtil;
 
 public class ReaderMode extends BaseActivityAnim {
-
-    public static final String EXTRA_URL   = "url";
-    public static final String EXTRA_COLOR = "color";
+    private       int    mSubredditColor;
     public static String html;
     SpoilerRobotoTextView v;
-    String                url;
+    private String url;
 
 
     @Override
@@ -48,13 +47,14 @@ public class ReaderMode extends BaseActivityAnim {
         applyColorTheme("");
         setContentView(R.layout.activity_reader);
 
-        int subredditColor = getIntent().getExtras().getInt(EXTRA_COLOR, Palette.getDefaultColor());
+        mSubredditColor =
+                getIntent().getExtras().getInt(LinkUtil.EXTRA_COLOR, Palette.getDefaultColor());
 
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
-        setupAppBar(R.id.toolbar, "", true, subredditColor, R.id.appbar);
+        setupAppBar(R.id.toolbar, "", true, mSubredditColor, R.id.appbar);
 
         if (getIntent().hasExtra("url")) {
-            url = getIntent().getExtras().getString(EXTRA_URL, "");
+            url = getIntent().getExtras().getString(LinkUtil.EXTRA_URL, "");
             ((Toolbar) findViewById(R.id.toolbar)).setTitle(url);
 
         }
@@ -137,7 +137,7 @@ public class ReaderMode extends BaseActivityAnim {
         @Override
         protected void onPostExecute(Void aVoid) {
             ((SwipeRefreshLayout) ReaderMode.this.findViewById(R.id.refresh)).setRefreshing(false);
-            ((SwipeRefreshLayout) ReaderMode.this.findViewById(R.id.refresh)).setEnabled(false);
+            ReaderMode.this.findViewById(R.id.refresh).setEnabled(false);
 
             if (articleText != null) {
                 display(title, articleText);
@@ -155,7 +155,7 @@ public class ReaderMode extends BaseActivityAnim {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
                                         Intent i = new Intent(ReaderMode.this, Website.class);
-                                        i.putExtra(Website.EXTRA_URL, url);
+                                        i.putExtra(LinkUtil.EXTRA_URL, url);
                                         startActivity(i);
                                         finish();
                                     }
@@ -190,9 +190,7 @@ public class ReaderMode extends BaseActivityAnim {
                 finish();
                 return true;
             case R.id.web:
-                Intent i = new Intent(this, Website.class);
-                i.putExtra(Website.EXTRA_URL, url);
-                ReaderMode.this.startActivity(i);
+                LinkUtil.openUrl(url, mSubredditColor, this);
                 finish();
                 return true;
             case R.id.share:

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
@@ -360,7 +360,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
             @Override
             public void onError() {
                 Intent i = new Intent(getActivity(), Website.class);
-                i.putExtra(Website.EXTRA_URL, url);
+                i.putExtra(LinkUtil.EXTRA_URL, url);
                 startActivity(i);
                 getActivity().finish();
             }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -195,7 +195,7 @@ public class TumblrPager extends FullScreenActivity
         public void onError() {
             Intent i =
                     new Intent(TumblrPager.this, Website.class);
-            i.putExtra(Website.EXTRA_URL, url);
+            i.putExtra(LinkUtil.EXTRA_URL, url);
             startActivity(i);
             finish();
         }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -43,10 +43,6 @@ import me.ccrama.redditslide.util.LogUtil;
 
 public class Website extends BaseActivityAnim {
 
-    public static final String EXTRA_URL        = "url";
-    public static final String EXTRA_COLOR      = "color";
-    public static final String ADAPTER_POSITION = "adapter_position";
-
     WebView              v;
     String               url;
     int                  subredditColor;
@@ -79,7 +75,7 @@ public class Website extends BaseActivityAnim {
         MenuItem item = menu.findItem(R.id.store_cookies);
         item.setChecked(SettingValues.cookies);
 
-        if (!getIntent().hasExtra(ADAPTER_POSITION)) {
+        if (!getIntent().hasExtra(LinkUtil.ADAPTER_POSITION)) {
             menu.findItem(R.id.comments).setVisible(false);
         }
         return true;
@@ -108,7 +104,7 @@ public class Website extends BaseActivityAnim {
                 v.goBack();
                 return true;
             case R.id.comments:
-                final int commentUrl = getIntent().getExtras().getInt(ADAPTER_POSITION);
+                final int commentUrl = getIntent().getExtras().getInt(LinkUtil.ADAPTER_POSITION);
                 finish();
                 SubmissionsView.datachanged(commentUrl);
                 break;
@@ -134,7 +130,6 @@ public class Website extends BaseActivityAnim {
                             @Override
                             public void onReceiveValue(String html) {
                                 Intent i = new Intent(Website.this, ReaderMode.class);
-
                                 if (html != null && !html.isEmpty()) {
                                     ReaderMode.html = html;
                                     LogUtil.v(html);
@@ -142,7 +137,7 @@ public class Website extends BaseActivityAnim {
                                     ReaderMode.html = "";
                                     i.putExtra("url", v.getUrl());
                                 }
-                                i.putExtra(ReaderMode.EXTRA_COLOR, subredditColor);
+                                i.putExtra(LinkUtil.EXTRA_COLOR, subredditColor);
                                 startActivity(i);
 
                             }
@@ -175,8 +170,9 @@ public class Website extends BaseActivityAnim {
         super.onCreate(savedInstanceState);
         applyColorTheme("");
         setContentView(R.layout.activity_web);
-        url = getIntent().getExtras().getString(EXTRA_URL, "");
-        subredditColor = getIntent().getExtras().getInt(EXTRA_COLOR, Palette.getDefaultColor());
+        url = getIntent().getExtras().getString(LinkUtil.EXTRA_URL, "");
+        subredditColor =
+                getIntent().getExtras().getInt(LinkUtil.EXTRA_COLOR, Palette.getDefaultColor());
 
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
         setupAppBar(R.id.toolbar, "", true, subredditColor, R.id.appbar);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -80,6 +80,7 @@ import me.ccrama.redditslide.Views.DoEditorActions;
 import me.ccrama.redditslide.Views.RoundedBackgroundSpan;
 import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.LinkUtil;
 
 /**
  * Created by Carlos on 8/4/2016.
@@ -172,11 +173,11 @@ public class CommentAdapterHelper {
                     case 5: {
                         //Gild comment
                         Intent i = new Intent(mContext, Website.class);
-                        i.putExtra(Website.EXTRA_URL, "https://reddit.com"
+                        i.putExtra(LinkUtil.EXTRA_URL, "https://reddit.com"
                                 + adapter.submission.getPermalink()
                                 + n.getFullName().substring(3, n.getFullName().length())
                                 + "?context=3&inapp=false");
-                        i.putExtra(Website.EXTRA_COLOR, Palette.getColor(n.getSubredditName()));
+                        i.putExtra(LinkUtil.EXTRA_COLOR, Palette.getColor(n.getSubredditName()));
                         mContext.startActivity(i);
                     }
                     break;

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
@@ -60,6 +60,7 @@ import me.ccrama.redditslide.Views.CatchStaggeredGridLayoutManager;
 import me.ccrama.redditslide.Views.CreateCardView;
 import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.SubmissionParser;
 
 
@@ -156,7 +157,8 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
                         }
@@ -172,7 +174,8 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
                         }
@@ -205,7 +208,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     LayoutInflater inflater = mContext.getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.postmenu, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(mContext);
-                    final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                    final TextView title = dialoglayout.findViewById(R.id.title);
                     title.setText(Html.fromHtml(submission.getTitle()));
 
                     ((TextView) dialoglayout.findViewById(R.id.userpopup)).setText("/u/" + submission.getAuthor());
@@ -251,7 +254,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         public void onClick(View v) {
                             String urlString = "https://reddit.com" + submission.getPermalink();
                             Intent i = new Intent(mContext, Website.class);
-                            i.putExtra(Website.EXTRA_URL, urlString);
+                            i.putExtra(LinkUtil.EXTRA_URL, urlString);
                             mContext.startActivity(i);
                         }
                     });
@@ -320,7 +323,8 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                                 }
                             });
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
 
@@ -332,7 +336,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             });
             new PopulateSubmissionViewHolder().populateSubmissionViewHolder(holder, submission, mContext, false, false, dataSet.posts, listView, false, false, null, null);
 
-            final ImageView hideButton = (ImageView) holder.itemView.findViewById(R.id.hide);
+            final ImageView hideButton = holder.itemView.findViewById(R.id.hide);
             if (hideButton != null && isHiddenPost) {
                 hideButton.setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
@@ -63,6 +63,7 @@ import me.ccrama.redditslide.TimeUtils;
 import me.ccrama.redditslide.UserSubscriptions;
 import me.ccrama.redditslide.Views.CreateCardView;
 import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
 import me.ccrama.redditslide.util.SubmissionParser;
@@ -154,7 +155,8 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
                         }
@@ -170,7 +172,8 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         @Override
                         public void run() {
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
                         }
@@ -202,7 +205,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     LayoutInflater inflater = mContext.getLayoutInflater();
                     final View dialoglayout = inflater.inflate(R.layout.postmenu, null);
                     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(mContext);
-                    final TextView title = (TextView) dialoglayout.findViewById(R.id.title);
+                    final TextView title = dialoglayout.findViewById(R.id.title);
                     title.setText(Html.fromHtml(submission.getTitle()));
 
                     ((TextView) dialoglayout.findViewById(R.id.userpopup)).setText("/u/" + submission.getAuthor());
@@ -248,7 +251,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         public void onClick(View v) {
                             String urlString = "https://reddit.com" + submission.getPermalink();
                             Intent i = new Intent(mContext, Website.class);
-                            i.putExtra(Website.EXTRA_URL, urlString);
+                            i.putExtra(LinkUtil.EXTRA_URL, urlString);
                             mContext.startActivity(i);
                         }
                     });
@@ -317,7 +320,8 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                                 }
                             });
                             View view = s.getView();
-                            TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                            TextView tv =
+                                    view.findViewById(android.support.design.R.id.snackbar_text);
                             tv.setTextColor(Color.WHITE);
                             s.show();
 
@@ -329,7 +333,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             });
             new PopulateSubmissionViewHolder().populateSubmissionViewHolder(holder, submission, mContext, false, false, dataSet.posts, listView, false, false, null, null);
 
-            final ImageView hideButton = (ImageView) holder.itemView.findViewById(R.id.hide);
+            final ImageView hideButton = holder.itemView.findViewById(R.id.hide);
             if (hideButton != null) {
                 hideButton.setVisibility(View.GONE);
             }
@@ -370,7 +374,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             titleString.append(spacer);
 
             {
-                final ImageView mod = (ImageView) holder.itemView.findViewById(R.id.mod);
+                final ImageView mod = holder.itemView.findViewById(R.id.mod);
                 try {
                     if (UserSubscriptions.modOf.contains(comment.getSubredditName())) {
                         //todo
@@ -635,8 +639,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_distinguished,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -671,8 +674,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_undistinguished,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
                 } else {
@@ -707,8 +709,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     Snackbar s = Snackbar.make(holder.itemView, R.string.comment_removed,
                             Snackbar.LENGTH_LONG);
                     View view = s.getView();
-                    TextView tv =
-                            (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+                    TextView tv = view.findViewById(android.support.design.R.id.snackbar_text);
                     tv.setTextColor(Color.WHITE);
                     s.show();
 

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
@@ -555,7 +555,7 @@ public class MediaFragment extends Fragment {
                     doLoadImage(url);
                 } else {
                     Intent i = new Intent(getActivity(), Website.class);
-                    i.putExtra(Website.EXTRA_URL, contentUrl);
+                    i.putExtra(LinkUtil.EXTRA_URL, contentUrl);
                     getActivity().startActivity(i);
                 }
             }
@@ -640,7 +640,7 @@ public class MediaFragment extends Fragment {
                                     + "]");
                             if (getContext() != null) {
                                 Intent i = new Intent(getContext(), Website.class);
-                                i.putExtra(Website.EXTRA_URL, finalUrl);
+                                i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                                 getContext().startActivity(i);
                             }
                         }
@@ -693,13 +693,13 @@ public class MediaFragment extends Fragment {
                                         });
                             } else {
                                 Intent i = new Intent(getContext(), Website.class);
-                                i.putExtra(Website.EXTRA_URL, finalUrl);
+                                i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                                 getContext().startActivity(i);
                             }
                         } catch (Exception e2) {
                             e2.printStackTrace();
                             Intent i = new Intent(getContext(), Website.class);
-                            i.putExtra(Website.EXTRA_URL, finalUrl);
+                            i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                             getContext().startActivity(i);
                         }
                     }
@@ -759,7 +759,7 @@ public class MediaFragment extends Fragment {
                                         actuallyLoaded = finalUrl2;
                                     } else if (!imageShown) {
                                         Intent i = new Intent(getActivity(), Website.class);
-                                        i.putExtra(Website.EXTRA_URL, finalUrl2);
+                                        i.putExtra(LinkUtil.EXTRA_URL, finalUrl2);
                                         getActivity().startActivity(i);
                                     }
                                 }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragmentComment.java
@@ -279,13 +279,13 @@ public class MediaFragmentComment extends Fragment {
                                         });
                             } else {
                                 Intent i = new Intent(getContext(), Website.class);
-                                i.putExtra(Website.EXTRA_URL, finalUrl);
+                                i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                                 getContext().startActivity(i);
                             }
                         } catch (Exception e2) {
                             e2.printStackTrace();
                             Intent i = new Intent(getContext(), Website.class);
-                            i.putExtra(Website.EXTRA_URL, finalUrl);
+                            i.putExtra(LinkUtil.EXTRA_URL, finalUrl);
                             getContext().startActivity(i);
                         }
                     }
@@ -367,7 +367,7 @@ public class MediaFragmentComment extends Fragment {
                     doLoadImage(url);
                 } else {
                     Intent i = new Intent(getActivity(), Website.class);
-                    i.putExtra(Website.EXTRA_URL, contentUrl);
+                    i.putExtra(LinkUtil.EXTRA_URL, contentUrl);
                     getActivity().startActivity(i);
                 }
             }
@@ -506,7 +506,7 @@ public class MediaFragmentComment extends Fragment {
                                         actuallyLoaded = finalUrl2;
                                     } else if (!imageShown) {
                                         Intent i = new Intent(getActivity(), Website.class);
-                                        i.putExtra(Website.EXTRA_URL, finalUrl2);
+                                        i.putExtra(LinkUtil.EXTRA_URL, finalUrl2);
                                         getActivity().startActivity(i);
                                     }
                                 }

--- a/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
+++ b/app/src/main/java/me/ccrama/redditslide/OpenRedditLink.java
@@ -204,7 +204,7 @@ public class OpenRedditLink {
                         LinkUtil.openUrl(oldUrl, Palette.getStatusBarColor(), (Activity) context);
                     } else {
                         i = new Intent(context, Website.class);
-                        i.putExtra(Website.EXTRA_URL, oldUrl);
+                        i.putExtra(LinkUtil.EXTRA_URL, oldUrl);
                     }
                 } else {
                     return false;

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -9,6 +9,7 @@ import net.dean.jraw.paginators.TimePeriod;
 import java.util.Calendar;
 import java.util.Locale;
 
+import me.ccrama.redditslide.Fragments.SettingsHandlingFragment;
 import me.ccrama.redditslide.Views.CreateCardView;
 import me.ccrama.redditslide.Visuals.Palette;
 import me.ccrama.redditslide.util.SortingUtil;
@@ -35,15 +36,14 @@ public class SettingValues {
     public static final String PREF_COLOR_BACK                = "colorBack";
     public static final String PREF_IMAGE_SUBFOLDERS          = "imageSubfolders";
     public static final String PREF_COLOR_NAV_BAR             = "colorNavBar";
+    public static final String PREF_READER_MODE               = "readerDefault";
     public static final String PREF_READER_NIGHT              = "readernight";
     public static final String PREF_COLOR_EVERYWHERE          = "colorEverywhere";
     public static final String PREF_EXPANDED_TOOLBAR          = "expandedToolbar";
     public static final String PREF_SWAP                      = "Swap";
-    public static final String PREFS_WEB                      = "web";
     public static final String PREF_ACTIONBAR_VISIBLE         = "actionbarVisible";
     public static final String PREF_SMALL_TAG                 = "smallTag";
     public static final String PREF_ACTIONBAR_TAP             = "actionbarTap";
-    public static final String PREF_CUSTOMTABS                = "customtabs";
     public static final String PREF_STORE_HISTORY             = "storehistory";
     public static final String PREF_STORE_NSFW_HISTORY        = "storensfw";
     public static final String PREF_SCROLL_SEEN               = "scrollSeen";
@@ -71,21 +71,20 @@ public class SettingValues {
     public static final String PREF_LOW_RES_ALWAYS            = "lowResAlways";
     public static final String PREF_LOW_RES_MOBILE            = "lowRes";
     public static final String PREF_IMAGE_LQ                  = "imageLq";
-    public static final String PREF_COLOR_SUB_NAME          = "colorSubName";
-    public static final String PREF_OVERRIDE_LANGUAGE       = "overrideLanguage";
-    public static final String PREF_IMMERSIVE_MODE          = "immersiveMode";
-    public static final String PREF_SHOW_DOMAIN             = "showDomain";
-    public static final String PREF_CARD_TEXT               = "cardText";
-    public static final String PREF_ZOOM_DEFAULT            = "zoomDefault";
-    public static final String PREF_SUBREDDIT_SEARCH_METHOD = "subredditSearchMethod";
-    public static final String PREF_BACK_BUTTON_BEHAVIOR    = "backButtonBehavior";
-    public static final String PREF_READER                  = "readerDefault";
-    public static final String PREF_LQ_LOW                  = "lqLow";
-    public static final String PREF_LQ_MID                  = "lqMid";
-    public static final String PREF_LQ_HIGH                 = "lqHigh";
-    public static final String PREF_SOUND_NOTIFS            = "soundNotifs";
-    public static final String PREF_COOKIES                 = "storeCookies";
-    public static final String PREF_NIGHT_START             = "nightStart";
+    public static final String PREF_COLOR_SUB_NAME            = "colorSubName";
+    public static final String PREF_OVERRIDE_LANGUAGE         = "overrideLanguage";
+    public static final String PREF_IMMERSIVE_MODE            = "immersiveMode";
+    public static final String PREF_SHOW_DOMAIN               = "showDomain";
+    public static final String PREF_CARD_TEXT                 = "cardText";
+    public static final String PREF_ZOOM_DEFAULT              = "zoomDefault";
+    public static final String PREF_SUBREDDIT_SEARCH_METHOD   = "subredditSearchMethod";
+    public static final String PREF_BACK_BUTTON_BEHAVIOR      = "backButtonBehavior";
+    public static final String PREF_LQ_LOW                    = "lqLow";
+    public static final String PREF_LQ_MID                    = "lqMid";
+    public static final String PREF_LQ_HIGH                   = "lqHigh";
+    public static final String PREF_SOUND_NOTIFS              = "soundNotifs";
+    public static final String PREF_COOKIES                   = "storeCookies";
+    public static final String PREF_NIGHT_START               = "nightStart";
     public static final String PREF_NIGHT_END                 = "nightEnd";
     public static final String PREF_SHOW_NSFW_CONTENT         = "showNSFWContent";
     public static final String PREF_HIDE_NSFW_PREVIEW         = "hideNSFWPreviews";
@@ -93,6 +92,7 @@ public class SettingValues {
     public static final String PREF_IGNORE_SUB_SETTINGS       = "ignoreSub";
     public static final String PREF_HIGHLIGHT_TIME            = "highlightTime";
     public static final String PREF_MUTE                      = "muted";
+    public static final String PREF_LINK_HANDLING_MODE        = "linkHandlingMode";
 
     public static final String PREF_FULL_COMMENT_OVERRIDE  = "fullCommentOverride";
     public static final String PREF_ALBUM                  = "album";
@@ -167,14 +167,13 @@ public class SettingValues {
     public static boolean colorEverywhere;
     public static boolean gif;
     public static boolean colorCommentDepth;
-    public static boolean web;
     public static boolean commentVolumeNav;
     public static boolean postNav;
     public static boolean cropImage;
     public static boolean smallTag;
     public static boolean typeInfoLine;
     public static boolean votesInfoLine;
-    public static boolean reader;
+    public static boolean readerMode;
     public static boolean collapseComments;
     public static boolean collapseCommentsDefault;
     public static boolean rightHandedCommentMenu;
@@ -185,6 +184,7 @@ public class SettingValues {
     public static int     backButtonBehavior;
     public static int     nightStart;
     public static int     nightEnd;
+    public static int     linkHandlingMode;
 
     public static int previews;
 
@@ -206,7 +206,6 @@ public class SettingValues {
     public static int     fabType = Constants.FAB_POST;
     public static boolean hideButton;
     public static boolean tabletUI;
-    public static boolean customtabs;
     public static boolean titleTop;
     public static boolean dualPortrait;
     public static boolean singleColumnMultiWindow;
@@ -268,7 +267,7 @@ public class SettingValues {
         overrideLanguage = prefs.getBoolean(PREF_OVERRIDE_LANGUAGE, false);
         immersiveMode = prefs.getBoolean(PREF_IMMERSIVE_MODE, false);
         largeDepth = prefs.getBoolean(PREF_LARGE_DEPTH, false);
-        reader = prefs.getBoolean(PREF_READER, false);
+        readerMode = prefs.getBoolean(PREF_READER_MODE, false);
         imageSubfolders = prefs.getBoolean(PREF_IMAGE_SUBFOLDERS, false);
         isMuted = prefs.getBoolean(PREF_MUTE, false);
 
@@ -337,11 +336,9 @@ public class SettingValues {
         smallTag = prefs.getBoolean(PREF_SMALL_TAG, false);
         swap = prefs.getBoolean(PREF_SWAP, false);
         hideSelftextLeadImage = prefs.getBoolean(PREF_SELFTEXT_IMAGE_COMMENT, false);
-        web = prefs.getBoolean(PREFS_WEB, true);
         image = prefs.getBoolean(PREF_IMAGE, true);
         cache = true;
         cacheDefault = false;
-        customtabs = prefs.getBoolean(PREF_CUSTOMTABS, false);
         storeHistory = prefs.getBoolean(PREF_STORE_HISTORY, true);
         upvotePercentage = prefs.getBoolean(PREF_UPVOTE_PERCENTAGE, false);
         storeNSFWHistory = prefs.getBoolean(PREF_STORE_NSFW_HISTORY, false);
@@ -350,6 +347,8 @@ public class SettingValues {
         synccitAuth = prefs.getString(SYNCCIT_AUTH, "");
         notifSound = prefs.getBoolean(PREF_SOUND_NOTIFS, false);
         cookies = prefs.getBoolean(PREF_COOKIES, true);
+        linkHandlingMode = prefs.getInt(PREF_LINK_HANDLING_MODE,
+                SettingsHandlingFragment.LinkHandlingMode.EXTERNAL.getValue());
 
         previews = prefs.getInt(PREVIEWS_LEFT, 10);
         nightStart = prefs.getInt(PREF_NIGHT_START, 9);
@@ -500,6 +499,4 @@ public class SettingValues {
     public enum ColorMatchingMode {
         ALWAYS_MATCH, MATCH_EXTERNALLY
     }
-
-
 }

--- a/app/src/main/java/me/ccrama/redditslide/util/CustomTabsHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/CustomTabsHelper.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 import me.ccrama.redditslide.SettingValues;
 
+import static me.ccrama.redditslide.Fragments.SettingsHandlingFragment.LinkHandlingMode;
+
 /**
  * Helper class for Custom Tabs.
  */
@@ -57,7 +59,7 @@ public class CustomTabsHelper {
      * @return The package name recommended to use for connecting to custom tabs related components.
      */
     public static String getPackageNameToUse(Context context) {
-        if (!SettingValues.customtabs) return null;
+        if (SettingValues.linkHandlingMode != LinkHandlingMode.CUSTOM_TABS.getValue()) return null;
         if (sPackageNameToUse != null) return sPackageNameToUse;
 
         PackageManager pm = context.getPackageManager();

--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -32,7 +32,6 @@ import com.devbrackets.android.exomedia.listener.OnPreparedListener;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.googlecode.mp4parser.authoring.builder.DefaultMp4Builder;
-import com.googlecode.mp4parser.authoring.builder.Mp4Builder;
 import com.googlecode.mp4parser.authoring.container.mp4.MovieCreator;
 import com.googlecode.mp4parser.authoring.tracks.CroppedTrack;
 
@@ -45,7 +44,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.BufferOverflowException;
@@ -435,8 +433,8 @@ public class GifUtils {
                         } else {
                             if (closeIfNull) {
                                 Intent web = new Intent(c, Website.class);
-                                web.putExtra(Website.EXTRA_URL, url);
-                                web.putExtra(Website.EXTRA_COLOR, Color.BLACK);
+                                web.putExtra(LinkUtil.EXTRA_URL, url);
+                                web.putExtra(LinkUtil.EXTRA_COLOR, Color.BLACK);
                                 c.startActivity(web);
                                 c.finish();
                             }
@@ -479,8 +477,8 @@ public class GifUtils {
                         } else {
                             if (closeIfNull) {
                                 Intent web = new Intent(c, Website.class);
-                                web.putExtra(Website.EXTRA_URL, url);
-                                web.putExtra(Website.EXTRA_COLOR, Color.BLACK);
+                                web.putExtra(LinkUtil.EXTRA_URL, url);
+                                web.putExtra(LinkUtil.EXTRA_COLOR, Color.BLACK);
                                 c.startActivity(web);
                                 c.finish();
                             }
@@ -615,8 +613,8 @@ public class GifUtils {
                             onError();
                             if (closeIfNull) {
                                 Intent web = new Intent(c, Website.class);
-                                web.putExtra(Website.EXTRA_URL, url);
-                                web.putExtra(Website.EXTRA_COLOR, Color.BLACK);
+                                web.putExtra(LinkUtil.EXTRA_URL, url);
+                                web.putExtra(LinkUtil.EXTRA_COLOR, Color.BLACK);
                                 c.startActivity(web);
                                 c.finish();
                             }
@@ -643,8 +641,8 @@ public class GifUtils {
                     LogUtil.e("We shouldn't be here!");
                     if (closeIfNull) {
                         Intent web = new Intent(c, Website.class);
-                        web.putExtra(Website.EXTRA_URL, url);
-                        web.putExtra(Website.EXTRA_COLOR, Color.BLACK);
+                        web.putExtra(LinkUtil.EXTRA_URL, url);
+                        web.putExtra(LinkUtil.EXTRA_COLOR, Color.BLACK);
                         c.startActivity(web);
                         c.finish();
                     }
@@ -695,7 +693,7 @@ public class GifUtils {
         }
 
         public void writeGif(final URL url, final ProgressBar progressBar, final Activity c,
-                final String subreddit) throws Exception {
+                final String subreddit) {
             if (size != null && c != null && !getProxy().isCached(url.toString())) {
                 getRemoteFileSize(url.toString(), client, size, c);
             }
@@ -782,7 +780,7 @@ public class GifUtils {
         }
 
         public void WriteGifMuxed(final URL url, final ProgressBar progressBar, final Activity c,
-                final String subreddit) throws Exception {
+                final String subreddit) {
             if (size != null && c != null && !getProxy().isCached(url.toString())) {
                 getRemoteFileSize(url.toString(), client, size, c);
             }
@@ -1101,7 +1099,7 @@ public class GifUtils {
         }
 
         @Override
-        public int write(ByteBuffer inputBuffer) throws IOException {
+        public int write(ByteBuffer inputBuffer) {
             int inputBytes = inputBuffer.remaining();
 
             if (inputBytes > byteBuffer.remaining()) {
@@ -1124,7 +1122,7 @@ public class GifUtils {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
             dumpToFile();
             isOpen = false;
         }

--- a/app/src/main/res/layout/activity_settings_handling_child.xml
+++ b/app/src/main/res/layout/activity_settings_handling_child.xml
@@ -40,12 +40,6 @@
                 android:layout_height="match_parent"
                 android:text="@string/settings_link_chrome"
                 android:id="@+id/settings_handling_browser_type_custom_tabs"/>
-
-        <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:text="@string/handling_reader_mode"
-                android:id="@+id/settings_handling_browser_type_reader_mode"/>
     </RadioGroup>
 
     <RelativeLayout
@@ -82,10 +76,65 @@
     </RelativeLayout>
 
     <View
-        android:layout_width="match_parent"
-        android:layout_height="0.25dp"
-        android:alpha=".25"
-        android:background="?attr/tintColor" />
+            android:layout_width="match_parent"
+            android:layout_height="0.25dp"
+            android:alpha=".25"
+            android:background="?attr/tintColor"/>
+
+    <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="?android:selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:paddingStart="16dp"
+            android:paddingLeft="16dp">
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="64dp"
+                android:orientation="vertical"
+                android:layout_marginRight="64dp">
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/settings_link_reader_mode_title"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="14sp"/>
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:alpha=".86"
+                    android:text="@string/settings_link_reader_mode_description"
+                    android:textColor="?attr/fontColor"
+                    android:textSize="13sp"/>
+        </LinearLayout>
+
+        <android.support.v7.widget.SwitchCompat
+                android:id="@+id/settings_handling_reader_mode"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:backgroundTint="?attr/tintColor"
+                android:button="@null"
+                android:buttonTint="?attr/tintColor"
+                android:hapticFeedbackEnabled="true"
+                android:paddingEnd="16dp"
+                android:textColor="?attr/fontColor"
+                android:textColorHint="?attr/fontColor"
+                android:paddingRight="16dp"/>
+    </RelativeLayout>
+
+    <View
+            android:layout_width="match_parent"
+            android:layout_height="0.25dp"
+            android:alpha=".25"
+            android:background="?attr/tintColor"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1174,7 +1174,8 @@
     <string name="mod_ban_reason_required">Reason is required</string>
     <string name="settings_abbreviate_post_scores">Abbreviate post scores (ex. 24.0k)</string>
     <string name="settings_wide_depth_indicators">Wide comment depth indicators</string>
-    <string name="handling_reader_mode">Reader mode</string>
+    <string name="settings_link_reader_mode_title">Use reader mode</string>
+    <string name="settings_link_reader_mode_description">Open all links in reader mode. The browser type will be used when opening from reader mode.</string>
     <string name="settings_link_reader_night">Link Reader mode and Night mode</string>
     <string name="theme_pixel">Pixel</string>
     <string name="save_images_to_subreddit_specific_subfolders">Save images to subreddit-specific subfolders</string>


### PR DESCRIPTION
Converted settings for browser types into an int
Added linkHandlingType enum
Moved reader mode out to a discrete option
Allow reader mode "open external" option to respect selected browser type
Moved intent extras for internal browsers to LinkUtil class

A byproduct of this change adds the feature request https://github.com/ccrama/Slide/issues/2707

I'll do the run down as always:
* The core of this issue was that `ReaderMode` and custom tabs were not respected after my change for link handling. 
    * I blamed the discrete boolean handling so I moved this out to an enum with an int for the `SettingValues`
* After this refactor, it was an opportune time to move `ReaderMode` out of the types of browser handling and into its own discrete option
    * This option appears below the link handling types. When on, all links with open in `ReaderMode`.
    * When the globe is pressed, the user's link handling type is respected
* I moved some constants for intent extras shared between `ReaderMode` and `Website` into `LinkUtil` since that felt more appropriate
* I consolidated the `LinkUtil.openUrl` logic to avoid duplication of code by calling the superior from the overloaded method
* I created a new method for handling theme-ing internal browsers (reader and internal) to avoid mistakes where one is changed and the other is not

As a result, users' defined link handling types will no longer be the same after this change is pushed. The only value that will continue to be respected will be `ReaderMode` since I decided to use the original preference value for this.

Lots of annoying auto-cleanup. But that is pretty much par for the course by now.