### PR TITLE
Save individual files to custom folders

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Album.java
@@ -60,7 +60,7 @@ public class Album extends FullScreenActivity implements FolderChooserDialogCrea
     private int         adapterPosition;
 
     @Override
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
             Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
             Toast.makeText(this,

--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -779,7 +779,7 @@ public class AlbumPager extends FullScreenActivity
     }
 
     @Override
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
             Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
             Toast.makeText(this,

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -1357,6 +1357,7 @@ public class MediaView extends FullScreenActivity
                 Intent i = new Intent(this, ImageDownloadNotificationService.class);
                 //always download the original file, or use the cached original if that is currently displayed
                 i.putExtra("actuallyLoaded", contentUrl);
+                i.putExtra("saveToLocation", folder.getAbsolutePath());
                 if (subreddit != null && !subreddit.isEmpty()) i.putExtra("subreddit", subreddit);
                 startService(i);
             } else {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -222,7 +222,7 @@ public class MediaView extends FullScreenActivity
         Drawable share = getResources().getDrawable(R.drawable.share);
         Drawable image = getResources().getDrawable(R.drawable.image);
         Drawable save = getResources().getDrawable(R.drawable.save);
-        Drawable saveToLocation = getResources().getDrawable(R.drawable.save);
+        Drawable collection = getResources().getDrawable(R.drawable.collection);
         Drawable file = getResources().getDrawable(R.drawable.savecontent);
         Drawable thread = getResources().getDrawable(R.drawable.commentchange);
 
@@ -230,7 +230,7 @@ public class MediaView extends FullScreenActivity
         share.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         image.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         save.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
-        saveToLocation.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        collection.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         file.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         thread.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
 
@@ -243,7 +243,7 @@ public class MediaView extends FullScreenActivity
 
         if (!isGif) b.sheet(3, image, getString(R.string.share_image));
         b.sheet(4, save, "Save " + (isGif ? "MP4" : "image"));
-        b.sheet(16, save, "Save " + (isGif ? "MP4" : "image"));
+        b.sheet(16, collection, "Save " + (isGif ? "MP4" : "image") + " to");
         if (isGif
                 && !contentUrl.contains(".mp4")
                 && !contentUrl.contains("streamable.com")
@@ -302,7 +302,7 @@ public class MediaView extends FullScreenActivity
                     }
                     break;
                     case (16): {
-                        doImageSaveLocation();
+                        doImageSaveForLocation();
                         break;
                     }
                 }
@@ -329,7 +329,7 @@ public class MediaView extends FullScreenActivity
         }
     }
 
-    public void doImageSaveLocation() {
+    public void doImageSaveForLocation() {
         if (!isGif) {
             new FolderChooserDialogCreate.Builder(
                     MediaView.this).chooseButton(

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -222,6 +222,7 @@ public class MediaView extends FullScreenActivity
         Drawable share = getResources().getDrawable(R.drawable.share);
         Drawable image = getResources().getDrawable(R.drawable.image);
         Drawable save = getResources().getDrawable(R.drawable.save);
+        Drawable saveToLocation = getResources().getDrawable(R.drawable.save);
         Drawable file = getResources().getDrawable(R.drawable.savecontent);
         Drawable thread = getResources().getDrawable(R.drawable.commentchange);
 
@@ -229,6 +230,7 @@ public class MediaView extends FullScreenActivity
         share.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         image.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         save.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        saveToLocation.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         file.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
         thread.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
 
@@ -241,6 +243,7 @@ public class MediaView extends FullScreenActivity
 
         if (!isGif) b.sheet(3, image, getString(R.string.share_image));
         b.sheet(4, save, "Save " + (isGif ? "MP4" : "image"));
+        b.sheet(16, save, "Save " + (isGif ? "MP4" : "image"));
         if (isGif
                 && !contentUrl.contains(".mp4")
                 && !contentUrl.contains("streamable.com")
@@ -296,6 +299,10 @@ public class MediaView extends FullScreenActivity
                     break;
                     case (4): {
                         doImageSave();
+                    }
+                    break;
+                    case (16): {
+                        doImageSaveLocation();
                         break;
                     }
                 }
@@ -319,6 +326,19 @@ public class MediaView extends FullScreenActivity
             }
         } else {
             doOnClick.run();
+        }
+    }
+
+    public void doImageSaveLocation() {
+        if (!isGif) {
+            new FolderChooserDialogCreate.Builder(
+                    MediaView.this).chooseButton(
+                    R.string.btn_select)  // changes label of the choose button
+                    .isSaveToLocation(true)
+                    .initialPath(
+                            Environment.getExternalStorageDirectory()
+                                    .getPath())  // changes initial path, defaults to external storage directory
+                    .show();
         }
     }
 
@@ -1331,12 +1351,20 @@ public class MediaView extends FullScreenActivity
     }
 
     @Override
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
-            Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
-            Toast.makeText(this,
-                    getString(R.string.settings_set_image_location, folder.getAbsolutePath()),
-                    Toast.LENGTH_LONG).show();
+            if (isSaveToLocation) {
+                Intent i = new Intent(this, ImageDownloadNotificationService.class);
+                //always download the original file, or use the cached original if that is currently displayed
+                i.putExtra("actuallyLoaded", contentUrl);
+                if (subreddit != null && !subreddit.isEmpty()) i.putExtra("subreddit", subreddit);
+                startService(i);
+            } else {
+                Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
+                Toast.makeText(this,
+                        getString(R.string.settings_set_image_location, folder.getAbsolutePath()),
+                        Toast.LENGTH_LONG).show();
+            }
         }
     }
 }

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Settings.java
@@ -45,7 +45,6 @@ import me.ccrama.redditslide.R;
 import me.ccrama.redditslide.Reddit;
 import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.Visuals.Palette;
-import me.ccrama.redditslide.util.LogUtil;
 import me.ccrama.redditslide.util.NetworkUtil;
 import me.ccrama.redditslide.util.OnSingleClickListener;
 
@@ -660,8 +659,8 @@ public class Settings extends BaseActivity
     }
 
     @Override
-    public void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder) {
-        mSettingsGeneralFragment.onFolderSelection(dialog, folder);
+    public void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder, boolean isSaveToLocation) {
+        mSettingsGeneralFragment.onFolderSelection(dialog, folder, false);
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/SettingsGeneral.java
@@ -31,8 +31,8 @@ public class SettingsGeneral extends BaseActivityAnim
     }
 
     @Override
-    public void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder) {
-        fragment.onFolderSelection(dialog, folder);
+    public void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder, boolean isSaveToLocation) {
+        fragment.onFolderSelection(dialog, folder, false);
     }
 
     @Override

--- a/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Tumblr.java
@@ -61,7 +61,7 @@ public class Tumblr extends FullScreenActivity implements FolderChooserDialogCre
     public  String subreddit;
 
     @Override
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
             Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
             Toast.makeText(this,

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -745,7 +745,7 @@ public class TumblrPager extends FullScreenActivity
     }
 
     @Override
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
             Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
             Toast.makeText(this,

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/FolderChooserDialogCreate.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/FolderChooserDialogCreate.java
@@ -142,7 +142,11 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
                                         File toCreate = new File(parentFolder.getPath() + File.separator + createdFile);
                                         toCreate.mkdir();
                                         dialog.dismiss();
-                                        mCallback.onFolderSelection(FolderChooserDialogCreate.this, toCreate, false);
+                                        if (getBuilder().mIsSaveToLocation) {
+                                            mCallback.onFolderSelection(FolderChooserDialogCreate.this, toCreate, true);
+                                        } else {
+                                            mCallback.onFolderSelection(FolderChooserDialogCreate.this, toCreate, false);
+                                        }
                                     }
                                 }).show();
                     }

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/FolderChooserDialogCreate.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/FolderChooserDialogCreate.java
@@ -45,7 +45,7 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
     String createdFile;
 
     public interface FolderCallback {
-        void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder);
+        void onFolderSelection(@NonNull FolderChooserDialogCreate dialog, @NonNull File folder, boolean isSaveToLocation);
     }
 
     public FolderChooserDialogCreate() {
@@ -101,7 +101,11 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
                     @Override
                     public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                         dialog.dismiss();
-                        mCallback.onFolderSelection(FolderChooserDialogCreate.this, parentFolder);
+                        if (getBuilder().mIsSaveToLocation) {
+                            mCallback.onFolderSelection(FolderChooserDialogCreate.this, parentFolder, true);
+                        } else {
+                            mCallback.onFolderSelection(FolderChooserDialogCreate.this, parentFolder, false);
+                        }
                     }
                 })
                 .onNegative(new MaterialDialog.SingleButtonCallback() {
@@ -138,7 +142,7 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
                                         File toCreate = new File(parentFolder.getPath() + File.separator + createdFile);
                                         toCreate.mkdir();
                                         dialog.dismiss();
-                                        mCallback.onFolderSelection(FolderChooserDialogCreate.this, toCreate);
+                                        mCallback.onFolderSelection(FolderChooserDialogCreate.this, toCreate, false);
                                     }
                                 }).show();
                     }
@@ -197,6 +201,7 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
         protected int mCancelButton;
         protected String mInitialPath;
         protected String mTag;
+        protected boolean mIsSaveToLocation;
 
         public <ActivityType extends AppCompatActivity & FolderCallback> Builder(@NonNull ActivityType context) {
             mContext = context;
@@ -230,6 +235,12 @@ public class FolderChooserDialogCreate extends DialogFragment implements Materia
             if (tag == null)
                 tag = DEFAULT_TAG;
             mTag = tag;
+            return this;
+        }
+
+        @NonNull
+        public Builder isSaveToLocation(boolean isSaveToLocation) {
+            mIsSaveToLocation = isSaveToLocation;
             return this;
         }
 

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsGeneralFragment.java
@@ -13,7 +13,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.SwitchCompat;
-import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -1087,7 +1086,7 @@ public class SettingsGeneralFragment<ActivityType extends AppCompatActivity & Fo
         }
     }
 
-    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder) {
+    public void onFolderSelection(FolderChooserDialogCreate dialog, File folder, boolean isSaveToLocation) {
         if (folder != null) {
             Reddit.appRestart.edit().putString("imagelocation", folder.getAbsolutePath()).apply();
             Toast.makeText(context,

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
@@ -59,7 +59,10 @@ public class ImageDownloadNotificationService extends Service {
         if (intent.hasExtra("subreddit")) {
             subreddit = intent.getStringExtra("subreddit");
         }
-        new PollTask(actuallyLoaded, intent.getIntExtra("index", -1), subreddit).executeOnExecutor(
+        new PollTask(actuallyLoaded,
+                intent.getIntExtra("index", -1),
+                subreddit,
+                intent.getStringExtra("saveToLocation")).executeOnExecutor(
                 AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
@@ -71,12 +74,14 @@ public class ImageDownloadNotificationService extends Service {
         public  String                     actuallyLoaded;
         private int                        index;
         private String                     subreddit;
+        public  String                     saveToLocation;
 
 
-        public PollTask(String actuallyLoaded, int index, String subreddit) {
+        public PollTask(String actuallyLoaded, int index, String subreddit, String saveToLocation) {
             this.actuallyLoaded = actuallyLoaded;
             this.index = index;
             this.subreddit = subreddit;
+            this.saveToLocation = saveToLocation;
         }
 
         public void startNotification() {
@@ -126,29 +131,57 @@ public class ImageDownloadNotificationService extends Service {
                                             File f_out = null;
                                             try {
                                                 if(SettingValues.imageSubfolders && !subreddit.isEmpty()){
-                                                    File directory = new File( Reddit.appRestart.getString("imagelocation",
-                                                            "")
-                                                            + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : ""));
+                                                    File directory;
+                                                    if (saveToLocation != null) {
+                                                        directory = new File(new File(saveToLocation,
+                                                                "")
+                                                                + (SettingValues.imageSubfolders && !subreddit.isEmpty() ? File.separator + subreddit : ""));
+                                                    } else {
+                                                        directory = new File( Reddit.appRestart.getString("imagelocation",
+                                                                "")
+                                                                + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : ""));
+                                                    }
                                                     directory.mkdirs();
                                                 }
-                                                f_out = new File(
-                                                        Reddit.appRestart.getString("imagelocation",
-                                                                "")
-                                                                + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
-                                                                + File.separator
-                                                                + (index > -1 ? String.format(
-                                                                "%03d_", index) : "")
-                                                                + getFileName(new URL(finalUrl1)));
+                                                if (saveToLocation != null) {
+                                                    f_out = new File(
+                                                            saveToLocation
+                                                                    + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
+                                                                    + File.separator
+                                                                    + (index > -1 ? String.format(
+                                                                    "%03d_", index) : "")
+                                                                    + getFileName(new URL(finalUrl1)));
+                                                } else {
+                                                    f_out = new File(
+                                                            Reddit.appRestart.getString("imagelocation",
+                                                                    "")
+                                                                    + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
+                                                                    + File.separator
+                                                                    + (index > -1 ? String.format(
+                                                                    "%03d_", index) : "")
+                                                                    + getFileName(new URL(finalUrl1)));
+                                                }
                                             } catch (MalformedURLException e) {
-                                                f_out = new File(
-                                                        Reddit.appRestart.getString("imagelocation",
-                                                                "")
-                                                                + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
-                                                                + File.separator
-                                                                + (index > -1 ? String.format(
-                                                                "%03d_", index) : "")
-                                                                + UUID.randomUUID().toString()
-                                                                + ".png");
+                                                if (saveToLocation != null) {
+                                                    f_out = new File(
+                                                            saveToLocation
+                                                                    + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
+                                                                    + File.separator
+                                                                    + (index > -1 ? String.format(
+                                                                    "%03d_", index) : "")
+                                                                    + UUID.randomUUID().toString()
+                                                                    + ".png");
+                                                } else {
+                                                    f_out = new File(
+                                                            Reddit.appRestart.getString("imagelocation",
+                                                                    "")
+                                                                    + (SettingValues.imageSubfolders && !subreddit.isEmpty() ?File.separator + subreddit : "")
+                                                                    + File.separator
+                                                                    + (index > -1 ? String.format(
+                                                                    "%03d_", index) : "")
+                                                                    + UUID.randomUUID().toString()
+                                                                    + ".png");
+                                                }
                                             }
                                             LogUtil.v("F out is " + f_out.toString());
                                             try {


### PR DESCRIPTION
Added the another "Save image/MP4 to" item to MediaView that will allow users to manually select their save location for each image they download. Users can still save to their default location using the regular "Save image/MP4" button.

This feature was requested in https://github.com/ccrama/Slide/issues/3134

This is my first open source contribution to a project so please let me know if there is anything that could be optimized or cleaned up. Thanks!