### PR TITLE
Added support for native spoiler markdown

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ robototextview {
 ext {
     supportLibVersion = '27.1.0'
     robolectricVersion = '3.3.1'
+    powerMockitoVersion = '1.7.4'
 }
 dependencies {
     withGPlayImplementation 'com.google.android.gms:play-services-drive:10.2.0'
@@ -127,7 +128,9 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.robolectric:shadows-multidex:$robolectricVersion"
+    testImplementation "org.powermock:powermock-api-mockito2:$powerMockitoVersion"
+    testImplementation "org.powermock:powermock-module-junit4:$powerMockitoVersion"
 }

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -1,38 +1,17 @@
 package me.ccrama.redditslide;
 
 import android.app.Activity;
-import android.content.ClipData;
+import android.content.*;
 import android.content.ClipboardManager;
-import android.content.Context;
-import android.content.ContextWrapper;
-import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.res.TypedArray;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Color;
-import android.graphics.PorterDuff;
-import android.graphics.Typeface;
+import android.graphics.*;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
 import android.support.v4.content.ContextCompat;
-import android.text.Html;
-import android.text.Spannable;
-import android.text.SpannableStringBuilder;
-import android.text.Spanned;
-import android.text.TextPaint;
-import android.text.style.BackgroundColorSpan;
-import android.text.style.CharacterStyle;
-import android.text.style.ForegroundColorSpan;
-import android.text.style.ImageSpan;
-import android.text.style.QuoteSpan;
-import android.text.style.RelativeSizeSpan;
-import android.text.style.StrikethroughSpan;
-import android.text.style.StyleSpan;
-import android.text.style.TypefaceSpan;
-import android.text.style.URLSpan;
+import android.text.*;
+import android.text.style.*;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.HapticFeedbackConstants;
@@ -41,19 +20,8 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import com.cocosw.bottomsheet.BottomSheet;
 import com.devspark.robototextview.widget.RobotoTextView;
-
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import me.ccrama.redditslide.Activities.Album;
 import me.ccrama.redditslide.Activities.AlbumPager;
 import me.ccrama.redditslide.Activities.MediaView;
@@ -74,6 +42,14 @@ import me.ccrama.redditslide.handler.TextViewLinkHandler;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by carlo_000 on 1/11/2016.
@@ -83,7 +59,9 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
     private              List<Integer>        storedSpoilerStarts = new ArrayList<>();
     private              List<Integer>        storedSpoilerEnds   = new ArrayList<>();
     private static final Pattern              htmlSpoilerPattern  =
-            Pattern.compile("<a href=\"([#/](?:spoiler|sp|s))\">([^<]*)</a>");
+            Pattern.compile("<a href=\"[#/](?:spoiler|sp|s)\">([^<]*)</a>");
+    private static final Pattern nativeSpoilerPattern =
+            Pattern.compile("<span class=\"[^\"]*md-spoiler-text+[^\"]*\">([^<]*)</span>");
 
     public SpoilerRobotoTextView(Context context) {
         super(context);
@@ -212,14 +190,18 @@ public class SpoilerRobotoTextView extends RobotoTextView implements ClickableTe
     }
 
     private String wrapAlternateSpoilers(String html) {
-        Matcher htmlSpoilerMatcher = htmlSpoilerPattern.matcher(html);
-        while (htmlSpoilerMatcher.find()) {
-            String newPiece = htmlSpoilerMatcher.group();
+        html = formatSpoilers(html, htmlSpoilerPattern.matcher(html));
+        html = formatSpoilers(html, nativeSpoilerPattern.matcher(html));
+        return html;
+    }
+
+    private String formatSpoilers(String html, Matcher matcher) {
+        while (matcher.find()) {
+            String text = matcher.group(1);
             String inner = "<a href=\"/spoiler\">spoiler&lt; [[s[ "
-                    + newPiece.substring(newPiece.indexOf(">") + 1,
-                    newPiece.indexOf("<", newPiece.indexOf(">")))
+                    + text
                     + "]s]]</a>";
-            html = html.replace(htmlSpoilerMatcher.group(), inner);
+            html = html.replace(text, inner);
         }
         return html;
     }

--- a/app/src/test/java/me/ccrama/redditslide/test/SpoilerTextTest.java
+++ b/app/src/test/java/me/ccrama/redditslide/test/SpoilerTextTest.java
@@ -1,0 +1,55 @@
+package me.ccrama.redditslide.test;
+
+import me.ccrama.redditslide.SpoilerRobotoTextView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static junit.framework.Assert.fail;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SpoilerRobotoTextView.class})
+public class SpoilerTextTest {
+    private final Pattern htmlSpoilerPattern = Whitebox.getInternalState(SpoilerRobotoTextView.class, "htmlSpoilerPattern");
+    private final Pattern nativeSpoilerPattern = Whitebox.getInternalState(SpoilerRobotoTextView.class, "nativeSpoilerPattern");
+
+    private final List<Object[]> htmlSpoilerTests = new ArrayList<Object[]>() {{
+        add(new Object[]{"<a href=\"#spoiler\">test</a>", true});
+        add(new Object[]{"<a href=\"#sp\">test</a>", true});
+        add(new Object[]{"<a href=\"#s\">test</a>", true});
+        add(new Object[]{"<a href=\"#not-a-spoiler\">test</a>", false});
+    }};
+
+    private final List<Object[]> nativeSpoilerTests = new ArrayList<Object[]>() {{
+        add(new Object[]{"<span class=\"md-spoiler-text\">test</span>", true});
+        add(new Object[]{"<span class=\"md-bold-text md-spoiler-text md-italic-text\">test</span>", true});
+        add(new Object[]{"<span class=\"not-a-spoiler\">test</span>", false});
+    }};
+
+    @Test
+    public void htmlSpoilerTest() {
+        spoilerTest(htmlSpoilerTests, htmlSpoilerPattern, "HTML spoiler test");
+    }
+
+    @Test
+    public void nativeSpoilerTest() {
+        spoilerTest(nativeSpoilerTests, nativeSpoilerPattern, "Native spoiler test");
+    }
+
+    private void spoilerTest(List<Object[]> tests, Pattern pattern, String name) {
+        for (Object[] test : tests) {
+            if (pattern.matcher((String) test[0]).matches() == (Boolean) test[1]) {
+                System.out.println(name.concat(": ").concat((String) test[0]).concat(" PASSED"));
+            } else {
+                System.out.println(name.concat(": ").concat((String) test[0]).concat(" FAILED"));
+                fail();
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Request from Reddit](https://www.reddit.com/r/slideforreddit/comments/8tlyb9/could_slide_please_get_support_for_this_new/)

I added support for marking the new "native" spoiler markdown as spoilers in the app. The regex checks out.
Some changes did occur with the logic for marking as spoilers but it should not break classic markdown. **If someone could hook me up with a link to text the non-native spoiler code or test it on your own that'd help.**

Also a clean up because everything is awful.

Please verify the regex is not wrong and should work / test this as well on top of my testing to ensure I did not mess it up. It'd be a bit bad to flub this one.

Additionally I added some very minimal tests for the patterns. They should at least fail on changes but they aren't exhaustive by any means and just do a very general check