### PR TITLE
Use submission title as the file name for GIFs / Videos with improved saving file name logic

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/AlbumPager.java
@@ -409,7 +409,7 @@ public class AlbumPager extends FullScreenActivity
                 public void run() {
 
                 }
-            }, false, true, rootView.findViewById(R.id.size), ((AlbumPager)getActivity()).subreddit).execute(url);
+            }, false, true, rootView.findViewById(R.id.size), ((AlbumPager)getActivity()).subreddit, getActivity().getIntent().getStringExtra(EXTRA_SUBMISSION_TITLE)).execute(url);
             rootView.findViewById(R.id.more).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/MediaView.java
@@ -771,7 +771,7 @@ public class MediaView extends FullScreenActivity
         findViewById(R.id.progress).setVisibility(View.GONE);
         gif = new GifUtils.AsyncLoadGif(this, videoView, loader,
                 findViewById(R.id.placeholder), doOnClick, true, true,
-                ((TextView) findViewById(R.id.size)), subreddit);
+                ((TextView) findViewById(R.id.size)), subreddit, submissionTitle);
         videoView.attachMuteButton((ImageView) findViewById(R.id.mute));
         videoView.attachHqButton((ImageView) findViewById(R.id.hq));
         gif.execute(dat);

--- a/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/ccrama/redditslide/Activities/TumblrPager.java
@@ -382,7 +382,7 @@ public class TumblrPager extends FullScreenActivity
                 public void run() {
 
                 }
-            }, false, true, rootView.findViewById(R.id.size),  ((TumblrPager) getActivity()).subreddit).execute(url);
+            }, false, true, rootView.findViewById(R.id.size),  ((TumblrPager) getActivity()).subreddit, null).execute(url);
             rootView.findViewById(R.id.more).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
+++ b/app/src/main/java/me/ccrama/redditslide/CommentCacheAsync.java
@@ -183,6 +183,7 @@ public class CommentCacheAsync extends AsyncTask {
                                                         Uri.parse(GifUtils.AsyncLoadGif.formatUrl(s.getUrl())),
                                                         (Activity) context,
                                                         s.getSubredditName(),
+                                                        null,
                                                         false
                                                 );
                                             }

--- a/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
+++ b/app/src/main/java/me/ccrama/redditslide/Notifications/ImageDownloadNotificationService.java
@@ -32,7 +32,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 
 import me.ccrama.redditslide.Activities.DeleteFile;
 import me.ccrama.redditslide.R;
@@ -212,29 +211,11 @@ public class ImageDownloadNotificationService extends Service {
             } catch (MalformedURLException e) {
                 extension = ".png";
             }
-            String fileIndex = index > -1 ? String.format(Locale.ENGLISH, "_%03d", index) : "";
-            String title = submissionTitle != null && !submissionTitle.replaceAll("\\W+", "").trim().isEmpty() //Replace all non-alphanumeric characters to ensure a valid File URL
-                    ? submissionTitle.replaceAll("\\W+", "") : UUID.randomUUID().toString();
-            String finalURL = (title + fileIndex + extension)
-                    .replaceAll(RESERVED_CHARS, "")
-                    .trim();
 
-            File file = new File(getFolderPath()
-                    + getSubfolderPath()
-                    + File.separator
-                    + finalURL);
-            int tries = 0;
-            while(file.exists()) {
-                tries += 1;
-                finalURL = (title + fileIndex + "_" + tries + extension )
-                        .replaceAll(RESERVED_CHARS, "")
-                        .trim();
-                file = new File(getFolderPath()
-                        + getSubfolderPath()
-                        + File.separator
-                        + finalURL);
-            }
-            return finalURL;
+            String fileIndex = index > -1 ? String.format(Locale.ENGLISH, "_%03d", index) : "";
+
+            return FileUtil.getValidFile(getFolderPath(), getSubfolderPath(),
+                    submissionTitle, fileIndex, extension).getName();
         }
 
         @Override

--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -61,7 +61,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.text.DecimalFormat;
 import java.util.Locale;
-import java.util.UUID;
 
 import me.ccrama.redditslide.Activities.MediaView;
 import me.ccrama.redditslide.Activities.Website;
@@ -162,7 +161,7 @@ public class GifUtils {
      * @param subreddit Subreddit for saving in sub-specific folders
      * @param save      Whether to permanently save the GIF of just temporarily cache it
      */
-    public static void cacheSaveGif(Uri uri, Activity a, String subreddit, boolean save) {
+    public static void cacheSaveGif(Uri uri, Activity a, String subreddit, String submissionTitle, boolean save) {
         if (save) {
             try {
                 Toast.makeText(a, a.getString(R.string.mediaview_notif_title), Toast.LENGTH_SHORT).show();
@@ -196,18 +195,16 @@ public class GifUtils {
 
                 @Override
                 protected Boolean doInBackground(Void... voids) {
+                    String folderPath = Reddit.appRestart.getString("imagelocation", "");
+
+                    String subFolderPath = "";
                     if (SettingValues.imageSubfolders && !subreddit.isEmpty()) {
-                        File directory = new File(Reddit.appRestart.getString("imagelocation", "")
-                                + (SettingValues.imageSubfolders
-                                && !subreddit.isEmpty() ? File.separator + subreddit : ""));
-                        directory.mkdirs();
+                        subFolderPath = File.separator + subreddit;
                     }
-                    outFile = new File(Reddit.appRestart.getString("imagelocation", "")
-                            + (SettingValues.imageSubfolders && !subreddit.isEmpty() ? File.separator
-                            + subreddit : "")
-                            + File.separator
-                            + UUID.randomUUID().toString()
-                            + ".mp4");
+
+                    String extension = ".mp4";
+
+                    outFile = FileUtil.getValidFile(folderPath, subFolderPath, submissionTitle, "", extension);
 
                     OutputStream out = null;
                     InputStream in = null;
@@ -351,6 +348,7 @@ public class GifUtils {
         private Runnable doOnClick;
         private boolean autostart;
         public String subreddit;
+        public String submissionTitle;
 
         private TextView size;
 
@@ -369,7 +367,7 @@ public class GifUtils {
 
         public AsyncLoadGif(@NonNull Activity c, @NonNull ExoVideoView video,
                 @Nullable ProgressBar p, @Nullable View placeholder, @Nullable Runnable gifSave,
-                boolean closeIfNull, boolean autostart, TextView size, String subreddit) {
+                boolean closeIfNull, boolean autostart, TextView size, String subreddit, String submissionTitle) {
             this.c = c;
             this.video = video;
             this.subreddit = subreddit;
@@ -379,6 +377,7 @@ public class GifUtils {
             this.doOnClick = gifSave;
             this.autostart = autostart;
             this.size = size;
+            this.submissionTitle = submissionTitle;
         }
 
         public void onError() {
@@ -835,14 +834,14 @@ public class GifUtils {
                 gifSave.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        cacheSaveGif(uri, c, subreddit, true);
+                        cacheSaveGif(uri, c, subreddit, submissionTitle, true);
                     }
                 });
             } else if (doOnClick != null) {
                 MediaView.doOnClick = new Runnable() {
                     @Override
                     public void run() {
-                        cacheSaveGif(uri, c, subreddit, true);
+                        cacheSaveGif(uri, c, subreddit, submissionTitle, true);
                     }
                 };
             }


### PR DESCRIPTION
I made some improvements over #3297.

- Submission title is now safe to use as a file name. It can have all the symbols and emojis. It will be properly sanitized to be saved on any platform.

- File names will be limited to 255 bytes as per Linux requirement. Also handles cases for broken UTF-8 characters due to truncation.

- GIFs and videos will now use submission title as file name, like images.