### PR TITLE
Fixes #3185: AlertDialog gives option to save multireddit upon exiting

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
@@ -120,6 +120,26 @@ public class CreateMulti extends BaseActivityAnim {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
     }
 
+    @Override
+    public void onBackPressed() {
+        new AlertDialogWrapper.Builder(CreateMulti.this).setTitle(R.string.general_confirm_exit)
+                .setMessage(R.string.multi_save_option)
+                .setPositiveButton(R.string.btn_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                        MultiredditOverview.multiActivity.finish();
+                        new SaveMulti().execute();
+                    }
+                })
+                .setNegativeButton(R.string.btn_no, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                        finish();
+                    }
+                })
+                .show();
+    }
+
     public void showSelectDialog() {
         //List of all subreddits of the multi
         List<String> multiSubs = new ArrayList<>(subs);
@@ -353,6 +373,7 @@ public class CreateMulti extends BaseActivityAnim {
                         @Override
                         public void run() {
                             Log.v(LogUtil.getTag(), "Update Subreddits");
+                            MultiredditOverview.multiActivity.finish();
                             new UserSubscriptions.SyncMultireddits(CreateMulti.this).execute();
                         }
                     });
@@ -433,6 +454,7 @@ public class CreateMulti extends BaseActivityAnim {
                         .setPositiveButton(R.string.btn_yes, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
+                                MultiredditOverview.multiActivity.finish();
                                 new MaterialDialog.Builder(CreateMulti.this)
                                         .title(R.string.deleting)
                                         .progress(true, 100)

--- a/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/CreateMulti.java
@@ -78,7 +78,7 @@ public class CreateMulti extends BaseActivityAnim {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        overrideRedditSwipeAnywhere();
+        overrideSwipeFromAnywhere();
 
         super.onCreate(savedInstanceState);
         applyColorTheme();

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MultiredditOverview.java
@@ -1,5 +1,6 @@
 package me.ccrama.redditslide.Activities;
 
+import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -66,6 +67,8 @@ public class MultiredditOverview extends BaseActivityAnim {
 
     public static final String EXTRA_PROFILE = "profile";
     public static final String EXTRA_MULTI = "multi";
+
+    public static Activity multiActivity;
 
     public static MultiReddit          searchMulti;
     public        OverviewPagerAdapter adapter;
@@ -422,6 +425,8 @@ public class MultiredditOverview extends BaseActivityAnim {
     @Override
     public void onCreate(Bundle savedInstance) {
         overrideSwipeFromAnywhere();
+
+        multiActivity = this;
 
         super.onCreate(savedInstance);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,8 @@
     <string name="multi_submit_which_sub">Which sub would you like to submit to?</string>
     <string name="multi_saved_successfully">Saved successfully</string>
     <string name="delete_multireddit_title">Do you really want to delete /m/%1$s?</string>
+    <string name="multi_save_option">Would you like to save this multireddit?</string>
+
 
 
     <!-- Content types -->


### PR DESCRIPTION
#3185

Previously, the CreateMulti class allowed the swipe right to exit gesture which bypasses OnBackPressed() and so that feature has been removed from that activity. I also fixed a bug where saving or creating a new multireddit launched a new MultiRedditOverview activity on top of the previous one, which meant the user had to press back twice or more to exit depending on how many multireddits they've created.

Now whenever editing or creating a multireddit, upon pressing back, the user is prompted with an option to save their changes. 