### PR TITLE
Fix build failure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ ext {
 dependencies {
     withGPlayImplementation 'com.google.android.gms:play-services-drive:10.2.0'
 
-    implementation 'com.github.ccrama:JRAW:b30799fdc8'
+    implementation 'com.github.ccrama:JRAW:c2bc59eb5e'
     implementation "com.google.guava:guava:23.0-android"
     //Updating material-dialogs to any newer version will break all AlertDialogWrapper
     //noinspection GradleDependency

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-        google()
     }
 
     dependencies {
@@ -17,11 +17,11 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url "https://jitpack.io" }
         maven {
             url 'https://maven.google.com'
         }
-        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 09 16:03:59 CDT 2017
+#Thu Oct 25 12:28:34 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Updates JRAW to the latest as required by #2866

Fixes a weird bug with the respository ordering, by putting google() at the top it stops the `Could not find lint-gradle-api.jar` error from appearing