### PR TITLE
Don't show suspended dialog for logged-in user

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Profile.java
@@ -233,7 +233,8 @@ public class Profile extends BaseActivityAnim {
             }
             return;
         }
-        if (account.getDataNode().has("is_suspended") && account.getDataNode().get("is_suspended").asBoolean()) {
+        if (account.getDataNode().has("is_suspended") && account.getDataNode().get("is_suspended").asBoolean()
+                && !name.equalsIgnoreCase(Authentication.name)) {
             try {
                 new AlertDialogWrapper.Builder(Profile.this)
                         .setTitle(R.string.account_suspended)


### PR DESCRIPTION
Logged in users can see their profile when they're suspended, so there's no reason to show the dialog and prevent profile access.

Closes #2711 