### PR TITLE
Display Wikis as HTML in a WebView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation 'me.everything:overscroll-decor-android:1.0.4'
     implementation 'com.mikepenz:aboutlibraries:5.8.1'
     implementation 'com.googlecode.mp4parser:isoparser:1.1.21'
+    implementation 'org.apache.commons:commons-text:1.4'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -44,7 +44,7 @@ import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.BufferedInputStream;
 import java.io.File;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/ReaderMode.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/ReaderMode.java
@@ -13,7 +13,7 @@ import android.view.MenuItem;
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.wuman.jreadability.Readability;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Search.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Search.java
@@ -23,7 +23,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import net.dean.jraw.paginators.SubmissionSearchPaginator;
 import net.dean.jraw.paginators.TimePeriod;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Locale;

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Shadowbox.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Shadowbox.java
@@ -8,7 +8,7 @@ import android.support.v4.view.ViewPager;
 
 import net.dean.jraw.models.Submission;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.List;
 

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -55,7 +55,7 @@ import net.dean.jraw.models.DistinguishedStatus;
 import net.dean.jraw.models.Submission;
 import net.dean.jraw.models.VoteDirection;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
@@ -37,7 +37,7 @@ import net.dean.jraw.models.Comment;
 import net.dean.jraw.models.CommentNode;
 import net.dean.jraw.models.DistinguishedStatus;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;

--- a/app/src/main/java/me/ccrama/redditslide/ColorPreferences.java
+++ b/app/src/main/java/me/ccrama/redditslide/ColorPreferences.java
@@ -6,7 +6,7 @@ import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 import android.util.Pair;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/MediaFragment.java
@@ -32,7 +32,7 @@ import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
 import net.dean.jraw.models.Submission;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/WikiPage.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/WikiPage.java
@@ -2,34 +2,57 @@ package me.ccrama.redditslide.Fragments;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
-import java.util.List;
-
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import me.ccrama.redditslide.Activities.Wiki;
 import me.ccrama.redditslide.Constants;
+import me.ccrama.redditslide.OpenRedditLink;
 import me.ccrama.redditslide.R;
-import me.ccrama.redditslide.SpoilerRobotoTextView;
-import me.ccrama.redditslide.Views.CommentOverflow;
 import me.ccrama.redditslide.Views.GeneralSwipeRefreshLayout;
 import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.SubmissionParser;
+import net.dean.jraw.managers.WikiManager;
+import org.apache.commons.text.StringEscapeUtils;
+
+import java.lang.ref.WeakReference;
+
 
 public class WikiPage extends Fragment {
     private String title;
     private String subreddit;
+    private String wikiUrl;
+
+    private WikiPageListener listener;
+
+    private WebView webView;
+    private GeneralSwipeRefreshLayout ref;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View v = inflater.inflate(R.layout.justtext, container, false);
+        return inflater.inflate(R.layout.justtext, container, false);
+    }
 
-        final SpoilerRobotoTextView body = (SpoilerRobotoTextView) v.findViewById(R.id.body);
-        final CommentOverflow commentOverflow = (CommentOverflow) v.findViewById(R.id.commentOverflow);
-        final GeneralSwipeRefreshLayout ref = (GeneralSwipeRefreshLayout) v.findViewById(R.id.ref);
+    @Override
+    public void onViewCreated(@NonNull final View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
+        ref = view.findViewById(R.id.ref);
+        webView = view.findViewById(R.id.wiki_web_view);
+
+        setUpRefresh();
+        setUpWebView();
+
+        if (getActivity() != null) {
+            new WikiAsyncTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                    ((Wiki) getActivity()).wiki, subreddit, title);
+        }
+    }
+
+    private void setUpRefresh() {
         ref.setColorSchemeColors(Palette.getColors(subreddit, getActivity()));
 
         //If we use 'findViewById(R.id.header).getMeasuredHeight()', 0 is always returned.
@@ -38,66 +61,48 @@ public class WikiPage extends Fragment {
         ref.setProgressViewOffset(false,
                 Constants.SINGLE_HEADER_VIEW_OFFSET - Constants.PTR_OFFSET_TOP,
                 Constants.SINGLE_HEADER_VIEW_OFFSET + Constants.PTR_OFFSET_BOTTOM);
-
         ref.post(new Runnable() {
             @Override
             public void run() {
                 ref.setRefreshing(true);
             }
         });
-        new AsyncTask<Void, Void, Void>() {
-            String text;
-
-            @Override
-            protected Void doInBackground(Void... params) {
-                try {
-                    text = ((Wiki) getActivity()).wiki.get(subreddit, title).getDataNode().get("content_html").asText();
-                } catch(Exception ignored){
-
-                }
-                return null;
-            }
-
-            @Override
-            protected void onPostExecute(Void aVoid) {
-                setViews(text, subreddit, body, commentOverflow);
-
-                ref.setRefreshing(false);
-                ref.setEnabled(false);
-
-            }
-        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-
-        return v;
     }
 
-    private void setViews(String rawHTML, String subredditName, SpoilerRobotoTextView firstTextView, CommentOverflow commentOverflow) {
-        if (rawHTML ==null || rawHTML.isEmpty()) {
-            return;
-        }
-
-        List<String> blocks = SubmissionParser.getBlocks(rawHTML);
-
-        int startIndex = 0;
-        // the <div class="md"> case is when the body contains a table or code block first
-        if (!blocks.get(0).equals("<div class=\"md\">")) {
-            firstTextView.setVisibility(View.VISIBLE);
-            firstTextView.setTextHtml(blocks.get(0), subredditName);
-            startIndex = 1;
-        } else {
-            firstTextView.setText("");
-            firstTextView.setVisibility(View.GONE);
-        }
-
-        if (blocks.size() > 1) {
-            if (startIndex == 0) {
-                commentOverflow.setViews(blocks, subredditName);
-            } else {
-                commentOverflow.setViews(blocks.subList(startIndex, blocks.size()), subredditName);
+    private void setUpWebView() {
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                if (url.toLowerCase().startsWith(wikiUrl.toLowerCase()) && listener != null) {
+                    String pagePiece = url.toLowerCase().replace(wikiUrl.toLowerCase(), "")
+                            .split("/")[0]
+                            .split("#")[0];
+                    listener.embeddedWikiLinkClicked(pagePiece);
+                } else {
+                    OpenRedditLink.openUrl(getContext(), url, true);
+                }
+                return true;
             }
-        } else {
-            commentOverflow.removeAllViews();
-        }
+
+            @Override
+            public void onPageFinished(WebView webView, String url) {
+                super.onPageFinished(webView, url);
+                if (getView() != null) {
+                    getView().findViewById(R.id.wiki_web_view).setVisibility(View.VISIBLE);
+                    ref.setRefreshing(false);
+                    ref.setEnabled(false);
+                }
+            }
+        });
+    }
+
+    private void onDomRetrieved(String dom) {
+        webView.loadDataWithBaseURL(
+                wikiUrl,
+                "<head>".concat(Wiki.getGlobalCustomCss()).concat("</head>").concat(dom),
+                "text/html",
+                "utf-8",
+                null);
     }
 
     @Override
@@ -106,7 +111,35 @@ public class WikiPage extends Fragment {
         Bundle bundle = this.getArguments();
         title = bundle.getString("title", "");
         subreddit = bundle.getString("subreddit", "");
-
+        wikiUrl = "https://www.reddit.com/r/".concat(subreddit).concat("/wiki/");
     }
 
+    public void setListener(WikiPageListener listener) {
+        this.listener = listener;
+    }
+
+    private static class WikiAsyncTask extends AsyncTask<Object, Void, String> {
+        WeakReference<WikiPage> wikiPageWeakReference;
+
+        WikiAsyncTask(WikiPage wikiPage) {
+            wikiPageWeakReference = new WeakReference<>(wikiPage);
+        }
+
+        @Override
+        protected String doInBackground(Object[] params) {
+            return StringEscapeUtils.unescapeHtml4(
+                    ((WikiManager) params[0]).get((String) params[1], (String) params[2]).getDataNode().get("content_html").asText());
+        }
+
+        @Override
+        protected void onPostExecute(String dom) {
+            if (wikiPageWeakReference.get() != null) {
+                wikiPageWeakReference.get().onDomRetrieved(dom);
+            }
+        }
+    }
+
+    public interface WikiPageListener {
+        void embeddedWikiLinkClicked(String wikiPageTitle);
+    }
 }

--- a/app/src/main/java/me/ccrama/redditslide/ImageLoaderUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/ImageLoaderUtils.java
@@ -19,7 +19,7 @@ import com.nostra13.universalimageloader.core.imageaware.ImageAware;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMail.java
@@ -23,7 +23,7 @@ import net.dean.jraw.models.Submission;
 import net.dean.jraw.paginators.InboxPaginator;
 import net.dean.jraw.paginators.SubmissionSearchPaginator;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMailSingle.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/CheckForMailSingle.java
@@ -20,7 +20,7 @@ import android.text.Html;
 import net.dean.jraw.models.Message;
 import net.dean.jraw.paginators.InboxPaginator;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -44,7 +44,7 @@ import net.dean.jraw.paginators.Sorting;
 import net.dean.jraw.paginators.SubmissionSearchPaginator;
 import net.dean.jraw.paginators.TimePeriod;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/ccrama/redditslide/SpoilerRobotoTextView.java
@@ -42,7 +42,7 @@ import me.ccrama.redditslide.handler.TextViewLinkHandler;
 import me.ccrama.redditslide.util.GifUtils;
 import me.ccrama.redditslide.util.LinkUtil;
 import me.ccrama.redditslide.util.LogUtil;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
@@ -38,7 +38,7 @@ import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.models.Contribution;
 import net.dean.jraw.models.Submission;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -56,7 +56,7 @@ import net.dean.jraw.models.Submission;
 import net.dean.jraw.models.Thing;
 import net.dean.jraw.models.VoteDirection;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/me/ccrama/redditslide/Views/PeekMediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/PeekMediaView.java
@@ -30,7 +30,7 @@ import com.nostra13.universalimageloader.core.imageaware.ImageViewAware;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -28,7 +28,7 @@ import android.widget.Toast;
 
 import net.dean.jraw.models.Submission;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;

--- a/app/src/main/java/me/ccrama/redditslide/util/SubmissionParser.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/SubmissionParser.java
@@ -1,6 +1,6 @@
 package me.ccrama.redditslide.util;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/res/layout/justtext.xml
+++ b/app/src/main/res/layout/justtext.xml
@@ -1,39 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <me.ccrama.redditslide.Views.GeneralSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/card_background"
-    android:id="@+id/ref"
-    android:orientation="vertical">
+                                                       android:layout_width="match_parent"
+                                                       android:layout_height="match_parent"
+                                                       android:background="?attr/activity_background"
+                                                       android:id="@+id/ref"
+                                                       android:orientation="vertical">
 
-
-    <android.support.v4.widget.NestedScrollView
-        android:layout_width="match_parent"
-        android:id="@+id/scrollView"
-        android:layout_height="match_parent">
-
-        <LinearLayout
+    <WebView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <me.ccrama.redditslide.SpoilerRobotoTextView  xmlns:android="http://schemas.android.com/apk/res/android"
-                android:id="@+id/body"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="16dp"
-                android:textColor="?attr/fontColor"
-                android:textIsSelectable="true"
-                android:textSize="16sp" />
-
-            <me.ccrama.redditslide.Views.CommentOverflow
-                android:id="@+id/commentOverflow"
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="8dp"
-                android:paddingEnd="8dp"
-                android:visibility="gone"/>
-        </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+            android:id="@+id/wiki_web_view"
+            android:layout_height="match_parent"
+            android:visibility="invisible"/>
 </me.ccrama.redditslide.Views.GeneralSwipeRefreshLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -14,6 +14,7 @@
         <attr name="card_background" format="color" />
         <attr name="fontColor" format="color" />
         <attr name="tintColor" format="color" />
+        <attr name="colorAccent" format="color"/>
         <attr name="list_background" format="color" />
 
     </declare-styleable>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1202,4 +1202,6 @@
     <string name="search_settings">Search settings</string>
     <string name="firefox">Firefox</string>
     <string name="show_collapse_expand_nav_bar">Show collapse/expand button in the comment navigation bar</string>
+    <string name="page_not_found">Page not found</string>
+    <string name="page_does_not_exist">The page you requested does not exist</string>
 </resources>


### PR DESCRIPTION
- I removed any native implementation for the Wiki rendering. **If there is something still hanging out let me know so I can remove it**
- I replaced everything in the layout for the WikiPage with a single webView that just gets the HTML data from the API loaded into it
    - I added a cover over the WebView that hides when the page finishes loading. This is to avoid a white flash before the styles are loaded in
- The customCss is set on the Wiki activity statically then accessed from the WikiPage. This is the prevent every fragment from recreating it since it only needs created once per subreddit as it is now
    - This CSS only modifies the background color, font color, and idle link text to match the default themes
    - There is a commented out method that makes tables horizontally scrollable in the view but that conflicted with the ViewPager so I commented it out and added a TODO
- I redid the AsyncTask on the WikiPage because it was in the way too often. It's a static inner class now that does the same thing but "safer"
- I overrode loading Urls on the WikiPage WebView
    - If the link out of the WikiPage is to itself, it calls a listener up to the Wiki activity to select the correct fragment
    - Otherwise is just tries to open it however it needs to via the app or externally based on the user's browser preferences
    - If it tries to open an embedded WikiPage that does not exist, I show a dialog matching Reddit's error for that situation