### PR TITLE
Handle Subreddit loading error gracefully

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubmissionAdapter.java
@@ -54,6 +54,7 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final int LOADING_SPINNER = 5;
     private final int NO_MORE         = 3;
     private final int SPACER          = 6;
+    private final int ERROR = 7;
     SubmissionDisplay displayer;
 
     public SubmissionAdapter(Activity context, SubredditPosts dataSet, RecyclerView listView,
@@ -109,13 +110,14 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else if (!dataSet.posts.isEmpty()) {
             position -= (1);
         }
-        if (position == dataSet.posts.size()
-                && !dataSet.posts.isEmpty()
-                && !dataSet.offline
-                && !dataSet.nomore) {
-            return LOADING_SPINNER;
-        } else if (position == dataSet.posts.size() && (dataSet.offline || dataSet.nomore)) {
-            return NO_MORE;
+        if (position == dataSet.posts.size()) {
+            if (dataSet.error) {
+                return ERROR;
+            } else if (!dataSet.posts.isEmpty() && !dataSet.offline && !dataSet.nomore) {
+                return LOADING_SPINNER;
+            } else if (dataSet.offline || dataSet.nomore) {
+                return NO_MORE;
+            }
         }
         int SUBMISSION = 1;
         return SUBMISSION;
@@ -139,6 +141,17 @@ public class SubmissionAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else if (i == NO_MORE) {
             View v = LayoutInflater.from(viewGroup.getContext())
                     .inflate(R.layout.nomoreposts, viewGroup, false);
+            return new SubmissionFooterViewHolder(v);
+        } else if (i == ERROR) {
+            View v = LayoutInflater.from(viewGroup.getContext())
+                    .inflate(R.layout.errorloadingcontent, viewGroup, false);
+            v.findViewById(R.id.retry).setOnClickListener(new OnSingleClickListener() {
+                @Override
+                public void onSingleClick(View v) {
+                    dataSet.loadMore(v.getContext(),
+                            (SubmissionsView) displayer, false, dataSet.subreddit);
+                }
+            });
             return new SubmissionFooterViewHolder(v);
         } else {
             View v = CreateCardView.CreateView(viewGroup);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/SubredditPosts.java
@@ -60,6 +60,7 @@ public class SubredditPosts implements PostLoader {
     public  boolean          offline;
     public  boolean          forced;
     public  boolean          loading;
+    public  boolean          error;
     private Paginator        paginator;
     public  OfflineSubreddit cached;
     Context c;
@@ -301,7 +302,9 @@ public class SubredditPosts implements PostLoader {
 
         @Override
         public void onPostExecute(final List<Submission> submissions) {
+            boolean success = true;
             loading = false;
+
             if (error != null) {
                 if (error instanceof NetworkException) {
                     NetworkException e = (NetworkException) error;
@@ -323,11 +326,7 @@ public class SubredditPosts implements PostLoader {
                                 Toast.LENGTH_SHORT).show();
                     }
                 }
-                if (error.getCause() instanceof UnknownHostException) {
-                    Toast.makeText(context, "Loading failed, please check your internet connection",
-                            Toast.LENGTH_LONG).show();
-                }
-                displayer.updateError();
+                success = false;
             } else if (submissions != null && !submissions.isEmpty()) {
                 if (displayer instanceof SubmissionsView
                         && ((SubmissionsView) displayer).adapter.isError) {
@@ -391,9 +390,11 @@ public class SubredditPosts implements PostLoader {
                 } else if (!nomore) {
                     // error
                     LogUtil.v("Setting error");
-                    displayer.updateError();
+                    success = false;
                 }
             }
+
+            SubredditPosts.this.error = !success;
         }
 
         @Override

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SubmissionsView.java
@@ -590,7 +590,6 @@ public class SubmissionsView extends Fragment implements SubmissionDisplay {
             }
         }
         mSwipeRefreshLayout.setRefreshing(false);
-        adapter.setError(true);
     }
 
     @Override

--- a/app/src/main/res/layout/errorloadingcontent.xml
+++ b/app/src/main/res/layout/errorloadingcontent.xml
@@ -1,0 +1,34 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="12dp"
+    android:paddingBottom="24dp"
+    android:paddingTop="24dp"
+    app:cardBackgroundColor="?attr/card_background">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:text="@string/err_loading_content"
+        android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <Button
+        android:id="@+id/retry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/textView"
+        android:layout_centerHorizontal="true"
+        android:gravity="center"
+        android:padding="10dp"
+        android:text="@string/misc_retry"
+        android:textAllCaps="true"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:theme="@style/Ripple.List" />
+
+</RelativeLayout>


### PR DESCRIPTION
When a loading error happens, the `SubmissionsView` would be swapped for an empty view. This PR changes the behavior to show a retry button as shown in the screenshot:

![screenshot of the change](https://user-images.githubusercontent.com/41328971/84311423-9057b300-ab63-11ea-86e1-cd40d172fbc9.png)

I would have preferred it if the button would say: "Retry", instead of: "Would you like to try again?", but this text was already available as a resource with translations.