### PR TITLE
Set FLAG_ACTIVITY_NEW_TASK on external link intents

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -4,42 +4,22 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.WindowManager;
-import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
-import android.webkit.DownloadListener;
-import android.webkit.ValueCallback;
-import android.webkit.WebChromeClient;
-import android.webkit.WebResourceResponse;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
+import android.view.*;
+import android.webkit.*;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
+import me.ccrama.redditslide.*;
+import me.ccrama.redditslide.Fragments.SubmissionsView;
+import me.ccrama.redditslide.Visuals.Palette;
+import me.ccrama.redditslide.util.AdBlocker;
+import me.ccrama.redditslide.util.LinkUtil;
+import me.ccrama.redditslide.util.LogUtil;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
-import me.ccrama.redditslide.ColorPreferences;
-import me.ccrama.redditslide.ContentType;
-import me.ccrama.redditslide.Fragments.SubmissionsView;
-import me.ccrama.redditslide.OpenRedditLink;
-import me.ccrama.redditslide.PostMatch;
-import me.ccrama.redditslide.R;
-import me.ccrama.redditslide.Reddit;
-import me.ccrama.redditslide.SettingValues;
-import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.AdBlocker;
-import me.ccrama.redditslide.util.LinkUtil;
-import me.ccrama.redditslide.util.LogUtil;
 
 public class Website extends BaseActivityAnim {
 
@@ -144,9 +124,7 @@ public class Website extends BaseActivityAnim {
                         });
                 return true;
             case R.id.chrome:
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(v.getUrl()));
-                LinkUtil.overridePackage(browserIntent);
-                startActivity(Intent.createChooser(browserIntent, getDomainName(v.getUrl())));
+                LinkUtil.openExternally(v.getUrl());
                 return true;
             case R.id.share:
                 Reddit.defaultShareText(v.getTitle(), v.getUrl(), Website.this);

--- a/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/LinkUtil.java
@@ -2,11 +2,7 @@ package me.ccrama.redditslide.util;
 
 import android.app.Activity;
 import android.app.PendingIntent;
-import android.content.ActivityNotFoundException;
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
-import android.content.Intent;
+import android.content.*;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -17,23 +13,11 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.customtabs.CustomTabsCallback;
-import android.support.customtabs.CustomTabsClient;
-import android.support.customtabs.CustomTabsIntent;
-import android.support.customtabs.CustomTabsServiceConnection;
-import android.support.customtabs.CustomTabsSession;
+import android.support.customtabs.*;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.util.Log;
 import android.widget.Toast;
-
-import net.dean.jraw.models.Submission;
-
-import org.apache.commons.text.StringEscapeUtils;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-
 import me.ccrama.redditslide.Activities.Crosspost;
 import me.ccrama.redditslide.Activities.MakeExternal;
 import me.ccrama.redditslide.Activities.ReaderMode;
@@ -42,6 +26,11 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SubmissionViews.PopulateSubmissionViewHolder;
+import net.dean.jraw.models.Submission;
+import org.apache.commons.text.StringEscapeUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 
 import static me.ccrama.redditslide.Fragments.SettingsHandlingFragment.LinkHandlingMode;
 
@@ -216,6 +205,7 @@ public class LinkUtil {
         Uri uri = formatURL(url);
 
         final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         overridePackage(intent);
         Reddit.getAppContext().startActivity(intent);
     }


### PR DESCRIPTION
Call LinkUtil.openExternally from Website context external button

This is a hopeful fix for external intents crashing the app. I added the NEW_TASK flag to the intents since we're launching externally off of the application context, so the new context can't attach back to us.

Does this even make sense? I'm going to try to vet it out to at least one other person before deciding it works.