### PR TITLE
Do not show "Best" option in default settings

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
@@ -469,6 +469,10 @@ public class MultiredditOverview extends BaseActivityAnim {
                         .toLowerCase(Locale.ENGLISH);
         final Spannable[] base = SortingUtil.getSortingSpannables("multi" + id);
         for (Spannable s : base) {
+            // Do not add option for "Best" in any subreddit except for the frontpage.
+            if (s.toString().equals(getString(R.string.sorting_best))) {
+                continue;
+            }
             MenuItem m = popup.getMenu().add(s);
         }
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
@@ -13,6 +13,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.SwitchCompat;
+import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -33,6 +34,7 @@ import net.dean.jraw.paginators.TimePeriod;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -595,11 +597,25 @@ public class SettingsGeneralFragment<ActivityType extends AppCompatActivity & Fo
                                         }
                                     }
                                 };
+
                         AlertDialogWrapper.Builder builder =
                                 new AlertDialogWrapper.Builder(SettingsGeneralFragment.this.context);
                         builder.setTitle(R.string.sorting_choose);
-                        builder.setSingleChoiceItems(SortingUtil.getSortingStrings(),
-                                SortingUtil.getSortingId(""), l2);
+
+                        // Remove the "Best" sorting option from settings because it is only supported on the frontpage.
+                        int skip = -1;
+                        List<String> sortingStrings = new ArrayList<>(Arrays.asList(SortingUtil.getSortingStrings()));
+                        for (int i = 0; i < sortingStrings.size(); i++) {
+                            if (sortingStrings.get(i).equals(context.getString(R.string.sorting_best))) {
+                                skip = i;
+                                break;
+                            }
+                        }
+                        if (skip != -1) {
+                            sortingStrings.remove(skip);
+                        }
+
+                        builder.setSingleChoiceItems(sortingStrings.toArray(new String[0]), SortingUtil.getSortingId(""), l2);
                         builder.show();
                     }
                 });


### PR DESCRIPTION
I realized after pushing #2866 that the default settings under general incorrectly display "Best" as an option (since it is only valid for the frontpage). This fixes that.