### PR TITLE
Handle CSS and invalid colours in toolbox usersnotes

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -12,7 +12,6 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
@@ -36,24 +35,37 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.*;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.cocosw.bottomsheet.BottomSheet;
 
-import me.ccrama.redditslide.Toolbox.*;
 import net.dean.jraw.ApiException;
 import net.dean.jraw.http.NetworkException;
 import net.dean.jraw.http.oauth.InvalidScopeException;
 import net.dean.jraw.managers.AccountManager;
 import net.dean.jraw.managers.ModerationManager;
-import net.dean.jraw.models.*;
+import net.dean.jraw.models.Comment;
+import net.dean.jraw.models.CommentNode;
+import net.dean.jraw.models.DistinguishedStatus;
+import net.dean.jraw.models.Ruleset;
+import net.dean.jraw.models.Submission;
+import net.dean.jraw.models.SubredditRule;
+import net.dean.jraw.models.VoteDirection;
 
 import org.apache.commons.text.StringEscapeUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import me.ccrama.redditslide.ActionStates;
 import me.ccrama.redditslide.Activities.Profile;
@@ -66,6 +78,8 @@ import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.SpoilerRobotoTextView;
 import me.ccrama.redditslide.TimeUtils;
+import me.ccrama.redditslide.Toolbox.Toolbox;
+import me.ccrama.redditslide.Toolbox.ToolboxUI;
 import me.ccrama.redditslide.UserSubscriptions;
 import me.ccrama.redditslide.UserTags;
 import me.ccrama.redditslide.Views.CommentOverflow;
@@ -1536,21 +1550,7 @@ public class CommentAdapterHelper {
             }
         }
 
-        if (SettingValues.toolboxEnabled
-                && Authentication.mod
-                && Toolbox.getUsernotes(comment.getSubredditName()) != null
-                && Toolbox.getUsernotes(comment.getSubredditName()).getNotesForUser(comment.getAuthor()) != null
-                && Toolbox.getUsernotes(comment.getSubredditName()).getNotesForUser(comment.getAuthor()).size() > 0) {
-            SpannableStringBuilder note = new SpannableStringBuilder("\u00A0" +
-                    Toolbox.getUsernotes(comment.getSubredditName())
-                            .getDisplayNoteForUser(comment.getAuthor()) + "\u00A0");
-            note.setSpan(new RoundedBackgroundSpan(mContext.getResources().getColor(R.color.white),
-                    Color.parseColor(Toolbox.getUsernotes(
-                            comment.getSubredditName()).getDisplayColorForUser(comment.getAuthor())
-                    ), false, mContext), 0, note.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            titleString.append(note);
-            titleString.append(" ");
-        }
+        ToolboxUI.appendToolboxNote(mContext, titleString, comment.getSubredditName(), comment.getAuthor());
 
         if (adapter.removed.contains(comment.getFullName()) || (comment.getBannedBy() != null
                 && !adapter.approved.contains(comment.getFullName()))) {

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
@@ -388,22 +388,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
 
-            if (SettingValues.toolboxEnabled
-                    && Authentication.mod
-                    && Toolbox.getUsernotes(comment.getSubredditName()) != null
-                    && Toolbox.getUsernotes(comment.getSubredditName()).getNotesForUser(comment.getAuthor()) != null
-                    && Toolbox.getUsernotes(comment.getSubredditName()).getNotesForUser(comment.getAuthor())
-                        .size() > 0) {
-                SpannableStringBuilder note = new SpannableStringBuilder("\u00A0" +
-                        Toolbox.getUsernotes(comment.getSubredditName())
-                                .getDisplayNoteForUser(comment.getAuthor()) + "\u00A0");
-                note.setSpan(new RoundedBackgroundSpan(mContext.getResources().getColor(R.color.white),
-                        Color.parseColor(Toolbox.getUsernotes(
-                                comment.getSubredditName()).getDisplayColorForUser(comment.getAuthor())
-                        ), false, mContext), 0, note.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                author.append(" ");
-                author.append(note);
-            }
+            ToolboxUI.appendToolboxNote(mContext, author, comment.getSubredditName(), comment.getAuthor());
 
             holder.user.setText(author);
             holder.user.append(mContext.getResources().getString(R.string.submission_properties_seperator));

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.WeakHashMap;
 
 import me.ccrama.redditslide.Adapters.CommentAdapterHelper;
+import me.ccrama.redditslide.Toolbox.ToolboxUI;
 import me.ccrama.redditslide.Views.RoundedBackgroundSpan;
 import me.ccrama.redditslide.Visuals.FontPreferences;
 import me.ccrama.redditslide.Visuals.Palette;
@@ -257,22 +258,7 @@ public class SubmissionCache {
             titleString.append(pinned);
         }
 
-        if (SettingValues.toolboxEnabled
-                && Authentication.mod
-                && Toolbox.getUsernotes(submission.getSubredditName()) != null
-                && Toolbox.getUsernotes(submission.getSubredditName()).getNotesForUser(submission.getAuthor()) != null
-                && Toolbox.getUsernotes(submission.getSubredditName()).getNotesForUser(submission.getAuthor())
-                    .size() > 0) {
-            SpannableStringBuilder note = new SpannableStringBuilder("\u00A0" +
-                    Toolbox.getUsernotes(submission.getSubredditName())
-                            .getDisplayNoteForUser(submission.getAuthor()) + "\u00A0");
-            note.setSpan(new RoundedBackgroundSpan(mContext.getResources().getColor(R.color.white),
-                    Color.parseColor(Toolbox.getUsernotes(
-                            submission.getSubredditName()).getDisplayColorForUser(submission.getAuthor())
-                    ), false, mContext), 0, note.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            titleString.append(" ");
-            titleString.append(note);
-        }
+        ToolboxUI.appendToolboxNote(mContext, titleString, submission.getSubredditName(), submission.getAuthor());
 
         /* too big, might add later todo
         if (submission.getAuthorFlair() != null && submission.getAuthorFlair().getText() != null && !submission.getAuthorFlair().getText().isEmpty()) {


### PR DESCRIPTION
Toolbox comes from the web, so users may use colours that are valid in CSS but not in Android's `Color.parseColor` (for example `orange` is a valid name in CSS but not one `parseColor` accepts).

As it happens exoplayer has a method that can parse most CSS colours, with a larger colour map and support for some other formats. It doesn't look like it has full support of all valid CSS colours, but it's an improvement that doesn't require adding a new dependency.

If the colour fails to parse, it now falls back to grey to prevent crashing

cc @timawesomeness 