### PR TITLE
Fix crash when entering offline mode with no cache

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MainActivity.java
@@ -4457,7 +4457,9 @@ public class MainActivity extends BaseActivity
      */
     private void setupSubredditSearchToolbar() {
         if (!NetworkUtil.isConnected(this)) {
-            findViewById(R.id.drawer_divider).setVisibility(View.GONE);
+            if (findViewById(R.id.drawer_divider) != null) {
+                findViewById(R.id.drawer_divider).setVisibility(View.GONE);
+            }
         } else {
             if ((SettingValues.subredditSearchMethod == Constants.SUBREDDIT_SEARCH_METHOD_TOOLBAR
                     || SettingValues.subredditSearchMethod


### PR DESCRIPTION
Slide crashes when "search in the app bar" is enabled and there's no cached offline content and you enter offline mode.

Fixes #3199 