### PR TITLE
Fix MP4 saving not working for cached GIFs

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -722,6 +722,21 @@ public class GifUtils {
 
                     if (getProxy().isCached(url.toString())) {
                         progressBar.setVisibility(View.GONE);
+                        if (gifSave != null) {
+                            gifSave.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    saveGif(getProxy().getCacheFile(url.toString()), c, subreddit);
+                                }
+                            });
+                        } else if (doOnClick != null) {
+                            MediaView.doOnClick = new Runnable() {
+                                @Override
+                                public void run() {
+                                    saveGif(getProxy().getCacheFile(url.toString()), c, subreddit);
+                                }
+                            };
+                        }
                     } else {
                         getProxy().registerCacheListener(new CacheListener() {
                             @Override
@@ -747,13 +762,6 @@ public class GifUtils {
                                                 public void run() {
                                                     saveGif(getProxy().getCacheFile(url), c,
                                                             subreddit);
-                                                    try {
-                                                        Toast.makeText(c, c.getString(
-                                                                R.string.mediaview_notif_title),
-                                                                Toast.LENGTH_SHORT).show();
-                                                    } catch (Exception ignored) {
-
-                                                    }
                                                 }
                                             };
                                         }


### PR DESCRIPTION
As reported [here](https://www.reddit.com/r/slideforreddit/comments/8r7xnm/issue_downloading_gifs/).

Also removed duplicate toast that's already shown by `saveGif`

I think this is the right way to fix this?