### PR TITLE
Fix handling of intent links in internal browser

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/Website.java
@@ -333,6 +333,20 @@ public class Website extends BaseActivityAnim {
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if (url.startsWith("intent://")) {
+                try {
+                    // https://stackoverflow.com/a/58163386/6952238
+                    Intent intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+                    if ((intent != null) && ((intent.getScheme().equals("https"))
+                            || (intent.getScheme().equals("http")))) {
+                        String fallbackUrl = intent.getStringExtra("browser_fallback_url");
+                        v.loadUrl(fallbackUrl);
+                    }
+                    return true;
+                } catch (URISyntaxException ignored) {
+                }
+            }
+
             ContentType.Type type = ContentType.getContentType(url);
 
             if (triedURLS == null) {
@@ -352,7 +366,7 @@ public class Website extends BaseActivityAnim {
                         }
                         return super.shouldOverrideUrlLoading(view, url);
                     case REDDIT:
-                        if(!url.contains("inapp=false")) {
+                        if (!url.contains("inapp=false")) {
                             boolean opened = OpenRedditLink.openUrl(view.getContext(), url, false);
                             if (!opened) {
                                 return super.shouldOverrideUrlLoading(view, url);


### PR DESCRIPTION
For example, google forms and google images both give share urls (forms.gle, images.app.goo.gl) that redirect to an intent:// url when they detect android, making the internal browser unable to handle them. This fixes that based on [this](https://stackoverflow.com/questions/57685214/google-forum-short-url-not-working-in-android-app-webview).