### PR TITLE
Allow night mode to be set manually when devices support automatic night mode

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsHandlingFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsHandlingFragment.java
@@ -10,21 +10,15 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-import android.widget.CompoundButton;
-import android.widget.EditText;
-import android.widget.LinearLayout;
-import android.widget.RadioGroup;
-import android.widget.TextView;
-
+import android.widget.*;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-
 import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 
 public class SettingsHandlingFragment implements CompoundButton.OnCheckedChangeListener {
@@ -86,12 +80,12 @@ public class SettingsHandlingFragment implements CompoundButton.OnCheckedChangeL
                         .putBoolean(SettingValues.PREF_READER_MODE, SettingValues.readerMode)
                         .apply();
                 context.findViewById(R.id.settings_handling_readernight)
-                        .setEnabled(SettingValues.nightMode && SettingValues.readerMode);
+                        .setEnabled(SettingValues.NightModeState.isEnabled() && SettingValues.readerMode);
             }
         });
 
         final SwitchCompat readernight = context.findViewById(R.id.settings_handling_readernight);
-        readernight.setEnabled(SettingValues.nightMode && SettingValues.readerMode);
+        readernight.setEnabled(SettingValues.NightModeState.isEnabled() && SettingValues.readerMode);
         readernight.setChecked(SettingValues.readerNight);
         readernight.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override

--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -1,12 +1,7 @@
 package me.ccrama.redditslide;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
-import android.app.ActivityManager;
-import android.app.Application;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.app.UiModeManager;
+import android.app.*;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -17,17 +12,12 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
-import android.os.AsyncTask;
-import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
+import android.os.*;
 import android.support.multidex.MultiDexApplication;
 import android.text.Html;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.widget.Toast;
-
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.danikula.videocache.HttpProxyCacheServer;
@@ -36,11 +26,19 @@ import com.google.common.collect.HashBiMap;
 import com.jakewharton.processphoenix.ProcessPhoenix;
 import com.lusfold.androidkeyvaluestore.KVStore;
 import com.nostra13.universalimageloader.core.ImageLoader;
-
+import me.ccrama.redditslide.Activities.MainActivity;
+import me.ccrama.redditslide.Autocache.AutoCacheScheduler;
+import me.ccrama.redditslide.ImgurAlbum.AlbumUtils;
+import me.ccrama.redditslide.Notifications.NotificationJobScheduler;
+import me.ccrama.redditslide.Notifications.NotificationPiggyback;
+import me.ccrama.redditslide.Tumblr.TumblrUtils;
+import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.*;
 import net.dean.jraw.http.NetworkException;
-
-import org.apache.commons.text.StringEscapeUtils;
+import okhttp3.Dns;
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -49,29 +47,7 @@ import java.lang.ref.WeakReference;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-
-import me.ccrama.redditslide.Activities.MainActivity;
-import me.ccrama.redditslide.Autocache.AutoCacheScheduler;
-import me.ccrama.redditslide.ImgurAlbum.AlbumUtils;
-import me.ccrama.redditslide.Notifications.NotificationJobScheduler;
-import me.ccrama.redditslide.Notifications.NotificationPiggyback;
-import me.ccrama.redditslide.Tumblr.TumblrUtils;
-import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.AdBlocker;
-import me.ccrama.redditslide.util.GifCache;
-import me.ccrama.redditslide.util.IabHelper;
-import me.ccrama.redditslide.util.IabResult;
-import me.ccrama.redditslide.util.LogUtil;
-import me.ccrama.redditslide.util.NetworkUtil;
-import me.ccrama.redditslide.util.SortingUtil;
-import me.ccrama.redditslide.util.UpgradeUtil;
-import okhttp3.Dns;
-import okhttp3.OkHttpClient;
+import java.util.*;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
@@ -119,7 +95,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     private       ImageLoader  defaultImageLoader;
     public static OkHttpClient client;
 
-    public static boolean isNightModeAuto = false;
+    public static boolean canUseNightModeAuto = false;
 
     public static void forceRestart(Context context, boolean forceLoadScreen) {
         if (forceLoadScreen) {
@@ -481,7 +457,7 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            setNightModeAuto();
+            setCanUseNightModeAuto();
         }
 
         overrideLanguage =
@@ -694,14 +670,14 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private static void setNightModeAuto() {
+    private static void setCanUseNightModeAuto() {
         UiModeManager uiModeManager =
                 (UiModeManager) getAppContext().getSystemService(Context.UI_MODE_SERVICE);
         if (uiModeManager != null) {
             uiModeManager.setNightMode(UiModeManager.MODE_NIGHT_AUTO);
-            isNightModeAuto = true;
+            canUseNightModeAuto = true;
         } else {
-            isNightModeAuto = false;
+            canUseNightModeAuto = false;
         }
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -2,18 +2,16 @@ package me.ccrama.redditslide;
 
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
-
+import me.ccrama.redditslide.Fragments.SettingsHandlingFragment;
+import me.ccrama.redditslide.Views.CreateCardView;
+import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.SortingUtil;
 import net.dean.jraw.models.CommentSort;
 import net.dean.jraw.paginators.Sorting;
 import net.dean.jraw.paginators.TimePeriod;
 
 import java.util.Calendar;
 import java.util.Locale;
-
-import me.ccrama.redditslide.Fragments.SettingsHandlingFragment;
-import me.ccrama.redditslide.Views.CreateCardView;
-import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.SortingUtil;
 
 /**
  * Created by ccrama on 9/19/2015.
@@ -25,6 +23,7 @@ public class SettingValues {
     public static final String PREF_FAB_TYPE                  = "FabType";
     public static final String PREF_DAY_TIME                  = "day";
     public static final String PREF_VOTE_GESTURES             = "voteGestures";
+    public static final String PREF_NIGHT_MODE_STATE = "nightModeState";
     public static final String PREF_NIGHT_MODE                = "nightMode";
     public static final String PREF_NIGHT_THEME               = "nightTheme";
     public static final String PREF_TYPE_IN_TEXT              = "typeInText";
@@ -212,7 +211,7 @@ public class SettingValues {
     public static boolean titleTop;
     public static boolean dualPortrait;
     public static boolean singleColumnMultiWindow;
-    public static boolean nightMode;
+    public static int nightModeState;
     public static boolean imageSubfolders;
     public static boolean autoTime;
     public static boolean albumSwipe;
@@ -297,7 +296,9 @@ public class SettingValues {
 
         highlightTime = prefs.getBoolean(PREF_HIGHLIGHT_TIME, true);
 
-        nightMode = prefs.getBoolean(PREF_NIGHT_MODE, false);
+        // TODO: Remove the old pref check in a later version
+        // This handles forward migration from the old night_mode boolean state
+        nightModeState = prefs.getInt(PREF_NIGHT_MODE_STATE, prefs.getBoolean(PREF_NIGHT_MODE, false) ? NightModeState.MANUAL.ordinal() : NightModeState.DISABLED.ordinal());
         nightTheme = prefs.getInt(PREF_NIGHT_THEME, 0);
         autoTime = prefs.getBoolean(PREF_AUTOTHEME, false);
         colorBack = prefs.getBoolean(PREF_COLOR_BACK, false);
@@ -476,8 +477,8 @@ public class SettingValues {
 
 
     public static boolean isNight() {
-        if (isPro && nightMode) {
-            if (Reddit.isNightModeAuto) {
+        if (isPro && NightModeState.isEnabled()) {
+            if (Reddit.canUseNightModeAuto && nightModeState == NightModeState.AUTOMATIC.ordinal()) {
                 return (Reddit.getAppContext().getResources().getConfiguration().uiMode
                         & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
             } else {
@@ -512,5 +513,13 @@ public class SettingValues {
 
     public enum ColorMatchingMode {
         ALWAYS_MATCH, MATCH_EXTERNALLY
+    }
+
+    public enum NightModeState {
+        DISABLED, MANUAL, AUTOMATIC;
+
+        public static boolean isEnabled() {
+            return nightModeState != DISABLED.ordinal();
+        }
     }
 }

--- a/app/src/main/res/layout/nightmode.xml
+++ b/app/src/main/res/layout/nightmode.xml
@@ -23,7 +23,8 @@
 
                 <TextView
                         android:id="@+id/title"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="wrap_content"
                         android:padding="18dp"
                         android:text="@string/night_mode"
@@ -31,17 +32,14 @@
                         android:textSize="18sp"
                         android:textStyle="bold"/>
 
-                <android.support.v7.widget.SwitchCompat
-                        android:id="@+id/enabled"
-                        android:layout_width="match_parent"
+                <android.support.v7.widget.AppCompatSpinner
+                        android:id="@+id/night_mode_state"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="18dp"
                         android:backgroundTint="?attr/tintColor"
-                        android:button="@null"
-                        android:buttonTint="?attr/tintColor"
-                        android:hapticFeedbackEnabled="true"
-                        android:textColor="?attr/fontColor"
-                        android:textColorHint="?attr/fontColor"/>
+                        android:layout_gravity="center_vertical|end"
+                        android:layout_marginRight="18dp"/>
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/values/array_night_mode_state.xml
+++ b/app/src/main/res/values/array_night_mode_state.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="night_mode_state">
+        <item>@string/disabled</item>
+        <item>@string/manual</item>
+        <item>@string/automatic</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,9 @@
     <string name="theme_black">AMOLED black</string>
     <string name="theme_dark_blue">Dark blue</string>
     <string name="night_mode">Night Mode</string>
+    <string name="disabled">Disabled</string>
+    <string name="manual">Manual</string>
+    <string name="automatic">Automatic</string>
     <string name="theme_default_color">Primary color</string>
     <string name="theme_subreddit_color">Change color</string>
     <string name="theme_accent_color">Accent color</string>


### PR DESCRIPTION
This change reverses my removal of the manual night mode options when a device support automatic night mode.

It replaces the boolean for night mode with an int that is based on the ordinals of values in a new NightModeState enum that tell us if the user has night mode disabled, set manually, or being followed automatically. I included a forward migration strategy inline and a TODO to remove that later (which I hope everyone reads.)

Not fully tested yet but seems to work. I recommend just testing this yourself manually to see if everything is triggering correctly.