### PR TITLE
Fix redgif api resolving

### DIFF
--- a/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
+++ b/app/src/main/java/me/ccrama/redditslide/util/GifUtils.java
@@ -495,7 +495,7 @@ public class GifUtils {
                         ucon.setInstanceFollowRedirects(false);
                         String secondURL = new URL(ucon.getHeaderField("location")).toString();
                         if (secondURL.contains("gifdeliverynetwork")){
-                            return Uri.parse(getUrlFromApi(getApiResponse("redgifs", name)));
+                            return Uri.parse(getUrlFromApi(getApiResponse("redgifs", name.toLowerCase())));
                         }
 
                     } catch (IOException e) {


### PR DESCRIPTION
When a post which contains a Gfycat NSFW gif, it is redirect to RedGifs, but not correctly "resolved" since apparently RedGifs' API requires a lowercase gif name. 

e.g.

[https://api.redgifs.com/v1/gfycats/DazzlingPrestigiousAmericankestrel](https://api.redgifs.com/v1/gfycats/DazzlingPrestigiousAmericankestrel) 404's while [https://api.redgifs.com/v1/gfycats/dazzlingprestigiousamericankestrel](https://api.redgifs.com/v1/gfycats/dazzlingprestigiousamericankestrel) doesn't (NSFW of course).

Example post: [https://reddit.com/r/CuteModeSlutMode/comments/4ld42v/ameri_ichinose_cute_mode_slut_mode_extended_cut/](https://reddit.com/r/CuteModeSlutMode/comments/4ld42v/ameri_ichinose_cute_mode_slut_mode_extended_cut/)


