### PR TITLE
#3223 Copy all text fix

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -311,7 +311,7 @@ public class CommentAdapterHelper {
                                                                 Context.CLIPBOARD_SERVICE);
                                                 ClipData clip =
                                                         ClipData.newPlainText("Comment text",
-                                                                Html.fromHtml(n.getBody()));
+                                                                StringEscapeUtils.unescapeHtml4(n.getBody()));
                                                 clipboard.setPrimaryClip(clip);
 
                                                 Toast.makeText(mContext,

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateNewsViewHolder.java
@@ -933,13 +933,14 @@ public class PopulateNewsViewHolder {
                                                         (ClipboardManager) mContext.getSystemService(
                                                                 Context.CLIPBOARD_SERVICE);
                                                 ClipData clip = ClipData.newPlainText("Selftext",
-                                                        Html.fromHtml(submission.getTitle()
-                                                                + "\n\n"
-                                                                + submission.getSelftext()));
+                                                        StringEscapeUtils.unescapeHtml4(
+                                                                submission.getTitle()
+                                                                        + "\n\n"
+                                                                        + submission.getSelftext()));
                                                 clipboard.setPrimaryClip(clip);
 
                                                 Toast.makeText(mContext,
-                                                        R.string.submission_comment_copied,
+                                                        R.string.submission_text_copied,
                                                         Toast.LENGTH_SHORT).show();
                                             }
                                         })

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionViews/PopulateSubmissionViewHolder.java
@@ -1066,13 +1066,14 @@ public class PopulateSubmissionViewHolder {
                                                         (ClipboardManager) mContext.getSystemService(
                                                                 Context.CLIPBOARD_SERVICE);
                                                 ClipData clip = ClipData.newPlainText("Selftext",
-                                                        Html.fromHtml(submission.getTitle()
-                                                                + "\n\n"
-                                                                + submission.getSelftext()));
+                                                        StringEscapeUtils.unescapeHtml4(
+                                                                submission.getTitle()
+                                                                        + "\n\n"
+                                                                        + submission.getSelftext()));
                                                 clipboard.setPrimaryClip(clip);
 
                                                 Toast.makeText(mContext,
-                                                        R.string.submission_comment_copied,
+                                                        R.string.submission_text_copied,
                                                         Toast.LENGTH_SHORT).show();
                                             }
                                         })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,9 +45,9 @@
     <string name="submission_comment_unsaved">Comment un-saved</string>
     <string name="submission_share_permalink">Share link</string>
     <string name="submission_comment_copied">Comment text copied</string>
+    <string name="submission_text_copied">Submission text copied</string>
     <string name="submission_nocontent">Submission has no content</string>
     <string name="submission_link_copied">Link copied</string>
-    <string name="submission_text_copied">Selftext copied</string>
     <string name="submission_removed">Submission removed</string>
 
 


### PR DESCRIPTION
#3223 Changed the clipdata to preserve newlines when pressing the "copy all text" button and updated toasts for post/link text. Previously when copying post/link texts, the toast would say "Comment text copied", which I just changed to "Submission text copied".