### PR TITLE
Dropping support for ICS (API 15)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "me.ccrama.redditslide"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 326
         versionName androidGitVersion.name()


### PR DESCRIPTION
As of 3 months ago, ICS held a total share of 0.2% of the total distribution.

https://www.xda-developers.com/android-version-distribution-statistics-android-studio/



Google themselves dropped support for 14 and 15 a year and a half ago. I believe it is time to move on.

https://www.xda-developers.com/google-play-services-dropping-support-android-ics-api-14-15/