### PR TITLE
Update CircularReveal library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,7 +143,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.7.0' //3.11.0
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation 'com.github.ozodrukh:CircularReveal:1.3.1' //2.1.0
+    implementation 'com.github.ozodrukh:CircularReveal:2.1.0'
     implementation 'org.jetbrains:annotations-java5:15.0' //16.0.3
     implementation 'com.mikepenz:itemanimators:1.0.2@aar' //1.1.0
     implementation 'com.neovisionaries:nv-websocket-client:1.31' //2.6

--- a/app/src/main/java/me/ccrama/redditslide/Views/AnimateHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/AnimateHelper.java
@@ -6,7 +6,6 @@ import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 
-import io.codetail.animation.SupportAnimator;
 import io.codetail.animation.ViewAnimationUtils;
 import me.ccrama.redditslide.R;
 
@@ -39,7 +38,7 @@ public class AnimateHelper {
 
 
                 try {
-                    SupportAnimator animator =
+                    Animator animator =
                             ViewAnimationUtils.createCircularReveal(v, cx, cy, 0, finalRadius);
                     animator.setInterpolator(new FastOutSlowInInterpolator());
                     animator.setDuration(250);

--- a/app/src/main/java/me/ccrama/redditslide/Views/RevealRelativeLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/RevealRelativeLayout.java
@@ -2,29 +2,19 @@ package me.ccrama.redditslide.Views;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Path;
-import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.RelativeLayout;
 
-import io.codetail.animation.RevealAnimator;
-import io.codetail.animation.SupportAnimator;
-import io.codetail.animation.ViewAnimationUtils;
+import io.codetail.animation.RevealViewGroup;
+import io.codetail.animation.ViewRevealManager;
 
 //Adapted from https://github.com/MajeurAndroid/CircularReveal/commit/a87e3ad4daac96f942be0e240ebfc098a79f5419
+//And migrated to 2.1.0
 
-public class RevealRelativeLayout extends RelativeLayout implements RevealAnimator {
+public class RevealRelativeLayout extends RelativeLayout implements RevealViewGroup {
 
-    private Path mRevealPath;
-    private final Rect mTargetBounds = new Rect();
-    private RevealInfo mRevealInfo;
-    private boolean mRunning;
-    private float mRadius;
-    @Override
-    public boolean hasOverlappingRendering() {
-        return false;
-    }
+    private ViewRevealManager manager;
 
     public RevealRelativeLayout(Context context) {
         this(context, null);
@@ -35,87 +25,36 @@ public class RevealRelativeLayout extends RelativeLayout implements RevealAnimat
     }
 
     public RevealRelativeLayout(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs);
-        mRevealPath = new Path();
-    }
-
-    @Override
-    public void onRevealAnimationStart() {
-        mRunning = true;
-    }
-
-    @Override
-    public void onRevealAnimationEnd() {
-        mRunning = false;
-        invalidate(mTargetBounds);
-    }
-
-    @Override
-    public void onRevealAnimationCancel() {
-        onRevealAnimationEnd();
-    }
-
-    /**
-     * Circle radius size
-     *
-     * @hide
-     */
-    @Override
-    public void setRevealRadius(float radius) {
-        mRadius = radius;
-        mRevealInfo.getTarget().getHitRect(mTargetBounds);
-        invalidate(mTargetBounds);
-    }
-
-    /**
-     * Circle radius size
-     *
-     * @hide
-     */
-    @Override
-    public float getRevealRadius() {
-        return mRadius;
-    }
-
-    /**
-     * @hide
-     */
-    @Override
-    public void attachRevealInfo(RevealInfo info) {
-        mRevealInfo = info;
-    }
-
-    /**
-     * @hide
-     */
-    @Override
-    public SupportAnimator startReverseAnimation() {
-        if (mRevealInfo != null && mRevealInfo.hasTarget() && !mRunning) {
-            return ViewAnimationUtils.createCircularReveal(mRevealInfo.getTarget(),
-                    mRevealInfo.centerX, mRevealInfo.centerY,
-                    mRevealInfo.endRadius, mRevealInfo.startRadius);
-        }
-        return null;
+        super(context, attrs, defStyle);
+        manager = new ViewRevealManager();
     }
 
     @Override
     protected boolean drawChild(Canvas canvas, View child, long drawingTime) {
-        if (mRunning && child == mRevealInfo.getTarget()) {
-            final int state = canvas.save();
+        try {
+            canvas.save();
 
-            mRevealPath.reset();
-            mRevealPath.addCircle(mRevealInfo.centerX, mRevealInfo.centerY, mRadius, Path.Direction.CW);
-
-            canvas.clipPath(mRevealPath);
-
-            boolean isInvalided = super.drawChild(canvas, child, drawingTime);
-
-            canvas.restoreToCount(state);
-
-            return isInvalided;
+            manager.transform(canvas, child);
+            return super.drawChild(canvas, child, drawingTime);
+        } finally {
+            canvas.restore();
         }
-
-        return super.drawChild(canvas, child, drawingTime);
     }
 
+    @Override
+    public ViewRevealManager getViewRevealManager() {
+        return manager;
+    }
+
+    public void setViewRevealManager(ViewRevealManager manager) {
+        if (manager == null) {
+            throw new NullPointerException("ViewRevealManager is null");
+        }
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean hasOverlappingRendering() {
+        return false;
+    }
 }


### PR DESCRIPTION
Updated from 1.3.1 to 2.1.0.

https://github.com/ozodrukh/CircularReveal/releases

~~How I migrated the custom RevealRelativeLayout to 2.x is black magic to me at this point (something about file comparison, blah blah blah), but I'm pretty sure it worked on my custom builds, so this should be good.~~ Nvm figured it out.