### PR TITLE
Fixes #3187 by hiding option to rename multireddit

### DIFF
--- a/app/src/main/res/menu/menu_multireddits.xml
+++ b/app/src/main/res/menu/menu_multireddits.xml
@@ -6,6 +6,7 @@
     <item android:id="@+id/action_edit"
         android:icon="@drawable/edit"
         android:title="@string/editor_title"
+        android:visible="false"
         app:showAsAction="ifRoom"/>
 
     <item android:id="@+id/action_shadowbox"


### PR DESCRIPTION
Looks like the endpoint to rename the multi (POST /api/multi/rename) has been removed/deprecated by reddit. The api documentation page doesn't exist either https://www.reddit.com/dev/api/oauth#POST_api_multi_rename

For now, I have hidden the option to rename multi.