### PR TITLE
Improved WikiPage implementation

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Views/ToggleSwipeViewPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/ToggleSwipeViewPager.java
@@ -12,6 +12,7 @@ import android.view.MotionEvent;
 public class ToggleSwipeViewPager extends ViewPager {
     private boolean mEnableSwiping = true;
     private boolean swipeLeftOnly = false;
+    private boolean mSwipeDisabledUntilRelease = false;
     private float mStartDragX;
 
     public ToggleSwipeViewPager(Context context) {
@@ -31,6 +32,12 @@ public class ToggleSwipeViewPager extends ViewPager {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (ev.getAction() == MotionEvent.ACTION_UP) {
+            if (mSwipeDisabledUntilRelease) {
+                setSwipingEnabled(true);
+                mSwipeDisabledUntilRelease = false;
+            }
+        }
         try {
             return (mEnableSwiping || swipeLeftOnly) && super.onInterceptTouchEvent(ev);
         } catch (IllegalArgumentException ex) {
@@ -45,6 +52,11 @@ public class ToggleSwipeViewPager extends ViewPager {
 
     public void setSwipingEnabled(boolean enabled) {
         mEnableSwiping = enabled;
+    }
+
+    public void disableSwipingUntilRelease() {
+        setSwipingEnabled(false);
+        mSwipeDisabledUntilRelease = true;
     }
 
 }

--- a/app/src/main/res/layout/activity_slidetabs.xml
+++ b/app/src/main/res/layout/activity_slidetabs.xml
@@ -33,7 +33,7 @@
                 android:background="#00000000" />
         </android.support.design.widget.AppBarLayout>
 
-        <android.support.v4.view.ViewPager
+        <me.ccrama.redditslide.Views.ToggleSwipeViewPager
             android:id="@+id/content_view"
             android:layout_width="match_parent"
             android:background="?attr/activity_background"


### PR DESCRIPTION
Corrected issue where Wiki sub-pages would not open from links
Allow table and code elements to be horizontally scrollable in WebView

Fixes issue https://github.com/ccrama/Slide/issues/2816

This change makes it so subpages (e.g. "recommended/books") in Wikis are opened correctly when clicking a link within the HTML

Additionally this change reformats `table` and `code` elements in the HTML to allow them to overflow on the x-axis be scrollable. This is done by injecting some JS that determines if the user touched a `table` or `code` dependent element and disables the ViewPager paging in the native code until their pointers are released from the screen.

Pros: You can scroll `table` and `code` blocks appropriately. This means the entire WebView does not scroll off the x-axis requiring panning before paging. Additionally we do not have to reformat these elements which would lead to them being rendered in an unexpected or unreadable way.
Additionally the way I implemented this allows it to extend to any element easily (written for `table` and `code` was just dropped in last minute and works fine)

Cons: You absolutely cannot page the pager on these elements regardless if they are actually overflowing the view. That logic in the JS would be pretty annoying to write and maintain and I feel it is an edge case of a problem. In cases the entire WikiPage is a `table` or `code` block this would just entirely kill paging, but again I believe that to be an edge case. The biggest problem is if a user is unaware why it is happening.

Let me know how you feel. and if you have any better ideas in your head for this.