### PR TITLE
Fix crash when going to the profile backing subreddit of a suspended/deleted account

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SubredditView.java
@@ -2133,7 +2133,12 @@ public class SubredditView extends BaseActivity {
         @Override
         protected Subreddit doInBackground(final String... params) {
             try {
-                return Authentication.reddit.getSubreddit(params[0]);
+                Subreddit result = Authentication.reddit.getSubreddit(params[0]);
+                if (result.isNsfw() == null) {
+                    // Sub is probably a user profile backing subreddit for a deleted/suspended user
+                    throw new Exception("Sub has null values where it shouldn't");
+                }
+                return result;
             } catch (Exception e) {
                 runOnUiThread(new Runnable() {
                     @Override


### PR DESCRIPTION
When an account with the new profile is suspended or deleted, the subreddit backing that profile (/r/u_username) is put in a weird state where it still exists, but has no content and minimal info. Slide expects certain properties, like `over18`, to not be null, so when they are null it crashes. This makes Slide consider those subreddits to be inaccessible so it doesn't crash.