### PR TITLE
Fixes notification getting stuck on 'downloading' after a sucessful download

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
@@ -345,6 +345,7 @@ public class ImageDownloadNotificationService extends Service {
                                             NotificationManager.class);
                             notif.flags |= Notification.FLAG_AUTO_CANCEL;
                             if (mNotificationManager != null) {
+                                mNotificationManager.cancel(id);
                                 mNotificationManager.notify(id, notif);
                             }
                             loadedImage.recycle();


### PR DESCRIPTION
fixes #2957 

Just a quick fix for the the downloading notification bug I have been experience recently, it doesn't always happen but I noticed that it only happened if it was my first time downloading that image.
I'm not sure if it was a race condition but I was unable to reproduce it after adding that line.

Thanks!