### PR TITLE
Ignore whitespace after END> in backup files

### DIFF
--- a/app/src/noGPlay/java/me/ccrama/redditslide/Activities/SettingsBackup.java
+++ b/app/src/noGPlay/java/me/ccrama/redditslide/Activities/SettingsBackup.java
@@ -81,7 +81,7 @@ public class SettingsBackup extends BaseActivityAnim {
 
                     if (read.contains("Slide_backupEND>")) {
 
-                        String[] files = read.split("END>");
+                        String[] files = read.split("END>\\s*");
                         progress.dismiss();
                         progress = new MaterialDialog.Builder(SettingsBackup.this).title(
                                 R.string.backup_restoring)


### PR DESCRIPTION
This can be useful since some editors might automatically add a newline
to the end of the file, or a user might open and it poke around a bit
since it's a .txt file

Fixes #2870