### PR TITLE
Disambiguate Turkish translations for short durations

### DIFF
--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -791,9 +791,9 @@
     <!-- Time: shorthand durations for example 1 hour → 1h -->
     <string name="time_years_short">%dy</string>
     <string name="time_days_short">%dg</string>
-    <string name="time_hours_short">%ds</string>
-    <string name="time_minutes_short">%dd</string>
-    <string name="time_seconds_short">%ds</string>
+    <string name="time_hours_short">%dsn</string>
+    <string name="time_minutes_short">%ddk</string>
+    <string name="time_seconds_short">%dst</string>
     <!-- Strings present during the login process -->
     <string name="login_subscribe_rslideforreddit">/r/slideforreddit\'e abone ol?</string>
     <string name="login_subscribe_rslideforreddit_desc">/r/slideforreddit\'e sorunları bildirmek ve son durumdan haberdar olmak için abone olmak ister misiniz?</string>


### PR DESCRIPTION
's' was used for both seconds and hours, which is catastrophic. Instead, add another letter from "saniye" and "saat" to disambiguate.
'd' for 'minute' is problematic because it can be confused with an untranslated 'day'. Making it use another letter from "dakika" makes it 100% non-ambiguous.