### PR TITLE
Don't show sticky action on non-self comments

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -624,7 +624,7 @@ public class CommentAdapterHelper {
         final boolean stickied = comment.getDataNode().has("stickied") && comment.getDataNode()
                 .get("stickied")
                 .asBoolean();
-        if (baseNode.isTopLevel()) {
+        if (baseNode.isTopLevel() && comment.getAuthor().equalsIgnoreCase(Authentication.name)) {
             if (!stickied) {
                 b.sheet(4, pin, mContext.getString(R.string.mod_sticky));
             } else {


### PR DESCRIPTION
Reddit doesn't let you sticky comments you didn't make. Prevents a crash reported [here](https://www.reddit.com/r/slideforreddit/comments/9shntl/when_you_try_to_sticky_a_comment_that_isnt_yours/).