### PR TITLE
Stop changing global dark mode setting on start

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/Reddit.java
+++ b/app/src/main/java/me/ccrama/redditslide/Reddit.java
@@ -705,11 +705,6 @@ public class Reddit extends MultiDexApplication implements Application.ActivityL
     @TargetApi(Build.VERSION_CODES.M)
     private static void setCanUseNightModeAuto() {
         UiModeManager uiModeManager = getAppContext().getSystemService(UiModeManager.class);
-        if (uiModeManager != null) {
-            uiModeManager.setNightMode(UiModeManager.MODE_NIGHT_AUTO);
-            canUseNightModeAuto = true;
-        } else {
-            canUseNightModeAuto = false;
-        }
+        canUseNightModeAuto = uiModeManager != null
     }
 }


### PR DESCRIPTION
Fixes #3065

This method is supposed to check if the "Automatic" option of dark mode is supported, but due to the setNightMode() method the setting changes globally. By removing this call the bug no longer happens and the auto check still succeeds.

Photo of "Night mode" settings dialog showing the "Automatic" option correctly:
![Screenshot_20210406-152121](https://user-images.githubusercontent.com/66086473/113780293-3fb1d780-96ec-11eb-89c7-93e3bd3e614d.png)