### PR TITLE
Update more libraries, downgrade robolectric to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,17 @@ android:
   components:
   - tools
   - platform-tools
-
-  - build-tools-28.0.3
+  - tools
+  - build-tools-29.0.3
   - android-28
 
   - extra-android-m2repository
   - extra-google-m2repository
   - extra-google-google_play_services
+
+  licenses:
+    - 'android-sdk-license-.+'
+    - 'android-sdk-preview-license-.+'
 
 notifications:
   email: false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,13 +78,13 @@ android {
 
 ext {
     supportLibVersion = '28.0.0'
-    robolectricVersion = '4.3'
-    powerMockitoVersion = '1.7.4' //2.0.0-RC.3
+    robolectricVersion = '3.8'
+    powerMockitoVersion = '1.7.4'
     exoPlayerVersion = '2.9.6' // need minSDK 16 for anything higher
 }
 
 dependencies {
-    withGPlayImplementation 'com.google.android.gms:play-services-drive:10.2.6' //16.0.0
+    withGPlayImplementation 'com.google.android.gms:play-services-drive:10.2.6'
 
     implementation 'com.github.ccrama:JRAW:9a2494892d'
     implementation 'com.github.ccrama:TedBottomPicker:496623c9b6'
@@ -95,6 +95,7 @@ dependencies {
 
     implementation "com.android.support:design:${supportLibVersion}"
     implementation "com.android.support:customtabs:${supportLibVersion}"
+    implementation "com.android.support:exifinterface:${supportLibVersion}"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:cardview-v7:${supportLibVersion}"
     implementation "com.android.support:recyclerview-v7:${supportLibVersion}"
@@ -107,36 +108,37 @@ dependencies {
     implementation "com.google.android.exoplayer:exoplayer-dash:${exoPlayerVersion}"
     implementation "com.google.android.exoplayer:exoplayer-ui:${exoPlayerVersion}"
 
-    implementation 'com.google.guava:guava:23.6.1-android' //27.0-android
+    implementation 'com.google.guava:guava:29.0-android'
     //Updating material-dialogs to any newer version will break all AlertDialogWrapper
     //noinspection GradleDependency
     implementation 'com.afollestad.material-dialogs:commons:0.8.6.2' //0.9.6.0
     implementation 'com.jakewharton:process-phoenix:2.0.0'
-    implementation 'org.ligi:snackengage:0.5'
-    implementation 'com.github.rey5137:material:1.2.4'
+    implementation 'com.github.ligi.snackengage:snackengage-core:0.22'
+    implementation 'com.github.ligi.snackengage:snackengage-playrate:0.22'
+    implementation 'com.github.rey5137:material:1.2.5'
     implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
-    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.6.0' //3.10.0
-    implementation 'com.cocosw:bottomsheet:1.3.0@aar'
+    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.6.0'
+    implementation 'com.cocosw:bottomsheet:1.4.0@aar'
     implementation 'com.lusfold.androidkeyvaluestore:library:0.1.0@aar'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.commons:commons-text:1.8'
     implementation 'commons-io:commons-io:2.7'
     implementation 'jp.wasabeef:blurry:2.1.1'
-    implementation 'com.makeramen:roundedimageview:2.2.1' //2.3.0
+    implementation 'com.makeramen:roundedimageview:2.3.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation 'com.sothree.slidinguppanel:library:3.3.1' //3.4.0
+    implementation 'com.sothree.slidinguppanel:library:3.4.0'
     implementation 'com.github.suckgamony.RapidDecoder:library:7cdfca47fa'
     implementation 'com.github.dasar:shiftcolorpicker:v0.5'
-    implementation 'com.squareup.okhttp3:okhttp:3.7.0' //3.11.0
+    implementation 'com.squareup.okhttp3:okhttp:3.12.12'
     implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'com.github.ozodrukh:CircularReveal:2.1.0'
-    implementation 'org.jetbrains:annotations-java5:15.0' //16.0.3
-    implementation 'com.mikepenz:itemanimators:1.0.2@aar' //1.1.0
+    compileOnly 'org.jetbrains:annotations:19.0.0'
+    implementation 'com.mikepenz:itemanimators:1.0.2@aar'
     implementation 'com.neovisionaries:nv-websocket-client:2.9'
-    implementation 'com.theartofdev.edmodo:android-image-cropper:2.3.1' //2.8.0
+    implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
     implementation 'me.everything:overscroll-decor-android:1.0.4'
-    implementation 'com.mikepenz:aboutlibraries:5.8.5' //5.9.0, 5.9.8, 6.0.0
+    implementation 'com.mikepenz:aboutlibraries:6.1.1'
     implementation 'com.googlecode.mp4parser:isoparser:1.1.22'
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
- Update Guava 23.6.1-android -> 29.0-android ([changelog](https://github.com/google/guava/releases))
- SnackEngage 0.5 -> 0.22 ([changelog](https://github.com/ligi/SnackEngage/releases))
- rey5137's material 1.2.4 -> 1.2.5 ([changelog](https://github.com/rey5137/material/releases))
- Bottomsheet 1.3.0 -> 1.4.0 ([changelog](https://github.com/soarcn/BottomSheet/blob/master/CHANGELOG.md))
- RoundedImageView 2.2.1 -> 2.3.0 ([changelog](https://github.com/vinc3m1/RoundedImageView/releases))
- AndroidSlidingUpPanel 3.3.1 -> 3.4.0 ([changelog](https://github.com/umano/AndroidSlidingUpPanel#changelog))
- OkHttp3 3.7.0 -> 3.12.12 ([changelog](https://square.github.io/okhttp/changelog_3x/))
- JetBrains annotations-java5 15.0 -> annotations 19.0.0 ([changelog](https://github.com/JetBrains/java-annotations/releases))
- Android-Image-Cropper 2.3.1 -> 2.7.0 ([changelog](https://github.com/ArthurHub/Android-Image-Cropper/releases))
- AboutLibraries 5.8.5 -> 6.1.1 ([changelog](https://github.com/mikepenz/AboutLibraries/releases))
- DOWNGRADE Robolectric to 3.8 (to fix that stupid AndroidX build failing thing)

All of these should be safe, I checked the differences of each individual version's source jars to make sure nothing broke. Also, I had updated these ones before in my personal custom builds and they worked fine (for me, at least). Of course, failures may occur on other devices, but that doesn't mean we shouldn't update these, just that we should fix the crashes (if there are any).