### PR TITLE
Add settings to hide awards

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/EditCardsLayout.java
@@ -130,6 +130,17 @@ public class EditCardsLayout extends BaseActivityAnim {
             });
         }
         {
+            SwitchCompat single2 = (SwitchCompat) findViewById(R.id.hidePostAwards);
+            single2.setChecked(SettingValues.hidePostAwards);
+            single2.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    SettingValues.hidePostAwards = isChecked;
+                    SettingValues.prefs.edit().putBoolean(SettingValues.PREF_HIDE_POST_AWARDS, isChecked).apply();
+                }
+            });
+        }
+        {
             SwitchCompat single2 = (SwitchCompat) findViewById(R.id.titleTop);
             single2.setChecked(SettingValues.titleTop);
             single2.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterHelper.java
@@ -1495,7 +1495,7 @@ public class CommentAdapterHelper {
             titleString.append(pinned);
             titleString.append(" ");
         }
-        if (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0) {
+        if (!SettingValues.hideCommentAwards && (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0)) {
             TypedArray a = mContext.obtainStyledAttributes(
                     new FontPreferences(mContext).getPostFontStyle().getResId(),
                     R.styleable.FontStyle);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/CommentAdapterSearch.java
@@ -48,6 +48,7 @@ import java.util.Locale;
 
 import me.ccrama.redditslide.Authentication;
 import me.ccrama.redditslide.R;
+import me.ccrama.redditslide.SettingValues;
 import me.ccrama.redditslide.TimeUtils;
 import me.ccrama.redditslide.UserSubscriptions;
 import me.ccrama.redditslide.UserTags;
@@ -187,7 +188,7 @@ public class CommentAdapterSearch extends RecyclerView.Adapter<RecyclerView.View
             titleString.append(pinned);
             titleString.append(" ");
         }
-        if (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0) {
+        if (!SettingValues.hideCommentAwards && (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0)) {
             TypedArray a = mContext.obtainStyledAttributes(
                     new FontPreferences(mContext).getPostFontStyle().getResId(),
                     R.styleable.FontStyle);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ContributionAdapter.java
@@ -430,7 +430,7 @@ public class ContributionAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             holder.content.setTypeface(typeface);
 
             ((TextView) holder.gild).setText("");
-            if (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0) {
+            if (!SettingValues.hideCommentAwards && (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0)) {
                 TypedArray a = mContext.obtainStyledAttributes(
                         new FontPreferences(mContext).getPostFontStyle().getResId(),
                         R.styleable.FontStyle);

--- a/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
+++ b/app/src/main/java/me/ccrama/redditslide/Adapters/ModeratorAdapter.java
@@ -478,7 +478,7 @@ public class ModeratorAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             setViews(comment.getDataNode().get("body_html").asText(), comment.getSubredditName(), holder);
 
             ((TextView) holder.gild).setText("");
-            if (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0) {
+            if (!SettingValues.hideCommentAwards && (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0)) {
                 TypedArray a = mContext.obtainStyledAttributes(
                         new FontPreferences(mContext).getPostFontStyle().getResId(),
                         R.styleable.FontStyle);

--- a/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsCommentsFragment.java
+++ b/app/src/main/java/me/ccrama/redditslide/Fragments/SettingsCommentsFragment.java
@@ -128,6 +128,17 @@ public class SettingsCommentsFragment {
             });
         }
         {
+            SwitchCompat single = context.findViewById(R.id.settings_comments_hide_awards);
+            single.setChecked(SettingValues.hideCommentAwards);
+            single.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    SettingValues.hideCommentAwards = isChecked;
+                    SettingValues.prefs.edit().putBoolean(SettingValues.PREF_HIDE_COMMENT_AWARDS, isChecked).apply();
+                }
+            });
+        }
+        {
             SwitchCompat single = context.findViewById(R.id.settings_comments_autohidenav);
             single.setChecked(SettingValues.commentAutoHide);
 

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -60,6 +60,7 @@ public class SettingValues {
     public static final String PREF_SUBREDDIT_FILTERS         = "subredditFilters";
     public static final String PREF_ABBREVIATE_SCORES         = "abbreviateScores";
     public static final String PREF_HIDE_POST_AWARDS          = "hidePostAwards";
+    public static final String PREF_HIDE_COMMENT_AWARDS       = "hideCommentAwards";
     public static final String PREF_FLAIR_FILTERS             = "subFlairFilters";
     public static final String PREF_COMMENT_LAST_VISIT        = "commentLastVisit";
     public static final String PREF_VOTES_INFO_LINE           = "votesInfoLine";
@@ -197,6 +198,7 @@ public class SettingValues {
     public static boolean rightHandedCommentMenu;
     public static boolean abbreviateScores;
     public static boolean hidePostAwards;
+    public static boolean hideCommentAwards;
     public static boolean shareLongLink;
     public static boolean isMuted;
     public static int     subredditSearchMethod;
@@ -361,7 +363,9 @@ public class SettingValues {
         noImages = prefs.getBoolean(PREF_NO_IMAGES, false);
 
         abbreviateScores = prefs.getBoolean(PREF_ABBREVIATE_SCORES, true);
+
         hidePostAwards = prefs.getBoolean(PREF_HIDE_POST_AWARDS, false);
+        hideCommentAwards = prefs.getBoolean(PREF_HIDE_COMMENT_AWARDS, false);
 
         lowResAlways = prefs.getBoolean(PREF_LOW_RES_ALWAYS, false);
         lowResMobile = prefs.getBoolean(PREF_LOW_RES_MOBILE, false);

--- a/app/src/main/java/me/ccrama/redditslide/SettingValues.java
+++ b/app/src/main/java/me/ccrama/redditslide/SettingValues.java
@@ -59,6 +59,7 @@ public class SettingValues {
     public static final String PREF_DRAFTS                    = "drafts";
     public static final String PREF_SUBREDDIT_FILTERS         = "subredditFilters";
     public static final String PREF_ABBREVIATE_SCORES         = "abbreviateScores";
+    public static final String PREF_HIDE_POST_AWARDS          = "hidePostAwards";
     public static final String PREF_FLAIR_FILTERS             = "subFlairFilters";
     public static final String PREF_COMMENT_LAST_VISIT        = "commentLastVisit";
     public static final String PREF_VOTES_INFO_LINE           = "votesInfoLine";
@@ -195,6 +196,7 @@ public class SettingValues {
     public static boolean collapseDeletedComments;
     public static boolean rightHandedCommentMenu;
     public static boolean abbreviateScores;
+    public static boolean hidePostAwards;
     public static boolean shareLongLink;
     public static boolean isMuted;
     public static int     subredditSearchMethod;
@@ -359,6 +361,7 @@ public class SettingValues {
         noImages = prefs.getBoolean(PREF_NO_IMAGES, false);
 
         abbreviateScores = prefs.getBoolean(PREF_ABBREVIATE_SCORES, true);
+        hidePostAwards = prefs.getBoolean(PREF_HIDE_POST_AWARDS, false);
 
         lowResAlways = prefs.getBoolean(PREF_LOW_RES_ALWAYS, false);
         lowResMobile = prefs.getBoolean(PREF_LOW_RES_MOBILE, false);

--- a/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
+++ b/app/src/main/java/me/ccrama/redditslide/SubmissionCache.java
@@ -418,8 +418,9 @@ public class SubmissionCache {
             titleString.append(" ");
             titleString.append(pinned);
         }
-        if (submission.getTimesSilvered() > 0 || submission.getTimesGilded() > 0
-                || submission.getTimesPlatinized() > 0) {
+
+        if (!SettingValues.hidePostAwards &&
+                (submission.getTimesSilvered() > 0 || submission.getTimesGilded() > 0 || submission.getTimesPlatinized() > 0)) {
             TypedArray a = mContext.obtainStyledAttributes(
                     new FontPreferences(mContext).getPostFontStyle().getResId(),
                     R.styleable.FontStyle);

--- a/app/src/main/java/me/ccrama/redditslide/Views/RedditItemView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Views/RedditItemView.java
@@ -420,7 +420,7 @@ public class RedditItemView extends RelativeLayout {
         }
         holder.content.setTypeface(typeface);
 
-        if (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0) {
+        if (!SettingValues.hideCommentAwards && (comment.getTimesSilvered() > 0 || comment.getTimesGilded() > 0  || comment.getTimesPlatinized() > 0)) {
             TypedArray a = getContext().obtainStyledAttributes(
                     new FontPreferences(getContext()).getPostFontStyle().getResId(),
                     R.styleable.FontStyle);

--- a/app/src/main/res/layout/activity_settings_comments_child.xml
+++ b/app/src/main/res/layout/activity_settings_comments_child.xml
@@ -361,6 +361,49 @@
             android:textColorHint="?attr/fontColor"/>
     </RelativeLayout>
 
+    <View
+        android:layout_width="match_parent"
+        android:background="?attr/tintColor"
+        android:alpha=".25"
+        android:layout_height="0.25dp"/>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:background="?android:selectableItemBackground"
+        android:paddingStart="16dp">
+
+        <LinearLayout
+            android:layout_marginEnd="64dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_hide_comment_awards"
+                android:textColor="?attr/fontColor"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/settings_comments_hide_awards"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingEnd="16dp"
+            android:backgroundTint="?attr/tintColor"
+            android:button="@null"
+            android:buttonTint="?attr/tintColor"
+            android:hapticFeedbackEnabled="true"
+            android:textColor="?attr/fontColor"
+            android:textColorHint="?attr/fontColor" />
+
+    </RelativeLayout>
+
     <TextView
         android:id="@+id/settings_comments_navigationHeader"
         style="@style/TextAppearance.AppCompat.Body2"

--- a/app/src/main/res/layout/activity_settings_theme_card.xml
+++ b/app/src/main/res/layout/activity_settings_theme_card.xml
@@ -597,6 +597,48 @@
                             android:textColorHint="?attr/fontColor" />
                 </RelativeLayout>
 
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="0.25dp"
+                    android:alpha=".25"
+                    android:background="?attr/tintColor" />
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:background="?android:selectableItemBackground"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_marginEnd="64dp"
+                        android:layout_marginRight="64dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_hide_post_awards"
+                            android:textColor="?attr/fontColor"
+                            android:textSize="14sp" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/hidePostAwards"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:backgroundTint="?attr/tintColor"
+                        android:button="@null"
+                        android:buttonTint="?attr/tintColor"
+                        android:hapticFeedbackEnabled="true"
+                        android:textColor="?attr/fontColor"
+                        android:textColorHint="?attr/fontColor" />
+                </RelativeLayout>
+
 
                 <TextView
                     style="@style/TextAppearance.AppCompat.Body2"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1328,4 +1328,5 @@
     <string name="page_does_not_exist">The page you requested does not exist</string>
     <string name="back_button_behavior_goto_first">Go to first subreddit</string>
     <string name="settings_hide_post_awards">Hide awards</string>
+    <string name="settings_hide_comment_awards">Hide awards</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1327,4 +1327,5 @@
     <string name="page_not_found">Page not found</string>
     <string name="page_does_not_exist">The page you requested does not exist</string>
     <string name="back_button_behavior_goto_first">Go to first subreddit</string>
+    <string name="settings_hide_post_awards">Hide awards</string>
 </resources>


### PR DESCRIPTION
This PR adds two settings to hide the display of awards (such as gold) on posts and comments

- Appearance > Post layout > Hide awards
- Appearance > Comments > Hide awards

I don't see any breaking issues with the code, so it should be ready to review. However, I'm worried that the comment setting might effect unwanted areas as I found 5 classes that had similar logic, compared to the single class for posts.